### PR TITLE
feat: Push traces from the challenge service to Zipkin

### DIFF
--- a/apps/openchallenges/challenge-service/build.gradle
+++ b/apps/openchallenges/challenge-service/build.gradle
@@ -53,6 +53,8 @@ dependencies {
   implementation "org.springframework.data:spring-data-commons:${springDataVersion}"
   runtimeOnly 'mysql:mysql-connector-java:8.0.30'
   testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+
+  implementation 'org.springframework.cloud:spring-cloud-starter-sleuth:2.2.8.RELEASE'
 }
 
 group = 'org.sagebionetworks.challenge'

--- a/apps/openchallenges/challenge-service/build.gradle
+++ b/apps/openchallenges/challenge-service/build.gradle
@@ -54,7 +54,8 @@ dependencies {
   runtimeOnly 'mysql:mysql-connector-java:8.0.30'
   testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
 
-  implementation 'org.springframework.cloud:spring-cloud-starter-sleuth:2.2.8.RELEASE'
+  implementation "org.springframework.cloud:spring-cloud-starter-sleuth:${springCloudVersion}"
+  implementation "org.springframework.cloud:spring-cloud-sleuth-zipkin:${springCloudVersion}"
 }
 
 group = 'org.sagebionetworks.challenge'

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -83,12 +83,13 @@
   },
   "tags": ["type:service", "scope:backend"],
   "implicitDependencies": [
-    // "openchallenges-api-gateway",
-    // "openchallenges-elasticsearch",
-    // "openchallenges-keycloak",
-    // "openchallenges-mariadb",
-    // "openchallenges-rabbitmq",
-    // "openchallenges-service-registry",
+    "openchallenges-api-gateway",
+    "openchallenges-elasticsearch",
+    "openchallenges-keycloak",
+    "openchallenges-mariadb",
+    "openchallenges-rabbitmq",
+    "openchallenges-service-registry",
+    "openchallenges-zipkin",
     "shared-java-util"
   ]
 }

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -83,12 +83,12 @@
   },
   "tags": ["type:service", "scope:backend"],
   "implicitDependencies": [
-    "openchallenges-api-gateway",
-    "openchallenges-elasticsearch",
-    "openchallenges-keycloak",
-    "openchallenges-mariadb",
-    "openchallenges-rabbitmq",
-    "openchallenges-service-registry",
+    // "openchallenges-api-gateway",
+    // "openchallenges-elasticsearch",
+    // "openchallenges-keycloak",
+    // "openchallenges-mariadb",
+    // "openchallenges-rabbitmq",
+    // "openchallenges-service-registry",
     "shared-java-util"
   ]
 }

--- a/apps/openchallenges/challenge-service/src/main/resources/application.yml
+++ b/apps/openchallenges/challenge-service/src/main/resources/application.yml
@@ -23,7 +23,6 @@ spring:
             hosts: openchallenges-elasticsearch:9200
             username: admin
             password: admin
-
   jackson:
     date-format: org.sagebionetworks.challenge.RFC3339DateFormat
     serialization:
@@ -40,6 +39,8 @@ spring:
     queue: challenge.queue
     routingkey: challenge.routingkey
   message: message succesfuly sent
+  zipkin:
+    base-url: http://openchallenges-zipkin:9411/
 
 server:
   port: 8085


### PR DESCRIPTION
Fixes #1202 

## Changelog

- Add Sleuth to the challenge service
- Push logs traces to Zipkin server
- Add Zipkin project as a dependency of the challenge service

## Notes

- Zipkin stores the traces in memory by default. E.g., stopping and restarting its container will delete the existing traces.
- [Zipkin supports different types of storage](https://hub.docker.com/r/openzipkin/zipkin/), including Elasticsearch.
- If Zipkin is not running when the challenge service starts, a Connection Refused is thrown (once?). This does not prevent the service to work and respond to the request.

## Preview

Analyze the traces of the requests sent to the challenge service with Zipkin:

![image](https://user-images.githubusercontent.com/3056480/212752052-d46c8b48-3eb8-4395-a734-c2c4a64a7077.png)

![image](https://user-images.githubusercontent.com/3056480/212752351-1aa49caf-c10d-4389-aa70-09efef96fd17.png)

