### PR TITLE
feat: Add util command to add git upstream remote

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -82,6 +82,10 @@ function openchallenges-db-cli {
   node dist/apps/openchallenges/db-cli/src/index.js
 }
 
+function workspace-add-git-remote-upstream {
+  git remote add upstream https://github.com/Sage-Bionetworks/sage-monorepo.git
+}
+
 # function challenge-seed-db {
 #   node dist/apps/challenge-db-cli/src/index.js seed "$WORKSPACE_DIR/apps/challenge-db-cli/data/seeds/production/"
 # }


### PR DESCRIPTION
> **Note** I will update this PR so that the upstream branch is added when the dev container starts instead of adding a command the developer may not know about.

We use the forking development workflow so we are cloning our fork first. To make it easier to open PR against the upstream repo, we need to add the git remote for the upstream repo.

## Changelog

- Add the workspace command `workspace-add-git-remote-upstream`, which is an alias for `git remote add upstream https://github.com/Sage-Bionetworks/sage-monorepo.git`.