### PR TITLE
feat: Add Challenge headline and description

### DIFF
--- a/libs/challenge-registry/api-description/src/components/schemas/ChallengeCreateRequest.yaml
+++ b/libs/challenge-registry/api-description/src/components/schemas/ChallengeCreateRequest.yaml
@@ -10,11 +10,15 @@ properties:
   #     type: string
   #     minLength: 3
   #     maxLength: 60
-  #   description:
-  #     description: A short description of the challenge
-  #     type: string
-  #     nullable: true
-  #     maxLength: 280
+  headline:
+    description: The headline of the challenge
+    type: string
+    nullable: true
+    maxLength: 80
+  description:
+    description: The description of the challenge
+    type: string
+    maxLength: 200
   #   websiteUrl:
   #     type: string
   #     format: url
@@ -64,6 +68,7 @@ properties:
 #     nullable: true
 required:
   - name
+  - description
   - status
 #   - description
 # example:


### PR DESCRIPTION
- Fixes #1119 
- Fixes #1120 

## Changelog

- Add the property `Challenge.headline`
  - The recommended length in this article is 60 chars. Here I give a bit more room and set the max length to 80 chars.
- Add the property `Challenge.description`
  - The recommended length in this article is between 150 and 160 characters. Here I set it to 280 (tweet length).
  - 280 chars is a compromise between a suitable description for Google SEO and a longer description that contribute to the relevance of results when using text search.
  - Happy to revisit this decision if additional considerations are available.