### PR TITLE
feat: Sort challenges by Closing soon, starting soon (backend)

### DIFF
--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -83,13 +83,13 @@
   },
   "tags": ["type:service", "scope:backend"],
   "implicitDependencies": [
-    // "openchallenges-api-gateway",
-    // "openchallenges-elasticsearch",
-    // "openchallenges-keycloak",
-    // "openchallenges-mariadb",
-    // "openchallenges-rabbitmq",
-    // "openchallenges-service-registry",
-    // "openchallenges-zipkin",
+    "openchallenges-api-gateway",
+    "openchallenges-elasticsearch",
+    "openchallenges-keycloak",
+    "openchallenges-mariadb",
+    "openchallenges-rabbitmq",
+    "openchallenges-service-registry",
+    "openchallenges-zipkin",
     "shared-java-util"
   ]
 }

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -83,13 +83,13 @@
   },
   "tags": ["type:service", "scope:backend"],
   "implicitDependencies": [
-    "openchallenges-api-gateway",
-    "openchallenges-elasticsearch",
-    "openchallenges-keycloak",
-    "openchallenges-mariadb",
-    "openchallenges-rabbitmq",
-    "openchallenges-service-registry",
-    "openchallenges-zipkin",
+    // "openchallenges-api-gateway",
+    // "openchallenges-elasticsearch",
+    // "openchallenges-keycloak",
+    // "openchallenges-mariadb",
+    // "openchallenges-rabbitmq",
+    // "openchallenges-service-registry",
+    // "openchallenges-zipkin",
     "shared-java-util"
   ]
 }

--- a/apps/openchallenges/challenge-service/requests.http
+++ b/apps/openchallenges/challenge-service/requests.http
@@ -48,6 +48,14 @@ GET {{basePath}}/challenges?inputDataTypes=genomic
 
 GET {{basePath}}/challenges?sort=starred&direction=desc
 
