### PR TITLE
fix: Limit elasticsearch memory to 2G

### DIFF
--- a/apps/challenge-registry/elasticsearch/docker-compose.yml
+++ b/apps/challenge-registry/elasticsearch/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - challenge-registry
     ports:
       - "9200:9200"
+    deploy:
+      resources:
+        limits:
+          memory: 2G
 
 # volumes:
 #   challenge-registry-elasticsearch:


### PR DESCRIPTION
Fixes #1140

## Preview

