### PR TITLE
feat: Add Vault CLI to the dev container

### DIFF
--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -38,10 +38,13 @@ RUN groupadd docker \
   # Add ngrok repository
   && curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
   && echo "deb https://ngrok-agent.s3.amazonaws.com bullseye main" | tee /etc/apt/sources.list.d/ngrok.list \
+  # Add hashicorp repository
+  && curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
+  && echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list \
   # Install extra packages
   && apt-get update -qq -y \
   && apt-get install --no-install-recommends -qq -y \
-    nodejs gh ngrok \
+    nodejs gh ngrok vault \
   && corepack enable yarn \
   && corepack prepare "yarn@${yarnVersion}" --activate \
   # Install @devcontainers/cli

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -45,6 +45,9 @@ RUN groupadd docker \
   && apt-get update -qq -y \
   && apt-get install --no-install-recommends -qq -y \
     nodejs gh ngrok vault \
+  # Fix Vault CLI
+  # See https://github.com/hashicorp/vault/issues/10924
+  && setcap -r /usr/bin/vault \
   && corepack enable yarn \
   && corepack prepare "yarn@${yarnVersion}" --activate \
   # Install @devcontainers/cli


### PR DESCRIPTION
Fixes  #1283

## Changelog

- Add `vault` command to the dev container.

## Preview

Print Vault version:

```console
$ vault --version
Vault v1.12.2 (415e1fe3118eebd5df6cb60d13defdc01aa17b03), built 2022-11-23T12:53:46Z
```

Set the following environment variables to interact with the OC vault server:

```console
export VAULT_ADDR='http://127.0.0.1:8200'
export VAULT_TOKEN=changeme
```

Add and read secrets:

```console
$ vault kv put secret/config-server plop.hello=world
====== Secret Path ======
secret/data/config-server

======= Metadata =======
Key                Value
---                -----
created_time       2023-02-05T01:27:10.263055161Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1
vscode@131d17258f7f:/workspaces/sage-monorepo$ vault kv get secret/config-server
====== Secret Path ======
secret/data/config-server

======= Metadata =======
Key                Value
---                -----
created_time       2023-02-05T01:27:10.263055161Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            1

======= Data =======
Key           Value
---           -----
plop.hello    world
```