### PR TITLE
fix: Increase Vault memory to 500M

### DIFF
--- a/docker/openchallenges/services/grafana.yml
+++ b/docker/openchallenges/services/grafana.yml
@@ -19,4 +19,4 @@ services:
     deploy:
       resources:
         limits:
-          memory: 200M
+          memory: 500M

--- a/docker/openchallenges/services/vault.yml
+++ b/docker/openchallenges/services/vault.yml
@@ -16,4 +16,4 @@ services:
     deploy:
       resources:
         limits:
-          memory: 200M
+          memory: 500M


### PR DESCRIPTION
Fixes #1429

@mdsage1 Here are tips to test this PR:

- Checkout the branch behind this PR. You can do that easily in VS Code from the GitHub extension, under the section "Waiting For My Review", then right-click on this PR and select the option to check it out.
- Remove all docker artifact with `workspace-docker-stop` and `docker system prune --volumes`.
- Starting Vault should be enough but I remember that you had this issue when starting the entire stack, so try again with `nx serve-detach openchallenges-app`.

If Vault container starts successfully, then this PR should have fixed the issue.
