### PR TITLE
style(ui): fix login and register pages

### DIFF
--- a/libs/challenge-registry/login/src/lib/login.component.html
+++ b/libs/challenge-registry/login/src/lib/login.component.html
@@ -4,30 +4,28 @@
       <img src="assets/images/registry_b.png" alt="Challenge Registry"/>
       <h3>Welcome back!</h3>
     </div>
-    <mat-card-content>
-      <form class="form-container" [formGroup]="loginForm" novalidate>
-        <mat-form-field class="login-username" appearance="outline">
-          <input matInput placeholder="Username" type="text" formControlName="username">
-          <mat-error *ngIf="username?.invalid">{{getUsernameErrorMessage()}}
-          </mat-error>
-        </mat-form-field>
-        <mat-form-field class="login-password" appearance="outline">
-          <input matInput placeholder="Password" type="password" formControlName="password">
-          <mat-error *ngIf="password?.invalid">{{getPasswordErrorMessage()}}
-          </mat-error>
-        </mat-form-field>
-        <a class="forgot-password" href="#">Forgot password?</a>
-        <mat-error *ngIf="errors.other">{{errors.other}}</mat-error>
-        <div class="btn-group">
-          <button mat-raised-button color="primary"
-            [disabled]="loginForm.invalid" (click)="login()">Log in</button>
-          <div class="login-options">
-            <button mat-stroked-button color="basic">Log in with Google</button>
-            <button mat-stroked-button color="basic">Log in with Synapse</button>
-          </div>
+    <form class="form-container" [formGroup]="loginForm" novalidate>
+      <mat-form-field class="login-username" appearance="outline">
+        <input matInput placeholder="Username" type="text" formControlName="username">
+        <mat-error *ngIf="username?.invalid">{{getUsernameErrorMessage()}}
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="login-password" appearance="outline">
+        <input matInput placeholder="Password" type="password" formControlName="password">
+        <mat-error *ngIf="password?.invalid">{{getPasswordErrorMessage()}}
+        </mat-error>
+      </mat-form-field>
+      <a class="forgot-password" href="#">Forgot password?</a>
+      <mat-error *ngIf="errors.other">{{errors.other}}</mat-error>
+      <div class="btn-group">
+        <button mat-raised-button color="primary"
+          [disabled]="loginForm.invalid" (click)="login()">Log in</button>
+        <div class="login-options">
+          <button mat-stroked-button color="basic">Log in with Google</button>
+          <button mat-stroked-button color="basic">Log in with Synapse</button>
         </div>
-      </form>
-    </mat-card-content>
+      </div>
+    </form>
     <div class="alternative">
       <p class="mat-body">Don't have an account? <a href="/signup">Create one!</a></p>
     </div>

--- a/libs/challenge-registry/login/src/lib/login.component.html
+++ b/libs/challenge-registry/login/src/lib/login.component.html
@@ -1,20 +1,18 @@
-<main>
-  <div class="container mat-body">
+<main class="mat-typography">
+  <div class="login-container">
     <div class="title">
       <img src="assets/images/registry_b.png" alt="Challenge Registry"/>
-      <mat-card-title>Log in to ROCC</mat-card-title>
+      <h3>Welcome back!</h3>
     </div>
     <mat-card-content>
       <form class="form-container" [formGroup]="loginForm" novalidate>
-        <mat-form-field class="username" appearance="fill">
-          <mat-label>Username</mat-label>
-          <input matInput placeholder="" type="text" formControlName="username">
+        <mat-form-field class="login-username" appearance="outline">
+          <input matInput placeholder="Username" type="text" formControlName="username">
           <mat-error *ngIf="username?.invalid">{{getUsernameErrorMessage()}}
           </mat-error>
         </mat-form-field>
-        <mat-form-field class="password" appearance="fill">
-          <mat-label>Password</mat-label>
-          <input matInput placeholder="" type="password" formControlName="password">
+        <mat-form-field class="login-password" appearance="outline">
+          <input matInput placeholder="Password" type="password" formControlName="password">
           <mat-error *ngIf="password?.invalid">{{getPasswordErrorMessage()}}
           </mat-error>
         </mat-form-field>

--- a/libs/challenge-registry/login/src/lib/login.component.html
+++ b/libs/challenge-registry/login/src/lib/login.component.html
@@ -33,5 +33,3 @@
     </div>
   </div>
 </main>
