### PR TITLE
fix: remove undefined typography

### DIFF
--- a/apps/schematic/app/src/_app-theme.scss
+++ b/apps/schematic/app/src/_app-theme.scss
@@ -18,7 +18,6 @@ $theme: mat.define-light-theme(
     ),
     typography: (
       fira: fonts.$fira,
-      poppins: fonts.$poppins,
     ),
   )
 );


### PR DESCRIPTION
I just noticed with the latest PR (#1428) that a test in the `schematic` app was failing due to a missing typography (which was removed with #1388).

This PR will fix that failed test.