### PR TITLE
feat: Filter the challenges by input data types (backend)

### DIFF
--- a/apps/challenge-registry/challenge-service/requests.http
+++ b/apps/challenge-registry/challenge-service/requests.http
@@ -40,6 +40,10 @@ GET {{basePath}}/challenges?searchTerms=mortality%20dream
 
 GET {{basePath}}/challenges?minStartDate=2017-01-01&maxStartDate=2017-12-31
 
+### List the challenges that include the input data type 'genomic'
+
+GET {{basePath}}/challenges?inputDataTypes=genomic
+
 ### Sort the challenges by their starred count in desc oder
 
 GET {{basePath}}/challenges?sort=starred&direction=desc

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
@@ -67,7 +67,7 @@ public class ChallengeEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "platform_id", nullable = false)
-  @IndexedEmbedded(includePaths = {"name"})
+  @IndexedEmbedded(includePaths = {"slug", "name"})
   @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
   private SimpleChallengePlatformEntity platform;
 
@@ -82,6 +82,8 @@ public class ChallengeEntity {
       name = "challenge_x_challenge_input_data_type",
       joinColumns = @JoinColumn(name = "challenge_id"),
       inverseJoinColumns = @JoinColumn(name = "challenge_input_data_type_id"))
+  @IndexedEmbedded(name = "input_data_types", includePaths = {"slug", "name"})
+  @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
   private List<SimpleChallengeInputDataTypeEntity> inputDataTypes;
 
   @OneToMany(mappedBy = "challenge", fetch = FetchType.LAZY)

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
@@ -82,7 +82,9 @@ public class ChallengeEntity {
       name = "challenge_x_challenge_input_data_type",
       joinColumns = @JoinColumn(name = "challenge_id"),
       inverseJoinColumns = @JoinColumn(name = "challenge_input_data_type_id"))