-
-<challenge-registry-footer [version]="appVersion"></challenge-registry-footer>

--- a/libs/challenge-registry/login/src/lib/login.component.html
+++ b/libs/challenge-registry/login/src/lib/login.component.html
@@ -29,7 +29,7 @@
       </form>
     </mat-card-content>
     <div class="alternative">
-      <p class="mat-body">Don't have an account? <a href="#">Create one!</a></p>
+      <p class="mat-body">Don't have an account? <a href="/signup">Create one!</a></p>
     </div>
   </div>
 </main>

--- a/libs/challenge-registry/login/src/lib/login.component.scss
+++ b/libs/challenge-registry/login/src/lib/login.component.scss
@@ -1,38 +1,36 @@
 main {
-  min-height: 100vh;
+  min-height: 80vh;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  padding: 16px;
 }
-
-.container {
-  width: 400px;
+.login-container {
+  min-width: 320px;
   max-width: 400px;
+  width: 100%
 }
-
 .title {
-  padding: 52px 0;
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-bottom: 32px;
 }
 .title img {
-  height: 60px;
-  width: 56px;
+  height: 120px;
   margin-bottom: 8px;
 }
-
 .form-container {
   display: flex;
   flex-direction: column;
 }
-
-mat-form-field.username {
+mat-form-field.login-username,
+mat-form-field.login-password {
   height: 70px;
 }
-
-mat-form-field.password {
-  height: 70px;
+input.mat-input-element {
+  padding: 10px 0;
 }
 .forgot-password {
   display: flex;

--- a/libs/challenge-registry/login/src/lib/login.component.scss
+++ b/libs/challenge-registry/login/src/lib/login.component.scss
@@ -8,7 +8,7 @@ main {
 }
 .login-container {
   min-width: 320px;
-  max-width: 400px;
+  max-width: 420px;
   width: 100%
 }
 .title {

--- a/libs/challenge-registry/login/src/lib/login.module.ts
+++ b/libs/challenge-registry/login/src/lib/login.module.ts
@@ -3,10 +3,10 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './login.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
+import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
+import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
 import { AuthModule } from '@sagebionetworks/challenge-registry/auth';
 import { UiModule } from '@sagebionetworks/challenge-registry/ui';
 

--- a/libs/challenge-registry/login/src/lib/login.module.ts
+++ b/libs/challenge-registry/login/src/lib/login.module.ts
@@ -3,10 +3,10 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './login.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
-import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
-import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { AuthModule } from '@sagebionetworks/challenge-registry/auth';
 import { UiModule } from '@sagebionetworks/challenge-registry/ui';
 

--- a/libs/challenge-registry/signup/src/lib/signup.component.html
+++ b/libs/challenge-registry/signup/src/lib/signup.component.html
@@ -1,35 +1,44 @@
-<main>
-  <mat-card class="container">
-    <mat-card-title class="title">Join ROCC</mat-card-title>
-    <mat-card-content>
-      <form class="form-container" [formGroup]="newUserForm" novalidate>
-        <mat-form-field class="email">
-          <input matInput placeholder="Enter your email" type="email"
-            formControlName="email">
-          <mat-error *ngIf="email?.invalid">{{getEmailErrorMessage()}}
-          </mat-error>
-        </mat-form-field>
-        <mat-form-field class="password">
-          <input matInput placeholder="Create a password" type="password"
-            formControlName="password">
-          <mat-error *ngIf="password?.invalid">{{getPasswordErrorMessage()}}
-          </mat-error>
-        </mat-form-field>
-        <mat-form-field class="username">
-          <input matInput placeholder="Enter a username" type="text"
-            formControlName="username">
-          <mat-error *ngIf="username?.invalid">{{getUsernameErrorMessage()}}
-          </mat-error>
-        </mat-form-field>
-        <mat-error *ngIf="errors.other">{{errors.other}}</mat-error>
-        <div>
-          <button mat-raised-button color="primary"
-            [disabled]="newUserForm.invalid" (click)="createUserAccount()">Sign
-            up</button>
+<main class="mat-typography">
+  <div class="register-container">
+    <div class="title">
+      <img src="assets/images/registry_b.png" alt="Challenge Registry"/>
+      <h3>Join Us on OpenChallenges!</h3>
+    </div>
+    <form class="form-container" [formGroup]="newUserForm" novalidate>
+      <mat-form-field class="new-email" appearance="outline">
+        <input matInput placeholder="Email" type="email"
+          formControlName="email">
+        <mat-error *ngIf="email?.invalid">{{getEmailErrorMessage()}}
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="new-username" appearance="outline">
+        <input matInput placeholder="Username" type="text"
+          formControlName="username">
+        <mat-error *ngIf="username?.invalid">{{getUsernameErrorMessage()}}
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="new-password" appearance="outline">
+        <input matInput placeholder="Password" type="password"
+          formControlName="password">
+        <mat-error *ngIf="password?.invalid">{{getPasswordErrorMessage()}}
+        </mat-error>
+      </mat-form-field>
+      <mat-error *ngIf="errors.other">{{errors.other}}</mat-error>
+      <div class="disclaimer"><p>
+        By creating an account, you agree to the <a href="#">Terms of Service</a> of
+        OpenChallenges. Our Privacy Statement can be read <a href="#">here</a>.
+      </p></div>
+      <div class="btn-group">
+        <button mat-raised-button color="primary"
+          [disabled]="newUserForm.invalid" (click)="createUserAccount()">Create Account</button>
+        <div class="login-options">
+          <button mat-stroked-button color="basic">Sign up with Google</button>
+          <button mat-stroked-button color="basic">Sign up with Synapse</button>
         </div>
-      </form>
-    </mat-card-content>
-  </mat-card>
+      </div>
+    </form>
+    <div class="alternative">
+      <p class="mat-body">Already have an account? <a href="/login">Login here.</a></p>
+    </div>
+  </div>
 </main>
-
-<challenge-registry-footer [version]="appVersion"></challenge-registry-footer>

--- a/libs/challenge-registry/signup/src/lib/signup.component.scss
+++ b/libs/challenge-registry/signup/src/lib/signup.component.scss
@@ -1,35 +1,47 @@
 main {
-  min-height: 100vh;
+  min-height: 80vh;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  padding: 16px;
 }
-
-.container {
-  width: 500px;
-  max-width: 500px;
+.register-container {
+  min-width: 320px;
+  max-width: 420px;
+  width: 100%
 }
-
 .title {
-  height: 70px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-bottom: 32px;
 }
-
+.title img {
+  height: 120px;
+  margin-bottom: 8px;
+}
 .form-container {
   display: flex;
   flex-direction: column;
 }
-
-mat-form-field.email {
+mat-form-field.new-username,
+mat-form-field.new-password,
+mat-form-field.new-email {
   height: 70px;
 }
-
-mat-form-field.password {
-  height: 70px;
+input.mat-input-element {
+  padding: 10px 0;
+}
+.disclaimer {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
 }
 
-mat-form-field.username {
-  height: 70px;
+.alternative {
+  margin-top: 68px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/libs/challenge-registry/signup/src/lib/signup.module.ts
+++ b/libs/challenge-registry/signup/src/lib/signup.module.ts
@@ -1,13 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
+import { SignupComponent } from './signup.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
 import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
-import { SignupComponent } from './signup.component';
+import { AuthModule } from '@sagebionetworks/challenge-registry/auth';
 import { UiModule } from '@sagebionetworks/challenge-registry/ui';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 const routes: Routes = [{ path: '', component: SignupComponent }];
 
@@ -22,6 +23,7 @@ const routes: Routes = [{ path: '', component: SignupComponent }];
     MatCardModule,
     MatFormFieldModule,
     MatInputModule,
+    AuthModule,
     UiModule,
   ],
   exports: [SignupComponent],

--- a/libs/challenge-registry/ui/src/lib/navbar/navbar.component.html
+++ b/libs/challenge-registry/ui/src/lib/navbar/navbar.component.html
@@ -19,7 +19,7 @@
     mat-button
     class="sage-button"
     *ngIf="!isLoggedIn"
-    (click)="logInClicked.emit(true)"
+    routerLink="/login"
     aria-label="Log In"
     >Log In</a
   >


### PR DESCRIPTION
Addresses #1151 :

### Login page

![Screen Shot 2023-01-12 at 11 24 34 PM](https://user-images.githubusercontent.com/9377970/212261656-34b59bb7-74f1-4c00-b880-b5ec37fdc44d.png)

### Register page

![Screen Shot 2023-01-12 at 11 24 25 PM](https://user-images.githubusercontent.com/9377970/212261670-49752058-2980-47ad-8615-1441176a0f64.png)

I think some fine-tuning details are still needed, but this should be enough for our closed launch.
