### PR TITLE
feat: increase the budget limit

### DIFF
--- a/apps/challenge-registry/app/project.json
+++ b/apps/challenge-registry/app/project.json
@@ -58,8 +58,8 @@
           "budgets": [
             {
               "type": "initial",
-              "maximumWarning": "500kb",
-              "maximumError": "1mb"
+              "maximumWarning": "1mb",
+              "maximumError": "2mb"
             },
             {
               "type": "anyComponentStyle",


### PR DESCRIPTION
It seems the initial budget size exceeds the limits of 1mb, which caused the CI failed [here](https://github.com/Sage-Bionetworks/challenge-registry/actions/runs/3833764119/jobs/6525526629#step:16:225).

Double the budget size to 2mb.