### PR TITLE
chore: Disable renovate to remove deps update noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "enabled": true,
+  "enabled": false,
   "assignees": ["tschaffter"],
   "semanticCommitScope": "deps",
   "automergeType": "pr",


### PR DESCRIPTION
Renovate is rebasing PR that it has opens every time we push to `main`, which triggers notifications in my GH feed (= noise).

I plan to reactivate renovate once per quarter to update dependencies.