### PR TITLE
chore: Update dev container image to get access to `jq` and Vault CLI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Sage",
-  "image": "sagebionetworks/sage-devcontainer:67f8864",
+  "image": "sagebionetworks/sage-devcontainer:0cde36d",
 
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2.0.0": {


### PR DESCRIPTION
## Changelog

- Update the dev container image to benefit from the following updates:
  - #1280
  - #1284