### PR TITLE
chore: Disable containers build in git hooks

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -4,5 +4,5 @@
 node tools/check-nodejs-dependencies.js
 node tools/check-java-environments.js
 node tools/check-python-dependencies.js
-node tools/check-container-images.js
+# node tools/check-container-images.js
 node tools/check-devcontainer-version.js

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -6,5 +6,5 @@
 node tools/check-nodejs-dependencies.js post-merge
 node tools/check-java-environments.js
 node tools/check-python-dependencies.js
-node tools/check-container-images.js
+# node tools/check-container-images.js
 node tools/check-devcontainer-version.js

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -4,5 +4,5 @@
 node tools/check-nodejs-dependencies.js
 node tools/check-java-environments.js
 node tools/check-python-dependencies.js
-node tools/check-container-images.js
+# node tools/check-container-images.js
 node tools/check-devcontainer-version.js


### PR DESCRIPTION
I recently added a scripts that build the containers of the projects that have changed after a git operation. While building the images shouldn't take more than 1 minute when a small number of projects have changed, I already observed that this introduced a risk of context switching for me.

This PR propose to disable this script in the git hooks. Instead, it is recommended for now to run `openchallenges-build-images` when needed and after pulling changes from upstream.

If you are working on a specific project and need to rebuild the image, you can achieve this efficiently with `nx build-image <project>`.

## App development workflow

Here is a suggested workflow when developing the app to minimize container build/start time:

```console
# Fresh start: build all the OC images (cached layers previously cashed will help)
openchallenges-build-images

# Start the stack (this step take some time that can be minimize later, see below)
nx serve-detach openchallenges-app

# Stop the container of the app
docker stop openchallenges-app

# Start the app development server (comes with hot reloading)
nx serve openchallenges-app
```

### Test the dockerized app

This step can be applied optionally before submitting a PR that modifies the app to ensure that it works once dockerize. In most cases there is no reason to think that it shouldn't.

Assuming that you followed the above workflow:

```console
# Stop the app development server

# Build the app container
nx build-image openchallenges-app

# Start the app container.
# NOTE: This operation should complete very quickly as the other containers of the stack should already be running!
nx serve-detach openchallenges-app
```
