### PR TITLE
feat: Disable format on save for Java files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,14 +48,14 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
-  "emeraldwalk.runonsave": {
-    "commands": [
-      {
-        "match": "\\.(java|sql)$",
-        "cmd": "node_modules/.bin/nx affected --base=HEAD --target=format"
-      }
-    ]
-  },
+  // "emeraldwalk.runonsave": {
+  //   "commands": [
+  //     {
+  //       "match": "\\.(java|sql)$",
+  //       "cmd": "node_modules/.bin/nx affected --base=HEAD --target=format"
+  //     }
+  //   ]
+  // },
   "eslint.workingDirectories": ["./apps/challenge-db-cli", "."],
   "sqltools.autoOpenSessionFiles": false,
   "sqltools.connections": [


### PR DESCRIPTION
Fixes #1052 

## Changelog

- Disable format on save for Java files because the current setup is too slow.
  - It takes 1-5 seconds to format after saving the files.
  - Files are already formatted by the pre-commit hook.