### PR TITLE
feat: Add zipkin server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,6 +59,7 @@
     8091,
     8092,
     9200,
+    9411,
     27017
   ],
 
@@ -149,6 +150,10 @@
     },
     "9200": {
       "label": "openchallenges-elasticsearch",
+      "onAutoForward": "silent"
+    },
+    "9411": {
+      "label": "openchallenges-zipkin",
       "onAutoForward": "silent"
     },
     "27017": {

--- a/apps/openchallenges/zipkin/Dockerfile
+++ b/apps/openchallenges/zipkin/Dockerfile
@@ -1,0 +1,1 @@
+FROM openzipkin/zipkin:2.24.0

--- a/apps/openchallenges/zipkin/docker-compose.yml
+++ b/apps/openchallenges/zipkin/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+
+services:
+  openchallenges-zipkin:
+    image: sagebionetworks/openchallenges-zipkin:latest
+    container_name: openchallenges-zipkin
+    restart: always
+    env_file:
+      - .env
+    networks:
+      - openchallenges
+    ports:
+      - "9411:9411"
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+
+networks:
+  openchallenges:
+    name: openchallenges

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -1,0 +1,40 @@
+{
+  "name": "openchallenges-zipkin",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/openchallenges-zipkin/src",
+  "projectType": "application",
+  "targets": {
+    "prepare": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "shx cp -n .env.example .env",
+        "cwd": "apps/openchallenges/zipkin"
+      }
+    },
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker compose up",
+        "cwd": "apps/openchallenges/zipkin"
+      },
+      "dependsOn": ["prepare", "build-image"]
+    },
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker compose up -d",
+        "cwd": "apps/openchallenges/zipkin"
+      },
+      "dependsOn": ["prepare", "build-image"]
+    },
+    "build-image": {
+      "executor": "@nx-tools/nx-docker:build",
+      "options": {
+        "context": "apps/openchallenges/zipkin",
+        "push": false,
+        "tags": ["sagebionetworks/openchallenges-zipkin:latest"]
+      }
+    }
+  },
+  "tags": ["type:db", "scope:backend"]
+}

--- a/tools/configure-hostnames.sh
+++ b/tools/configure-hostnames.sh
@@ -19,6 +19,7 @@ declare -a hostnames=(
   "127.0.0.1 openchallenges-rabbitmq"
   "127.0.0.1 openchallenges-service-registry"
   "127.0.0.1 openchallenges-user-service"
+  "127.0.0.1 openchallenges-zipkin"
   "127.0.0.1 schematic-api"
 )
 


### PR DESCRIPTION
Fixes #1200 

## Changelog

- Add the project `openchallenges-zipkin` (Docker service)
- Reserve the port 9411 for Zipkin

## Preview

Start the Zipkin server:

```console
nx serve openchallenges-zipkin
```

Access Zipkin UI on `http://localhost:9411`:

![Screen Shot 2023-01-15 at 19 29 51](https://user-images.githubusercontent.com/3056480/212592684-4c054600-529b-4ba8-99af-6ebabb45a245.png)
