### PR TITLE
fix: App serve does not need to build images of dependencies

### DIFF
--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -98,7 +98,7 @@
         "publicHost": "http://localhost:4200",
         "proxyConfig": "apps/openchallenges/app/src/proxy.conf.json"
       },
-      "dependsOn": ["^build-image", "^serve-detach"]
+      "dependsOn": ["^serve-detach"]
     },
     "extract-i18n": {
       "executor": "@angular-devkit/build-angular:extract-i18n",


### PR DESCRIPTION
@vpchung There is actually no need for the app to build the image of its dependencies: running their task `serve-detach` is already taking care of building their image. So today's score is 1-0... 😊