### PR TITLE
fix: Add `notebook` enum value to api description source file

### DIFF
--- a/libs/openchallenges/api-client-angular/src/lib/model/challengeSubmissionType.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/challengeSubmissionType.ts
@@ -14,11 +14,12 @@
 /**
  * The submission type of the challenge.
  */
-export type ChallengeSubmissionType = 'container_image' | 'prediction_file' | 'other';
+export type ChallengeSubmissionType = 'container_image' | 'prediction_file' | 'notebook' | 'other';
 
 export const ChallengeSubmissionType = {
     ContainerImage: 'container_image' as ChallengeSubmissionType,
     PredictionFile: 'prediction_file' as ChallengeSubmissionType,
+    Notebook: 'notebook' as ChallengeSubmissionType,
     Other: 'other' as ChallengeSubmissionType
 };
 

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -297,6 +297,7 @@ components:
       enum:
         - container_image
         - prediction_file
+        - notebook
         - other
       example: container_image
     ChallengeSearchQuery:

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSubmissionType.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSubmissionType.yaml
@@ -3,5 +3,6 @@ type: string
 enum:
   - container_image
   - prediction_file
+  - notebook
   - other
 example: container_image


### PR DESCRIPTION
Follow up to #1298

## Changelog

- Add the value `notebook` to the API description source file.
- `nx build openchallenges-api-description`
- `nx openapi-generate openchallenges-challenge-service`
- `nx openapi-generate openchallenges-api-client-angular`