### PR TITLE
feat: Sign the URL returned by the image service

### DIFF
--- a/apps/openchallenges/image-service/build.gradle
+++ b/apps/openchallenges/image-service/build.gradle
@@ -42,6 +42,7 @@ dependencies {
   implementation "org.sagebionetworks.openchallenges:openchallenges-app-config-data:${openchallengesVersion}"
 
   implementation 'io.micrometer:micrometer-registry-prometheus:1.10.4'
+  implementation 'com.squareup:pollexor:3.0.0'
 }
 
 group = 'org.sagebionetworks.openchallenges'

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
@@ -1,13 +1,33 @@
 package org.sagebionetworks.openchallenges.image.service.service;
 
+import com.squareup.pollexor.Thumbor;
+import org.sagebionetworks.openchallenges.app.config.data.ImageServiceConfigData;
 import org.sagebionetworks.openchallenges.image.service.model.dto.ImageDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ImageService {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ImageService.class);
+
+  private final ImageServiceConfigData imageServiceConfigData;
+
+  private final Thumbor thumbor;
+
+  public ImageService(ImageServiceConfigData imageServiceConfigData) {
+    this.imageServiceConfigData = imageServiceConfigData;
+
+    LOG.info("Thumbor host: {}", this.imageServiceConfigData.getThumborHost());
+    this.thumbor =
+        Thumbor.create(
+            this.imageServiceConfigData.getThumborHost(),
+            this.imageServiceConfigData.getThumborSecurityKey());
+  }
+
   public ImageDto getImage(String image) {
-    String imageUrl = String.format("http://localhost:8889/unsafe/%s", image);
+    String imageUrl = thumbor.buildImage(image).resize(300, 300).toUrl();
     return ImageDto.builder().url(imageUrl).build();
   }
 }

--- a/libs/openchallenges/app-config-data/src/main/java/org/sagebionetworks/openchallenges/app/config/data/ImageServiceConfigData.java
+++ b/libs/openchallenges/app-config-data/src/main/java/org/sagebionetworks/openchallenges/app/config/data/ImageServiceConfigData.java
@@ -10,4 +10,6 @@ import org.springframework.context.annotation.Configuration;
 public class ImageServiceConfigData {
 
   private String welcomeMessage;
+  private String thumborHost;
+  private String thumborSecurityKey;
 }


### PR DESCRIPTION
Closes #1416 

## Changelog

- Add a Thumbor client to the image service project.
- Sign the URLs to images served by Thumbor.

## Notes

- The Thumbor config parameter `SECURITY_KEY` must be set (here to `changeme`).

## Preview

Get the image with the key `triforce.png`:

```
GET {{basePath}}/images/triforce.png

HTTP/1.1 200 
{
  "url": "http://localhost:8889/ucBCtKeFXF3rPUsmUGmxcTRnoj0=/300x300/triforce.png"
}
```

Tampering with the URL will return a 400 error.