### PR TITLE
feat: Prepare Python dependencies during git moves

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -3,4 +3,5 @@
 
 node tools/check-nodejs-dependencies.js
 node tools/check-java-dependencies.js
+node tools/check-python-dependencies.js
 node tools/check-devcontainer-version.js

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -5,4 +5,5 @@
 # rm -rf node_modules && yarn install --immutable
 node tools/check-nodejs-dependencies.js post-merge
 node tools/check-java-dependencies.js
+node tools/check-python-dependencies.js
 node tools/check-devcontainer-version.js

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -3,4 +3,5 @@
 
 node tools/check-nodejs-dependencies.js
 node tools/check-java-dependencies.js
+node tools/check-python-dependencies.js
 node tools/check-devcontainer-version.js

--- a/tools/check-python-dependencies.js
+++ b/tools/check-python-dependencies.js
@@ -1,0 +1,50 @@
+// For each Python project in the workspace, this script checks if the project definition has
+// changed since the last git move. If it has changed, then the target `prepare-python` of the
+// project is executed.
+
+'use strict';
+
+const fs = require('fs');
+const { spawn } = require("child_process");
+const { getGitDiffFiles } = require('./git-util');
+
+const jsonData = fs.readFileSync(`workspace.json`);
+const json = JSON.parse(jsonData);
+
+const isPoetryProject = (projectLocation) => {
+  const filenames = fs.readdirSync(projectLocation);
+  return filenames.includes('poetry.lock');
+}
+
+const hasPoetryProjectDefinitionChanged = (projectLocation, changedFiles) => {
+  if (isPoetryProject(projectLocation)) {
+    const projectDefinitionPaths = ['poetry.lock']
+      .map(filename => `${projectLocation}/${filename}`);
+    if (projectDefinitionPaths.some(projectDefinitionPath => changedFiles.includes(projectDefinitionPath))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const installPythonDependencies = (projectName) => {
+  spawn('yarn', ['nx', 'prepare-python', projectName], {stdio:'inherit'})
+    .on('exit', function (error) {
+      if (error) {
+        console.log(`error: ${error.message}`);
+        return;
+      }
+    });
+}
+
+console.log('✨ Preparing Python dependencies');
+getGitDiffFiles().then((changedFiles) => {
+  Object.entries(json['projects']).forEach(([projectName, projectLocation]) => {
+    if (hasPoetryProjectDefinitionChanged(projectLocation, changedFiles)) {
+      installPythonDependencies(projectName);
+    }
+  });
+});
+
+
+


### PR DESCRIPTION
Fixes #1125 

## Preview

```console
vscode@8938397bfb17:/workspaces/sage-monorepo$ git checkout prepare-python-dependencies 
Switched to branch 'prepare-python-dependencies'
Your branch is up to date with 'origin/prepare-python-dependencies'.
✨ Preparing Node.js dependencies
✨ Preparing Java dependencies
✨ Preparing Python dependencies
vscode@8938397bfb17:/workspaces/sage-monorepo$
```