### PR TITLE
feat: Implement method to get (unsafe) image url

### DIFF
--- a/apps/openchallenges/image-service/.openapi-generator/FILES
+++ b/apps/openchallenges/image-service/.openapi-generator/FILES
@@ -9,4 +9,3 @@ src/main/java/org/sagebionetworks/openchallenges/image/service/configuration/Spr
 src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/BasicErrorDto.java
 src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/ImageDto.java
 src/main/resources/openapi.yaml
-src/test/java/org/sagebionetworks/openchallenges/image/service/OpenApiGeneratorApplicationTests.java

--- a/apps/openchallenges/image-service/requests.http
+++ b/apps/openchallenges/image-service/requests.http
@@ -1,4 +1,4 @@
-@imageServiceHost = http://openchallenges-image-service:8084
+@imageServiceHost = http://openchallenges-image-service:8086
 @apiGatewayHost = http://openchallenges-api-gateway:8082
 
 ### Select the base path
@@ -8,4 +8,6 @@
 # Send the requests to the API gateway
 # @basePath = {{apiGatewayHost}}/api/v1
 
-### Get the image with the key logo/sagebionetworks.org
+### Get the image with the key triforce.png
+
+GET {{basePath}}/images/triforce.png

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/api/ImageApiDelegateImpl.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/api/ImageApiDelegateImpl.java
@@ -1,0 +1,21 @@
+package org.sagebionetworks.openchallenges.image.service.api;
+
+import org.sagebionetworks.openchallenges.image.service.model.dto.ImageDto;
+import org.sagebionetworks.openchallenges.image.service.service.ImageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageApiDelegateImpl implements ImageApiDelegate {
+
+  private final ImageService imageService;
+
+  public ImageApiDelegateImpl(ImageService imageService) {
+    this.imageService = imageService;
+  }
+
+  @Override
+  public ResponseEntity<ImageDto> getImage(String image) {
+    return ResponseEntity.ok(imageService.getImage(image));
+  }
+}

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/ImageDto.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/ImageDto.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.*;
 @Schema(name = "Image", description = "An image")
 @JsonTypeName("Image")
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
-// TODO Add x-java-class-annotations
+@lombok.Builder
 public class ImageDto {
 
   @JsonProperty("url")

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.openchallenges.image.service.service;
+
+import org.sagebionetworks.openchallenges.image.service.model.dto.ImageDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ImageService {
+
+  public ImageDto getImage(String image) {
+    String imageUrl = String.format("http://localhost:8889/unsafe/%s", image);
+    return ImageDto.builder().url(imageUrl).build();
+  }
+}

--- a/apps/openchallenges/image-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/image-service/src/main/resources/openapi.yaml
@@ -95,6 +95,8 @@ components:
       required:
       - url
       type: object
+      x-java-class-annotations:
+      - '@lombok.Builder'
     BasicError:
       description: Problem details (tools.ietf.org/html/rfc7807)
       properties:

--- a/docker/openchallenges/services/image-service.yml
+++ b/docker/openchallenges/services/image-service.yml
@@ -16,6 +16,8 @@ services:
         condition: service_healthy
       openchallenges-service-registry:
         condition: service_healthy
+      openchallenges-thumbor:
+        condition: service_healthy
       openchallenges-zipkin:
         condition: service_healthy
     deploy:

--- a/libs/openchallenges/api-description/build/image.openapi.yaml
+++ b/libs/openchallenges/api-description/build/image.openapi.yaml
@@ -51,6 +51,8 @@ components:
           example: http://example.com/an-image.png
       required:
         - url
+      x-java-class-annotations:
+        - '@lombok.Builder'
     BasicError:
       type: object
       description: Problem details (tools.ietf.org/html/rfc7807)

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -751,6 +751,8 @@ components:
           example: 'http://example.com/an-image.png'
       required:
         - url
+      x-java-class-annotations:
+        - '@lombok.Builder'
     ChallengeContributorRole:
       description: The role of a challenge contributor.
       type: string

--- a/libs/openchallenges/api-description/src/components/schemas/Image.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/Image.yaml
@@ -6,3 +6,5 @@ properties:
     example: http://example.com/an-image.png
 required:
   - url
+x-java-class-annotations:
+  - '@lombok.Builder'


### PR DESCRIPTION
Closes #1414

## Changelog

- Implement the get image endpoint of the image service

## Preview

Get the image with the key `triforce.png` (stored in the AWS S3 bucket):

```
GET {{basePath}}/images/triforce.png

HTTP/1.1 200 
{
  "url": "http://localhost:8889/unsafe/triforce.png"
}
```