+### Sort the challenges by how soon they start
+
+GET {{basePath}}/challenges?sort=starting_soon
+
+### Sort the challenges by how soon they end
+
+GET {{basePath}}/challenges?sort=ending_soon
+
 ### List the challenge platforms
 
 GET {{basePath}}/challengePlatforms

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDirectionDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeDirectionDto.java
@@ -36,6 +36,6 @@ public enum ChallengeDirectionDto {
         return b;
       }
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    return null;
   }
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeSearchQueryDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeSearchQueryDto.java
@@ -30,7 +30,7 @@ public class ChallengeSearchQueryDto {
   private ChallengeSortDto sort = ChallengeSortDto.RELEVANCE;
 
   @JsonProperty("direction")
-  private ChallengeDirectionDto direction = ChallengeDirectionDto.DESC;
+  private ChallengeDirectionDto direction = null;
 
   @JsonProperty("difficulties")
   @Valid

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeSortDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/dto/ChallengeSortDto.java
@@ -11,9 +11,13 @@ import javax.validation.constraints.*;
 public enum ChallengeSortDto {
   CREATED("created"),
 
+  ENDING_SOON("ending_soon"),
+
   RELEVANCE("relevance"),
 
-  STARRED("starred");
+  STARRED("starred"),
+
+  STARTING_SOON("starting_soon");
 
   private String value;
 

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
@@ -103,11 +103,11 @@ public class ChallengeEntity {
   private List<ChallengeStar> stars;
 
   @Column(name = "start_date", columnDefinition = "DATE")
-  @GenericField(name = "start_date")
+  @GenericField(name = "start_date", sortable = Sortable.YES)
   private LocalDate startDate;
 
   @Column(name = "end_date", columnDefinition = "DATE")
-  @GenericField(name = "end_date")
+  @GenericField(name = "end_date", sortable = Sortable.YES)
   private LocalDate endDate;
 
   @Column(name = "created_at")

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/entity/ChallengeEntity.java
@@ -102,11 +102,11 @@ public class ChallengeEntity {
       sortable = Sortable.YES)
   private List<ChallengeStar> stars;
 
-  @Column(name = "start_date", columnDefinition = "DATE")
+  @Column(name = "start_date", columnDefinition = "DATE", nullable = true)
   @GenericField(name = "start_date", sortable = Sortable.YES)
   private LocalDate startDate;
 
-  @Column(name = "end_date", columnDefinition = "DATE")
+  @Column(name = "end_date", columnDefinition = "DATE", nullable = true)
   @GenericField(name = "end_date", sortable = Sortable.YES)
   private LocalDate endDate;
 

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
@@ -261,11 +261,13 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
    * @return
    */
   private SearchSort getSearchSort(SearchSortFactory sf, ChallengeSearchQueryDto query) {
-    SortOrder order =
+    SortOrder orderWithDefaultAsc =
         query.getDirection() == ChallengeDirectionDto.DESC ? SortOrder.DESC : SortOrder.ASC;
+    SortOrder orderWithDefaultDesc =
+        query.getDirection() == ChallengeDirectionDto.ASC ? SortOrder.ASC : SortOrder.DESC;
 
-    SearchSort createdSort = sf.field("created_at").order(order).toSort();
-    SearchSort scoreSort = sf.score().order(order).toSort();
+    SearchSort createdSort = sf.field("created_at").order(orderWithDefaultAsc).toSort();
+    SearchSort scoreSort = sf.score().order(orderWithDefaultAsc).toSort();
     SearchSort relevanceSort =
         (query.getSearchTerms() == null || query.getSearchTerms().isBlank())
             ? createdSort
@@ -276,16 +278,16 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
         return createdSort;
       }
       case ENDING_SOON -> {
-        return sf.field("end_date").order(order).toSort();
+        return sf.field("end_date").order(orderWithDefaultAsc).toSort();
       }
       case RELEVANCE -> {
         return relevanceSort;
       }
       case STARRED -> {
-        return sf.field("starred_count").order(order).toSort();
+        return sf.field("starred_count").order(orderWithDefaultDesc).toSort();
       }
       case STARTING_SOON -> {
-        return sf.field("start_date").order(order).toSort();
+        return sf.field("start_date").order(orderWithDefaultAsc).toSort();
       }
       default -> {
         throw new BadRequestException(

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
@@ -266,8 +266,8 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
     SortOrder orderWithDefaultDesc =
         query.getDirection() == ChallengeDirectionDto.ASC ? SortOrder.ASC : SortOrder.DESC;
 
-    SearchSort createdSort = sf.field("created_at").order(orderWithDefaultAsc).toSort();
-    SearchSort scoreSort = sf.score().order(orderWithDefaultAsc).toSort();
+    SearchSort createdSort = sf.field("created_at").order(orderWithDefaultDesc).toSort();
+    SearchSort scoreSort = sf.score().order(orderWithDefaultDesc).toSort();
     SearchSort relevanceSort =
         (query.getSearchTerms() == null || query.getSearchTerms().isBlank())
             ? createdSort

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/challenge/model/repository/CustomChallengeRepositoryImpl.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.challenge.model.repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.EntityManager;

--- a/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.1.0__insert_data.sql
+++ b/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.1.0__insert_data.sql
@@ -75,6 +75,28 @@ VALUES (
     '2',
     '2019-01-01',
     '2019-02-01'
+  ),
+    (
+    '4',
+    'Awesome Challenge 2024',
+    'Example headline',
+    'Example description',
+    'completed',
+    'advanced',
+    '2',
+    '2024-01-01',
+    '2024-02-01'
+  ),
+    (
+    '5',
+    'Awesome Challenge 2025',
+    'Example headline',
+    'Example description',
+    'completed',
+    'advanced',
+    '2',
+    '2025-01-01',
+    '2025-02-01'
   );
 
 -- challenge_incentive data

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -273,8 +273,10 @@ components:
       description: What to sort results by.
       enum:
       - created
+      - ending_soon
       - relevance
       - starred
+      - starting_soon
       type: string
     ChallengeDirection:
       default: desc

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -279,11 +279,11 @@ components:
       - starting_soon
       type: string
     ChallengeDirection:
-      default: desc
       description: The direction to sort the results by.
       enum:
       - asc
       - desc
+      nullable: true
       type: string
     ChallengeDifficulty:
       description: The difficulty level of a challenge.

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -109,9 +109,11 @@ components:
       type: string
       default: relevance
       enum:
+        - closing_soon
         - created
         - relevance
         - starred
+        - starting_soon
     ChallengeDirection:
       description: The direction to sort the results by.
       type: string

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -109,8 +109,8 @@ components:
       type: string
       default: relevance
       enum:
-        - closing_soon
         - created
+        - ending_soon
         - relevance
         - starred
         - starting_soon

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -117,7 +117,7 @@ components:
     ChallengeDirection:
       description: The direction to sort the results by.
       type: string
-      default: desc
+      nullable: true
       enum:
         - asc
         - desc

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -238,9 +238,11 @@ components:
       type: string
       default: relevance
       enum:
+        - closing_soon
         - created
         - relevance
         - starred
+        - starting_soon
     ChallengeDirection:
       description: The direction to sort the results by.
       type: string

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -246,7 +246,7 @@ components:
     ChallengeDirection:
       description: The direction to sort the results by.
       type: string
-      default: desc
+      nullable: true
       enum:
         - asc
         - desc

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -238,8 +238,8 @@ components:
       type: string
       default: relevance
       enum:
-        - closing_soon
         - created
+        - ending_soon
         - relevance
         - starred
         - starting_soon

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeDirection.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeDirection.yaml
@@ -1,6 +1,6 @@
 description: The direction to sort the results by.
 type: string
-default: desc
+nullable: true
 enum:
   - asc
   - desc

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
@@ -2,6 +2,8 @@ description: What to sort results by.
 type: string
 default: relevance
 enum:
+  - closing_soon
   - created
   - relevance
   - starred
+  - starting_soon

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
@@ -2,8 +2,8 @@ description: What to sort results by.
 type: string
 default: relevance
 enum:
-  - closing_soon
   - created
+  - ending_soon
   - relevance
   - starred
   - starting_soon


### PR DESCRIPTION
Fixes #1157 

## Changelog

- Add two example challenges: one organized in 2024 and one in 2025.
- Add the option to sort challenges by `starting_soon` and `ending_soon`.
- Accept `null` direction so that the backend can decide on the default to choose (`desc` or `asc`).
  - Example 1: `/challenges?sort=starred` should use the default direction `desc`
  - Example 2: `/challenges?sort=starting_soon` should use the default direction `asc` to show first the challenges that start the closest to now.

## Notes

- Changing the OA description to accept `null` direction has one minor negative side effect: The OA generator for Java will handles the creation of enums as follows: "if the specified value does not exist, return `null`". It would have been preferable to check if the value specified is in (`asc`, `desc`, `null`), and otherwise throw a Bad Request exception for other values. This behavior can be implemented by modifying the OA generator template for enums. However, I won't implement that in this PR as not strictly required.

## Preview

Sort the challenges by how soon they start.

> **Note**
> The challenges with a start date before "now" or with a `null` value are not included.

```console
GET {{basePath}}/challenges?sort=starting_soon

HTTP/1.1 200 
{
  "number": 0,
  "size": 100,
  "totalElements": 2,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challenges": [
    {
      "id": 4,
      "name": "Awesome Challenge 2024",
      "headline": "Example headline",
      "description": "Example description",
      "status": "completed",
      "difficulty": "advanced",
      "platform": {
        "id": 2,
        "slug": "codalab",
        "name": "CodaLab"
      },
      "incentives": [],
      "submissionTypes": [],
      "inputDataTypes": [],
      "startDate": "2024-01-01",
      "endDate": "2024-02-01",
      "starredCount": 0,
      "createdAt": "2023-01-17T23:34:52Z",
      "updatedAt": "2023-01-17T23:34:52Z"
    },
    {
      "id": 5,
      "name": "Awesome Challenge 2025",
      "headline": "Example headline",
      "description": "Example description",
      "status": "completed",
      "difficulty": "advanced",
      "platform": {
        "id": 2,
        "slug": "codalab",
        "name": "CodaLab"
      },
      "incentives": [],
      "submissionTypes": [],
      "inputDataTypes": [],
      "startDate": "2025-01-01",
      "endDate": "2025-02-01",
      "starredCount": 0,
      "createdAt": "2023-01-17T23:34:52Z",
      "updatedAt": "2023-01-17T23:34:52Z"
    }
  ]
}
```

Sort the challenges by how soon they end:

> **Note**
> The challenges with an end date before "now" or with a `null` value are not included.

```console
GET {{basePath}}/challenges?sort=ending_soon

HTTP/1.1 200 
{
  "number": 0,
  "size": 100,
  "totalElements": 2,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challenges": [
    {
      "id": 4,
      "name": "Awesome Challenge 2024",
      "headline": "Example headline",
      "description": "Example description",
      "status": "completed",
      "difficulty": "advanced",
      "platform": {
        "id": 2,
        "slug": "codalab",
        "name": "CodaLab"
      },
      "incentives": [],
      "submissionTypes": [],
      "inputDataTypes": [],
      "startDate": "2024-01-01",,
      "endDate": "2024-02-01",
      "starredCount": 0,
      "createdAt": "2023-01-17T23:37:20Z",
      "updatedAt": "2023-01-17T23:37:20Z"
    },
    {
      "id": 5,
      "name": "Awesome Challenge 2025",
      "headline": "Example headline",
      "description": "Example description",
      "status": "completed",
      "difficulty": "advanced",
      "platform": {
        "id": 2,
        "slug": "codalab",
        "name": "CodaLab"
      },
      "incentives": [],
      "submissionTypes": [],
      "inputDataTypes": [],
      "startDate": "2025-01-01",
      "endDate": "2025-02-01",
      "starredCount": 0,
      "createdAt": "2023-01-17T23:37:20Z",
      "updatedAt": "2023-01-17T23:37:20Z"
    }
  ]
}
```