### PR TITLE
feat:  Externalize the config of the challenge service

### DIFF
--- a/apps/openchallenges/challenge-service/config/application-local.yml
+++ b/apps/openchallenges/challenge-service/config/application-local.yml
@@ -1,2 +1,2 @@
 openchallenges-challenge-service:
-  welcome-message: 'Welcome to the challenge service (local).'
+  welcome-message: 'Welcome to the challenge service (local config).'

--- a/apps/openchallenges/challenge-service/config/application-local.yml
+++ b/apps/openchallenges/challenge-service/config/application-local.yml
@@ -1,0 +1,2 @@
+openchallenges-challenge-service:
+  welcome-message: 'Welcome to the challenge service (local).'

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/ChallengeServiceApplication.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/ChallengeServiceApplication.java
@@ -1,5 +1,9 @@
 package org.sagebionetworks.openchallenges.challenge.service;
 
+import org.sagebionetworks.openchallenges.app.config.data.ChallengeServiceConfigData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
@@ -7,15 +11,23 @@ import org.springframework.context.annotation.ComponentScan;
 
 @EnableEurekaClient
 @SpringBootApplication
-@ComponentScan(basePackages = {"org.sagebionetworks.openchallenges.challenge.service"})
-public class ChallengeServiceApplication {
+@ComponentScan(basePackages = {"org.sagebionetworks.openchallenges"})
+public class ChallengeServiceApplication implements CommandLineRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ChallengeServiceApplication.class);
+
+  private final ChallengeServiceConfigData challengeServiceConfigData;
+
+  public ChallengeServiceApplication(ChallengeServiceConfigData challengeServiceConfigData) {
+    this.challengeServiceConfigData = challengeServiceConfigData;
+  }
 
   public static void main(String[] args) {
     SpringApplication.run(ChallengeServiceApplication.class, args);
   }
 
-  // @Bean
-  // public Module jsonNullableModule() {
-  //   return new JsonNullableModule();
-  // }
+  @Override
+  public void run(String... args) throws Exception {
+    LOG.info(challengeServiceConfigData.getWelcomeMessage());
+  }
 }

--- a/apps/openchallenges/image-service/config/application-local.yml
+++ b/apps/openchallenges/image-service/config/application-local.yml
@@ -1,2 +1,2 @@
 openchallenges-image-service:
-  welcome-message: 'Welcome to the image service (local).'
+  welcome-message: 'Welcome to the image service (local config).'

--- a/apps/openchallenges/organization-service/config/application-local.yml
+++ b/apps/openchallenges/organization-service/config/application-local.yml
@@ -1,2 +1,2 @@
 openchallenges-organization-service:
-  welcome-message: 'Welcome to the Organization service (local).'
+  welcome-message: 'Welcome to the organization service (local config).'

--- a/apps/openchallenges/organization-service/config/application-local.yml
+++ b/apps/openchallenges/organization-service/config/application-local.yml
@@ -1,2 +1,2 @@
 openchallenges-organization-service:
-  welcome-message: 'Welcome to the Organization service LOCAL.'
+  welcome-message: 'Welcome to the Organization service (local).'

--- a/libs/openchallenges/app-config-data/src/main/java/org/sagebionetworks/openchallenges/app/config/data/ChallengeServiceConfigData.java
+++ b/libs/openchallenges/app-config-data/src/main/java/org/sagebionetworks/openchallenges/app/config/data/ChallengeServiceConfigData.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.openchallenges.app.config.data;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "openchallenges-challenge-service")
+public class ChallengeServiceConfigData {
+
+  private String welcomeMessage;
+}


### PR DESCRIPTION
Closes #1383 

## Changelog

- Add the config data class and use it in the challenge service.

## Notes

- The config of the challenge service is already living in the GH repo.