-  @IndexedEmbedded(name = "input_data_types", includePaths = {"slug", "name"})
+  @IndexedEmbedded(
+      name = "input_data_types",
+      includePaths = {"slug", "name"})
   @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
   private List<SimpleChallengeInputDataTypeEntity> inputDataTypes;
 

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengeInputDataTypeEntity.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengeInputDataTypeEntity.java
@@ -6,6 +6,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,8 +29,10 @@ public class SimpleChallengeInputDataTypeEntity {
   private Long id;
 
   @Column(nullable = false)
+  @GenericField
   private String slug;
 
   @Column(nullable = false)
+  @FullTextField()
   private String name;
 }

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengeInputDataTypeEntity.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengeInputDataTypeEntity.java
@@ -6,14 +6,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Entity
 @Table(name = "challenge_input_data_type")

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengePlatformEntity.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengePlatformEntity.java
@@ -10,7 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengePlatformEntity.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/SimpleChallengePlatformEntity.java
@@ -10,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Entity
@@ -26,10 +28,11 @@ public class SimpleChallengePlatformEntity {
   private Long id;
 
   @Column(nullable = false)
+  @GenericField()
   private String slug;
 
   @Column(nullable = false)
-  @GenericField()
+  @FullTextField()
   private String name;
 
   @Column(name = "avatar_url", nullable = false)

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
@@ -50,23 +50,26 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
     if (query.getSearchTerms() != null && !query.getSearchTerms().isBlank()) {
       predicates.add(getSearchTermsPredicate(pf, query, fields));
     }
-    if (query.getStatus() != null && query.getStatus().size() > 0) {
+    if (query.getStatus() != null && !query.getStatus().isEmpty()) {
       predicates.add(getChallengeStatusPredicate(pf, query));
     }
-    if (query.getDifficulties() != null && query.getDifficulties().size() > 0) {
+    if (query.getDifficulties() != null && !query.getDifficulties().isEmpty()) {
       predicates.add(getChallengeDifficultyPredicate(pf, query));
     }
-    if (query.getPlatforms() != null && query.getPlatforms().size() > 0) {
+    if (query.getPlatforms() != null && !query.getPlatforms().isEmpty()) {
       predicates.add(getChallengePlatformPredicate(pf, query));
     }
-    if (query.getSubmissionTypes() != null && query.getSubmissionTypes().size() > 0) {
+    if (query.getSubmissionTypes() != null && !query.getSubmissionTypes().isEmpty()) {
       predicates.add(getChallengeSubmissionTypesPredicate(pf, query));
     }
-    if (query.getIncentives() != null && query.getIncentives().size() > 0) {
+    if (query.getIncentives() != null && !query.getIncentives().isEmpty()) {
       predicates.add(getChallengeIncentivesPredicate(pf, query));
     }
     if (query.getMinStartDate() != null || query.getMaxStartDate() != null) {
       predicates.add(getChallengeStartDatePredicate(pf, query));
+    }
+    if (query.getInputDataTypes() != null && !query.getInputDataTypes().isEmpty()) {
+      predicates.add(getChallengeInputDataTypesPredicate(pf, query));
     }
 
     SearchPredicate topLevelPredicate = buildTopLevelPredicate(pf, predicates);
@@ -146,7 +149,7 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
     return pf.bool(
             b -> {
               for (String platform : query.getPlatforms()) {
-                b.should(pf.match().field("platform.name").matching(platform));
+                b.should(pf.match().field("platform.slug").matching(platform));
               }
             })
         .toPredicate();
@@ -167,6 +170,25 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
               for (ChallengeSubmissionTypeDto submissionType : query.getSubmissionTypes()) {
                 b.should(
                     pf.match().field("submission_types.name").matching(submissionType.toString()));
+              }
+            })
+        .toPredicate();
+  }
+
+  /**
+   * Matches the challenges whose at least one of their input data types is in the list of input
+   * data types specified.
+   *
+   * @param pf
+   * @param query
+   * @return
+   */
+  private SearchPredicate getChallengeInputDataTypesPredicate(
+      SearchPredicateFactory pf, ChallengeSearchQueryDto query) {
+    return pf.bool(
+            b -> {
+              for (String inputDataType : query.getInputDataTypes()) {
+                b.should(pf.match().field("input_data_types.slug").matching(inputDataType));
               }
             })
         .toPredicate();

--- a/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
+++ b/apps/challenge-registry/challenge-service/src/main/java/org/sagebionetworks/challenge/service/ChallengeService.java
@@ -27,7 +27,7 @@ public class ChallengeService {
   private ChallengeMapper challengeMapper = new ChallengeMapper();
 
   private static final List<String> SEARCHABLE_FIELDS =
-      Arrays.asList("name", "headline", "description");
+      Arrays.asList("name", "headline", "description", "input_data_types.name");
 
   @Transactional(readOnly = true)
   public ChallengesPageDto listChallenges(ChallengeSearchQueryDto query) {


### PR DESCRIPTION
Fixes #1178 

## Changelog

- Filter challenges with the query parameter `inputDataTypes`.
- Enable full-text search to search using a challenge input data types.
- Update API client for Angular.

## Preview

List the challenges that include the input data type `genomic`:

```console
GET {{basePath}}/challenges?inputDataTypes=genomic

HTTP/1.1 200 
{
  "number": 0,
  "size": 100,
  "totalElements": 2,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challenges": [
    {
      "id": 1,
      "name": "The Digital Mammography DREAM Challenge",
      "headline": "Example headline",
      "description": "Example description",
      "status": "upcoming",
      "difficulty": "good_for_beginners",
      "platform": {
        "id": 1,
        "slug": "synapse",
        "name": "Synapse"
      },
      "incentives": [
        "monetary",
        "publication"
      ],
      "submissionTypes": [
        "container_image"
      ],
      "inputDataTypes": [
        {
          "id": 1,
          "slug": "genomic",
          "name": "genomic"
        },
        {
          "id": 2,
          "slug": "proteomic",
          "name": "proteomic"
        }
      ],
      "startDate": "2017-01-01",
      "endDate": "2017-02-01",
      "starredCount": 2,
      "createdAt": "2023-01-13T19:17:37Z",
      "updatedAt": "2023-01-13T19:17:37Z"
    },
    {
      "id": 2,
      "name": "Patient Mortality EHR DREAM Challenge",
      "headline": "Example headline",
      "description": "Example description",
      "status": "active",
      "difficulty": "intermediate",
      "platform": {
        "id": 1,
        "slug": "synapse",
        "name": "Synapse"
      },
      "incentives": [
        "monetary"
      ],
      "submissionTypes": [
        "prediction_file",
        "container_image"
      ],
      "inputDataTypes": [
        {
          "id": 1,
          "slug": "genomic",
          "name": "genomic"
        }
      ],
      "startDate": "2018-01-01",
      "endDate": "2018-02-01",
      "starredCount": 1,
      "createdAt": "2023-01-13T19:17:37Z",
      "updatedAt": "2023-01-13T19:17:37Z"
    }
  ]
}
```

Find challenges with genomic input data using full-text search:

```console
GET {{basePath}}/challenges?searchTerms=genomic

HTTP/1.1 200 
{
  "number": 0,
  "size": 100,
  "totalElements": 2,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challenges": [
    {
      "id": 2,
      "name": "Patient Mortality EHR DREAM Challenge",
      "headline": "Example headline",
      "description": "Example description",
      "status": "active",
      "difficulty": "intermediate",
      "platform": {
        "id": 1,
        "slug": "synapse",
        "name": "Synapse"
      },
      "incentives": [
        "monetary"
      ],
      "submissionTypes": [
        "prediction_file",
        "container_image"
      ],
      "inputDataTypes": [
        {
          "id": 1,
          "slug": "genomic",
          "name": "genomic"
        }
      ],
      "startDate": "2018-01-01",
      "endDate": "2018-02-01",
      "starredCount": 1,
      "createdAt": "2023-01-13T19:24:21Z",
      "updatedAt": "2023-01-13T19:24:21Z"
    },
    {
      "id": 1,
      "name": "The Digital Mammography DREAM Challenge",
      "headline": "Example headline",
      "description": "Example description",
      "status": "upcoming",
      "difficulty": "good_for_beginners",
      "platform": {
        "id": 1,
        "slug": "synapse",
        "name": "Synapse"
      },
      "incentives": [
        "monetary",
        "publication"
      ],
      "submissionTypes": [
        "container_image"
      ],
      "inputDataTypes": [
        {
          "id": 1,
          "slug": "genomic",
          "name": "genomic"
        },
        {
          "id": 2,
          "slug": "proteomic",
          "name": "proteomic"
        }
      ],
      "startDate": "2017-01-01",
      "endDate": "2017-02-01",
      "starredCount": 2,
      "createdAt": "2023-01-13T19:24:21Z",
      "updatedAt": "2023-01-13T19:24:21Z"
    }
  ]
}
```