### PR TITLE
feat: Add basic authentication to the config server

### DIFF
--- a/apps/openchallenges/config-server/build.gradle
+++ b/apps/openchallenges/config-server/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   implementation "org.sagebionetworks.openchallenges:openchallenges-app-config-data:${openchallengesVersion}"
   implementation "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
   implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
+  implementation "org.springframework.boot:spring-boot-starter-security:${springBootVersion}"
   implementation "org.springframework.cloud:spring-cloud-config-server:${springCloudVersion}"
   implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudVersion}"
   testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"

--- a/apps/openchallenges/config-server/src/main/resources/application.yml
+++ b/apps/openchallenges/config-server/src/main/resources/application.yml
@@ -22,6 +22,10 @@ spring:
     fail-fast: true
   profiles:
     active: git,vault
+  security:
+    user:
+      name: openchallenges
+      password: changeme
 
 server:
   port: 8090

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -85,7 +85,7 @@
   "implicitDependencies": [
     "openchallenges-api-gateway",
     "openchallenges-app-config-data",
-    "openchallenges-config-server",
+    // "openchallenges-config-server",
     "openchallenges-keycloak",
     "openchallenges-mariadb",
     "openchallenges-service-registry",

--- a/apps/openchallenges/organization-service/src/main/resources/application.yml
+++ b/apps/openchallenges/organization-service/src/main/resources/application.yml
@@ -1,82 +1,12 @@
 spring:
   application:
     name: openchallenges-organization-service
-  datasource:
-    # url: jdbc:mysql://openchallenges-mariadb:3306/challenge
-    url: ${db.url}
-    # url: jdbc:h2:mem:challenge
-    username: organization_service
-    password: changeme
-  jpa:
-    hibernate:
-      ddl-auto: update
-  jackson:
-    date-format: org.sagebionetworks.openchallenges.organization.service.RFC3339DateFormat
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
-  flyway:
-    enabled: true
-  #   cleanOnValidationError: true
-  zipkin:
-    base-url: http://openchallenges-zipkin:9411
+  profiles:
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
+    # name: openchallenges-organization-service,openchallenges
   cloud:
     config:
       username: openchallenges
       password: changeme
-  profiles:
-    active: dev,local
-
-server:
-  port: 8084
-
-eureka:
-  client:
-    service-url:
-      defaultZone: ${service.registry.url}
-  instance:
-    preferIpAddress: true
-
-management:
-  info:
-    env:
-      enabled: true
-  endpoints:
-    web:
-      exposure:
-        include: info,health
-
-info:
-  application:
-    name: ${spring.application.name}
-
-keycloak:
-  realm: test
-  resource: openchallenges-organization-service
-  credentials:
-    secret: GFRau7cQTxhx19CUmSdrqrqrZ1pshjjB
-  auth-server-url: ${keycloak.url}
-  ssl-required: external
-  use-resource-role-mappings: true
-  bearer-only: true
-
-app:
-  config:
-    keycloak:
-      server-url: ${keycloak.url}
-      realm: test
-      # TODO: Which client ID property is used?
-      client-id: challenge-api-client
-      clientId: challenge-api-client
-      client-secret: mg2DrRcxHx19PIITibdOnbNEbJUKjGKb
-# springdoc:
-#   version: openapi_3_1
-#   swagger-ui:
-#     path: /api/v1/api-docs/ui
-#     # url: /api/v1/api-docs/openapi.json
-#   api-docs:
-#     enabled: true
-#     path: /api/v1/api-docs/openapi.json
-#   packagesToScan: org.sagebionetworks.openchallenges.organization.service.controller
-#   pathsToMatch: /**

--- a/apps/openchallenges/organization-service/src/main/resources/application.yml
+++ b/apps/openchallenges/organization-service/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
     base-url: http://openchallenges-zipkin:9411
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
+  cloud:
+    config:
+      username: openchallenges
+      password: changeme
   profiles:
     active: dev,local
 


### PR DESCRIPTION
Fixes #1278 

## Changelog

- Add basic authentication to the config server.
- Configure the org service to authenticate with the config server.