### PR TITLE
fix: Rename VS Code extension `vscode-boot-dev-pack`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,10 +27,10 @@
     "mtxr.sqltools-driver-pg",
     "mtxr.sqltools",
     "nrwl.angular-console",
-    "Pivotal.vscode-boot-dev-pack",
     "ritwickdey.LiveServer",
     "shengchen.vscode-checkstyle",
     "stkb.rewrap",
+    "vmware.vscode-boot-dev-pack",
     "vscjava.vscode-gradle",
     "vscjava.vscode-java-pack",
     "webhint.vscode-webhint"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,10 +16,10 @@
     "mtxr.sqltools-driver-pg",
     "mtxr.sqltools",
     "nrwl.angular-console",
-    "Pivotal.vscode-boot-dev-pack",
     "ritwickdey.LiveServer",
     "shengchen.vscode-checkstyle",
     "stkb.rewrap",
+    "vmware.vscode-boot-dev-pack",
     "vscjava.vscode-gradle",
     "vscjava.vscode-java-pack",
     "webhint.vscode-webhint"


### PR DESCRIPTION
Fixes #1257