### PR TITLE
feat: Disable linter errors generated for the API client for Angular

### DIFF
--- a/libs/openchallenges/api-client-angular/.eslintrc.json
+++ b/libs/openchallenges/api-client-angular/.eslintrc.json
@@ -1,36 +1,4 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
-  "overrides": [
-    {
-      "files": ["*.ts"],
-      "extends": [
-        "plugin:@nrwl/nx/angular",
-        "plugin:@angular-eslint/template/process-inline-templates"
-      ],
-      "rules": {
-        "@angular-eslint/directive-selector": [
-          "error",
-          {
-            "type": "attribute",
-            "prefix": "openchallenges",
-            "style": "camelCase"
-          }
-        ],
-        "@angular-eslint/component-selector": [
-          "error",
-          {
-            "type": "element",
-            "prefix": "openchallenges",
-            "style": "kebab-case"
-          }
-        ]
-      }
-    },
-    {
-      "files": ["*.html"],
-      "extends": ["plugin:@nrwl/nx/angular-template"],
-      "rules": {}
-    }
-  ]
+  "ignorePatterns": ["libs/openchallenges/api-client-angular/src/**/*.ts"]
 }

--- a/libs/openchallenges/api-client-angular/project.json
+++ b/libs/openchallenges/api-client-angular/project.json
@@ -47,8 +47,7 @@
       "options": {
         "commands": [
           "rm -fr src/lib/*",
-          "openapi-generator-cli generate",
-          "echo 'TODO Format generated code'"
+          "openapi-generator-cli generate"
         ],
         "cwd": "libs/openchallenges/api-client-angular",
         "parallel": false


### PR DESCRIPTION
Fixes #991 

## Changelog

- Disable linter errors generated for the API client for Angular

## Preview

### Before

![image](https://user-images.githubusercontent.com/3056480/224837430-dc349996-ad27-4ae0-974c-603621aa8335.png)

### After

![image](https://user-images.githubusercontent.com/3056480/224837550-c9877c10-65ae-434d-abfc-62e789f4de02.png)
