### PR TITLE
feat: Remove the docker compose command for microservice

### DIFF
--- a/docker/openchallenges/services/api-gateway.yml
+++ b/docker/openchallenges/services/api-gateway.yml
@@ -11,7 +11,6 @@ services:
       - openchallenges
     ports:
       - '8082:8082'
-    command: start-dev
     depends_on:
       openchallenges-config-server:
         condition: service_healthy

--- a/docker/openchallenges/services/challenge-service.yml
+++ b/docker/openchallenges/services/challenge-service.yml
@@ -11,7 +11,6 @@ services:
       - openchallenges
     ports:
       - '8085:8085'
-    command: start-dev
     depends_on:
       openchallenges-config-server:
         condition: service_healthy

--- a/docker/openchallenges/services/config-server.yml
+++ b/docker/openchallenges/services/config-server.yml
@@ -11,7 +11,6 @@ services:
       - openchallenges
     ports:
       - '8090:8090'
-    command: start-dev
     deploy:
       resources:
         limits:

--- a/docker/openchallenges/services/organization-service.yml
+++ b/docker/openchallenges/services/organization-service.yml
@@ -11,7 +11,6 @@ services:
       - openchallenges
     ports:
       - '8084:8084'
-    command: start-dev
     depends_on:
       openchallenges-config-server:
         condition: service_healthy

--- a/docker/openchallenges/services/service-registry.yml
+++ b/docker/openchallenges/services/service-registry.yml
@@ -11,7 +11,6 @@ services:
       - openchallenges
     ports:
       - '8081:8081'
-    command: start-dev
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Fixes #1345 

## Changelog

- Remove the `command` property from the microservice Docker compose services.