### PR TITLE
feat: Add a workspace command to kill the process that listens to a port

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -43,6 +43,17 @@ function workspace-prepare {
 #   nx run-many --parallel --target=python
 # }
 
+function workspace-kill-port {
+  port="$1"
+  pids="$(lsof -t -i:$port)"
+  if [ -z "$pids" ]; then
+    echo "There are no processes listening to port $port."
+  else
+    echo "Killing process listening to port $port"
+    kill $(lsof -t -i:$pids)
+  fi
+}
+
 function workspace-lint {
   nx run-many --target=lint
 }

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -47,9 +47,9 @@ function workspace-kill-port {
   port="$1"
   pids="$(lsof -t -i:$port)"
   if [ -z "$pids" ]; then
-    echo "There are no processes listening to port $port."
+    echo "There are no processes listening to the port $port."
   else
-    echo "Killing process listening to port $port"
+    echo "Killing the processes listening to the port $port."
     kill $(lsof -t -i:$pids)
   fi
 }


### PR DESCRIPTION
Fixes #1192

## Changelog

- Add a workspace command to quickly kill the process(es) listening to the port specified.
    ```console
    workspace-kill-port
    ```

## Preview

When a process is listening to the port specified:

```console
$ workspace-kill-port 12345
Killing the processes listening to the port 12345.
```

When a process is NOT listening to the port specified:

```console
$ workspace-kill-port 12345
There are no processes listening to the port 12345.
```