### PR TITLE
fix(ui): UI cleanup

### DIFF
--- a/apps/openchallenges/app/src/_app-theme.scss
+++ b/apps/openchallenges/app/src/_app-theme.scss
@@ -8,7 +8,7 @@
 @include mat.legacy-core();
 
 $primary: mat.define-palette(palettes.$dark-blue-palette, 600);
-$accent: mat.define-palette(palettes.$accent-pink-palette, 400);
+$accent: mat.define-palette(palettes.$accent-purple-palette, 400);
 
 $theme: mat.define-light-theme(
   (

--- a/libs/openchallenges/about/src/lib/_about-theme.scss
+++ b/libs/openchallenges/about/src/lib/_about-theme.scss
@@ -5,13 +5,6 @@
   $config: mat.get-color-config($theme);
   $primary: map.get($config, primary);
   $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
-  $background: map.get($config, background);
-  $foreground: map.get($config, foreground);
-
-  .welcome-msg > span {
-    color: mat.get-color-from-palette($primary, default);
-  }
 }
 
 @mixin typography($theme) {

--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -2,17 +2,17 @@
   <section class="title">
     <div class="container">
       <div class="section-outer">
-        <img class="logo" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
+        <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
         <h2>About OpenChallenges</h2>
       </div>
     </div>
   </section>
   <section class="vision">
     <div class="container">
-      <h4 class="welcome-msg">
-        Welcome to <span>OpenChallenges</span>, the centralized hub for
+      <p class="mat-body-strong welcome-msg">
+        Welcome to <em>OpenChallenges</em>, the centralized hub for
         all challenges biomedical and more.
-      </h4>
+      </p>
       <div class="section-inner">
         <p>
           The Challenge experience is currently cumbersome for all stakeholders involved.

--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -1,106 +1,96 @@
 <main class="base mat-typography">
-  <section class="title">
-    <div class="container">
-      <div class="section-outer">
-        <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
-        <h2>About OpenChallenges</h2>
-      </div>
-    </div>
-  </section>
+  <div class="top-design section-inner">
+    <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
+    <h2>About OpenChallenges</h2>
+  </div>
   <section class="vision">
+    <p class="mat-body-strong welcome-msg">
+      Welcome to <em>OpenChallenges</em>, the centralized hub for
+      all challenges biomedical and more.
+    </p>
     <div class="container">
-      <p class="mat-body-strong welcome-msg">
-        Welcome to <em>OpenChallenges</em>, the centralized hub for
-        all challenges biomedical and more.
+      <p>
+        The Challenge experience is currently cumbersome for all stakeholders involved.
+        Participants encounter a huge pain-point in discovering Challenges they are interested in,
+        while Organizers struggle to find a streamlined solution to reaching a wide audience.
       </p>
-      <div class="section-inner">
-        <p>
-          The Challenge experience is currently cumbersome for all stakeholders involved.
-          Participants encounter a huge pain-point in discovering Challenges they are interested in,
-          while Organizers struggle to find a streamlined solution to reaching a wide audience.
-        </p>
-        <p>
-          OpenChallenges (OC) strives to address some of the friction in the
-          Challenge experience by providing a centralized hub to reduce participant search cost and
-          increasing Challenge visibility. Think of the ROCC like an EventBrite for the scientific
-          benchmarking space!
-        </p>
-      </div>
+      <p>
+        OpenChallenges (OC) strives to address some of the friction in the
+        Challenge experience by providing a centralized hub to reduce participant search cost and
+        increasing Challenge visibility. Think of the ROCC like an EventBrite for the scientific
+        benchmarking space!
+      </p>
     </div>
   </section>
 
   <section class="background">
     <div class="container">
-      <div class="section-inner">
-        <h3>Background</h3>
-        <p>
-          Sage Bionetworks strives to bridge the translational divide between biomedical research
-          and clinical application by embracing open and reusable practices. One example is hosting
-          scientific Challenges, galvanizing large communities of experts around new and complex
-          biomedical problems. Aside from crowdsourcing biomedical problems, Challenges also seek to
-          enable the robust assessment of tool performance (Ellrott, K., Buchanan, A., Creason, A.
-          et al.)
-        </p>
-        <p>
-          When done right, Challenges encourage innovation by promoting friendly competition to
-          develop the best algorithms, evaluation with objective frameworks for assessment of these
-          algorithms, and collaboration by bringing together new teams to uncover new insights. The
-          Challenges ecosystem, however, is bottlenecked by the lack of a hub centralizing all
-          biomedical challenges. Participants encounter a huge pain-point in discovering Challenges
-          they are interested in, while Organizers struggle to find a streamlined solution to
-          reaching a wide audience.
-        </p>
-      </div>
+      <h3>Background</h3>
+      <p>
+        Sage Bionetworks strives to bridge the translational divide between biomedical research
+        and clinical application by embracing open and reusable practices. One example is hosting
+        scientific Challenges, galvanizing large communities of experts around new and complex
+        biomedical problems. Aside from crowdsourcing biomedical problems, Challenges also seek to
+        enable the robust assessment of tool performance (Ellrott, K., Buchanan, A., Creason, A.
+        et al.)
+      </p>
+      <p>
+        When done right, Challenges encourage innovation by promoting friendly competition to
+        develop the best algorithms, evaluation with objective frameworks for assessment of these
+        algorithms, and collaboration by bringing together new teams to uncover new insights. The
+        Challenges ecosystem, however, is bottlenecked by the lack of a hub centralizing all
+        biomedical challenges. Participants encounter a huge pain-point in discovering Challenges
+        they are interested in, while Organizers struggle to find a streamlined solution to
+        reaching a wide audience.
+      </p>
     </div>
   </section>
   <section class="goals">
     <div class="container">
-      <div class="section-inner">
-        <h3>Goals</h3>
-        <div class="cards-container">
-          <div class="card">
-            <div class="card-header">
-              <img src="https://via.placeholder.com/100x100.png" />
-              <h4 class="card-title text-center">Make challenges more discoverable</h4>
-            </div>
-            <div class="card-content">
-              <ul>
-                <li>Standardize information about Challenges</li>
-                <li>Create a community hub</li>
-              </ul>
-            </div>
+      <h3>Goals</h3>
+      <div class="cards-container">
+        <div class="card">
+          <div class="card-header">
+            <img src="https://via.placeholder.com/100x100.png" />
+            <h4 class="card-title text-center">Make challenges more discoverable</h4>
           </div>
-          <div class="card">
-            <div class="card-header">
-              <img src="https://via.placeholder.com/100x100.png" />
-              <h4 class="card-title text-center">Empower professional identity</h4>
-            </div>
-            <div class="card-content">
-              <ul>
-                <li>Help organizers drive thought, leadership, and awareness</li>
-                <li>Support participants with their professional development journeys</li>
-              </ul>
-            </div>
+          <div class="card-content">
+            <ul>
+              <li>Standardize information about Challenges</li>
+              <li>Create a community hub</li>
+            </ul>
           </div>
-          <div class="card">
-            <div class="card-header">
-              <img src="https://via.placeholder.com/100x100.png" />
-              <h4 class="card-title text-center">Increase challenge intelligence</h4>
-            </div>
-            <div class="card-content">
-              <ul>
-                <li>Create OC user profiles to enable challenge intelligence</li>
-                <li>Require registered OC users to go through an onboarding flow</li>
-              </ul>
-            </div>
+        </div>
+        <div class="card">
+          <div class="card-header">
+            <img src="https://via.placeholder.com/100x100.png" />
+            <h4 class="card-title text-center">Empower professional identity</h4>
           </div>
-          <div class="card">
-            <div class="card-header">
-              <img src="https://via.placeholder.com/100x100.png" />
-              <h4 class="card-title text-center">Promote discoverability and resusability</h4>
-            </div>
-            <div class="card-content"></div>
+          <div class="card-content">
+            <ul>
+              <li>Help organizers drive thought, leadership, and awareness</li>
+              <li>Support participants with their professional development journeys</li>
+            </ul>
           </div>
+        </div>
+        <div class="card">
+          <div class="card-header">
+            <img src="https://via.placeholder.com/100x100.png" />
+            <h4 class="card-title text-center">Increase challenge intelligence</h4>
+          </div>
+          <div class="card-content">
+            <ul>
+              <li>Create OC user profiles to enable challenge intelligence</li>
+              <li>Require registered OC users to go through an onboarding flow</li>
+            </ul>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-header">
+            <img src="https://via.placeholder.com/100x100.png" />
+            <h4 class="card-title text-center">Promote discoverability and resusability</h4>
+          </div>
+          <div class="card-content"></div>
         </div>
       </div>
     </div>

--- a/libs/openchallenges/about/src/lib/about.component.scss
+++ b/libs/openchallenges/about/src/lib/about.component.scss
@@ -22,7 +22,7 @@ main {
 
 h2,
 h3,
-h4 {
+.welcome-msg {
   text-align: center;
 }
 
@@ -45,10 +45,6 @@ h4 {
       margin: 8px 0;
     }
   }
-}
-
-.welcome-msg {
-  margin: 40px 0 0;
 }
 
 .goals {

--- a/libs/openchallenges/about/src/lib/about.component.scss
+++ b/libs/openchallenges/about/src/lib/about.component.scss
@@ -36,11 +36,6 @@ h3,
     text-align: center;
     margin-bottom: 40px;
 
-    .logo {
-      width: 140px;
-      height: 140px;
-    }
-
     h2 {
       margin: 8px 0;
     }

--- a/libs/openchallenges/about/src/lib/about.component.scss
+++ b/libs/openchallenges/about/src/lib/about.component.scss
@@ -11,35 +11,13 @@ main {
 .container {
   max-width: 1366px;
   margin: 0 auto;
-  padding: 16px;
-}
-
-.section-inner {
-  position: relative;
-  padding-top: 48px;
-  padding-bottom: 48px;
+  padding: 48px 16px;
 }
 
 h2,
 h3,
 .welcome-msg {
   text-align: center;
-}
-
-.title {
-  background: url('/openchallenges-assets/images/about-banner.svg');
-  background-size: cover;
-  background-position: bottom;
-  padding-top: 108px;
-
-  .section-outer {
-    text-align: center;
-    margin-bottom: 40px;
-
-    h2 {
-      margin: 8px 0;
-    }
-  }
 }
 
 .goals {

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -7,7 +7,7 @@
     </div>
     <div id="title" class="row">
       <div class="col col-10">
-        <h2>Search the OpenChallenges</h2>
+        <h2>Search OpenChallenges</h2>
         <!-- TODO: add "Add Challenge" button when service is available -->
       </div>
       <div class="col col-2">

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/_challenge-overview-theme.scss
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/_challenge-overview-theme.scss
@@ -18,7 +18,6 @@
   .section-title {
     font-weight: 400;
     font-size: 21px;
-    text-transform: uppercase;
   }
 }
 

--- a/libs/openchallenges/challenge/src/lib/challenge-stats/_challenge-stats-theme.scss
+++ b/libs/openchallenges/challenge/src/lib/challenge-stats/_challenge-stats-theme.scss
@@ -22,10 +22,6 @@
 }
 
 @mixin typography($theme) {
-  .action-btn {
-    font-size: 21px;
-    text-transform: uppercase;
-  }
   .stat-item > h4 {
     line-height: 0.5;
   }

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.html
@@ -1,6 +1,6 @@
 <section id="organizations" class="mat-typography">
   <div class="container">
-    <h3 class="section-title">Discover challenge hosts</h3>
+    <h3 class="section-title">Discover Challenge Hosts</h3>
     <div class="row">
       <div class="card-group">
         <openchallenges-organization-card

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
@@ -13,13 +13,13 @@
           <span class="typing"></span>
         </ngx-typed-js>
       </h1>
-      <p class="mat-body-strong about-rocc">
-        The OpenChallenges strives to provide a centralized hub of biomedical challenges from
+      <p>
+        OpenChallenges strives to provide a centralized hub of biomedical challenges from
         various hosting organizations. Our goal is to empower both participants with the most
         up-to-date information about relevant challenges, as well as organizers with standardized
         challenge templates and intelligence.
       </p>
-      <h4>Let the ROCC help find the perfect challenge for you!</h4>
+      <p class="mat-body-strong">Let us help find the perfect challenge for you!</p>
       <div class="search field field-grouped">
         <div class="control control-expanded">
           <input

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
@@ -94,10 +94,6 @@ a:active {
   padding: 210px 64px 72px;
   background-color: #F8F8F8;
 }
-.about-rocc {
-  margin-bottom: 40px;
-  max-width: 100%;
-}
 #landing {
   .search {
   max-width: 360px;
@@ -105,12 +101,6 @@ a:active {
   }
 }
 @media (min-width: $screen-sm) {
-  .about-rocc {
-    font-size: 18px;
-    line-height: 32px;
-    letter-spacing: -0.1px;
-    max-width: 90%;
-  }
   #landing {
     height: 100%;
     

--- a/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
+++ b/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
@@ -2,10 +2,8 @@
   <div class="container">
     <div class="cards-inner section-inner">
       <div class="cards-header text-center">
-        <h3 class="section-title">Featured challenges</h3>
-        <p class="text-sm">
-          Not sure where to start? Try one of the following featured challenges!
-        </p>
+        <h3 class="section-title">Featured Challenges</h3>
+        Not sure where to start? Try one of the following featured challenges!
       </div>
       <div class="cards-wrap">
         <div class="card-group">

--- a/libs/openchallenges/home/src/lib/home.component.html
+++ b/libs/openchallenges/home/src/lib/home.component.html
@@ -1,7 +1,7 @@
 <main class="base mat-typography">
   <openchallenges-challenge-search></openchallenges-challenge-search>
   <openchallenges-statistics-viewer></openchallenges-statistics-viewer>
-  <openchallenges-topics-viewer></openchallenges-topics-viewer>
+  <!-- <openchallenges-topics-viewer></openchallenges-topics-viewer> -->
   <openchallenges-challenge-host-list *sageAppShellNoRender></openchallenges-challenge-host-list>
   <openchallenges-challenge-registration
     *sageAppShellNoRender

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
@@ -1,6 +1,6 @@
 <section id="acknowledgements" class="mat-typography">
   <div class="container">
-    <h4 class="section-title text-center">The ROCC project was made possible by...</h4>
+    <h4 class="mat-body-strong text-center">OpenChallenges was made possible by...</h4>
     <div class="row">
       <div class="col text-center sponsor-item">
         <h3>ITCR grant</h3>

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.scss
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.scss
@@ -9,9 +9,6 @@
   text-align: center;
   margin-bottom: 42px;
 }
-.text-center {
-  text-align: center;
-}
 .sponsor-item {
   display: flex;
   justify-content: center;

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -1,13 +1,13 @@
 <section id="statistics" class="mat-typography">
   <div class="container">
-    <h3 class="section-title">Current landscape</h3>
+    <h3 class="section-title">Current Landscape</h3>
     <div class="row">
       <div class="col text-center">
-        <h2 [countUp]="92">0</h2>
+        <h2 [countUp]="166">0</h2>
         <p>annotated challenges</p>
       </div>
       <div class="col text-center">
-        <h2 [countUp]="11">0</h2>
+        <h2 [countUp]="238">0</h2>
         <p>organizations & hosting societies</p>
       </div>
       <div class="col text-center">

--- a/libs/openchallenges/login/src/lib/login.component.html
+++ b/libs/openchallenges/login/src/lib/login.component.html
@@ -1,7 +1,7 @@
 <main class="base mat-typography">
   <div class="login-container">
     <div class="title">
-      <img src="assets/images/registry_b.png" alt="OpenChallenges" />
+      <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
       <h3>Welcome back!</h3>
     </div>
     <form class="form-container" [formGroup]="loginForm" novalidate>

--- a/libs/openchallenges/org-profile/src/lib/org-profile-overview/_org-profile-overview-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-overview/_org-profile-overview-theme.scss
@@ -17,7 +17,6 @@
   .section-title {
     font-weight: 400;
     font-size: 21px;
-    text-transform: uppercase;
   }
 }
 

--- a/libs/openchallenges/org-profile/src/lib/org-profile-stats/_org-profile-stats-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-stats/_org-profile-stats-theme.scss
@@ -22,10 +22,6 @@
 }
 
 @mixin typography($theme) {
-  .action-btn {
-    font-size: 21px;
-    text-transform: uppercase;
-  }
   .stat-item > h4 {
     line-height: 0.5;
   }

--- a/libs/openchallenges/signup/src/lib/signup.component.html
+++ b/libs/openchallenges/signup/src/lib/signup.component.html
@@ -1,7 +1,7 @@
 <main class="base mat-typography">
   <div class="register-container">
     <div class="title">
-      <img src="assets/images/registry_b.png" alt="OpenChallenges" />
+      <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
       <h3>Join Us on OpenChallenges!</h3>
     </div>
     <form class="form-container" [formGroup]="newUserForm" novalidate>
@@ -19,7 +19,7 @@
       </mat-form-field>
       <mat-error *ngIf="errors.other">{{ errors.other }}</mat-error>
       <div class="disclaimer">
-        <p>
+        <p class="mat-caption">
           By creating an account, you agree to the <a href="#">Terms of Service</a> of
           OpenChallenges. Our Privacy Statement can be read <a href="#">here</a>.
         </p>

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -61,6 +61,10 @@ body {
   margin: 5px;
   padding: 3px 32px;
 }
+.action-btn {
+  font-size: 21px;
+  text-transform: uppercase;
+}
 
 // CARDS
 .card-group {

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -41,10 +41,25 @@ body {
   text-align: center;
 }
 
-// LOGO
+// LOGO & DESIGN
 .logo-icon {
   width: 140px;
   height: 140px;
+}
+.top-design {
+  background: url('/openchallenges-assets/images/about-banner.svg');
+  background-size: cover;
+  background-position: bottom;
+  padding-top: 108px;
+  text-align: center;
+
+  .section-inner {
+    margin-bottom: 40px;
+
+    h2 {
+      margin: 8px 0;
+    }
+  }
 }
 
 // BUTTONS

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -37,6 +37,15 @@ body {
 .text-left {
   text-align: left;
 }
+.text-center {
+  text-align: center;
+}
+
+// LOGO
+.logo-icon {
+  width: 140px;
+  height: 140px;
+}
 
 // BUTTONS
 .btn {

--- a/libs/openchallenges/team/src/lib/_team-theme.scss
+++ b/libs/openchallenges/team/src/lib/_team-theme.scss
@@ -19,13 +19,13 @@
 @mixin typography($theme) {
   em {
     font-style: normal;
+    font-weight: 700;
   }
   .card-name {
-    font-weight: 300 !important;
+    font-weight: 700;
   }
   .card-roles {
     font-size: 1.1em;
-    font-style: italic;
   }
 }
 

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -1,5 +1,5 @@
 <main id="team" class="base mat-typography">
-  <img class="team-logo" src="assets/images/registry_b.png" alt="OpenChallenges" />
+  <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
   <h2>Meet Our Team</h2>
   <p class="mat-body-strong">
     We're smart, we're hard-working, and we love a <em>good challenge</em>.

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -1,9 +1,11 @@
 <main id="team" class="base mat-typography">
-  <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
-  <h2>Meet Our Team</h2>
-  <p class="mat-body-strong">
-    We're smart, we're hard-working, and we love a <em>good challenge</em>.
-  </p>
+  <div class="top-design section-inner">
+    <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
+    <h2>Meet Our Team</h2>
+    <p class="mat-body-strong">
+      We're smart, we're hard-working, and we love a <em>good challenge</em>.
+    </p>
+  </div>
   <div class="member-group">
     <div class="member-card">
       <img class="member-pic" src="assets/images/thomas.png" alt="Thomas Schaffter" />

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -23,7 +23,7 @@
       <p class="card-roles">Frontend developer</p>
     </div>
     <div class="member-card">
-      <img class="member-pic" src="https://via.placeholder.com/100x100.png" alt="Maria Diaz" />
+      <img class="member-pic" src="assets/images/maria.png" alt="Maria Diaz" />
       <h3 class="card-name">Maria Diaz</h3>
       <p class="card-roles">Backend developer</p>
     </div>

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -1,21 +1,29 @@
 <main id="team" class="base mat-typography">
   <img class="team-logo" src="assets/images/registry_b.png" alt="OpenChallenges" />
   <h2>Meet Our Team</h2>
+  <p class="mat-body-strong">
+    We're smart, we're hard-working, and we love a <em>good challenge</em>.
+  </p>
   <div class="member-group">
     <div class="member-card">
       <img class="member-pic" src="assets/images/thomas.png" alt="Thomas Schaffter" />
       <h3 class="card-name">Thomas Schaffter</h3>
-      <p class="card-roles">Project lead, Architect, Lead developer</p>
+      <p class="card-roles">Project lead, Architect, Backend developer</p>
     </div>
     <div class="member-card">
       <img class="member-pic" src="assets/images/rong.png" alt="Rong Chai" />
       <h3 class="card-name">Rong Chai</h3>
-      <p class="card-roles">Developer</p>
+      <p class="card-roles">Frontend developer</p>
     </div>
     <div class="member-card">
       <img class="member-pic" src="assets/images/verena.png" alt="Verena Chung" />
       <h3 class="card-name">Verena Chung</h3>
-      <p class="card-roles">Developer</p>
+      <p class="card-roles">Frontend developer</p>
+    </div>
+    <div class="member-card">
+      <img class="member-pic" src="https://via.placeholder.com/100x100.png" alt="Maria Diaz" />
+      <h3 class="card-name">Maria Diaz</h3>
+      <p class="card-roles">Backend developer</p>
     </div>
   </div>
   <div class="member-group">
@@ -29,13 +37,6 @@
       <h3 class="card-name">Amy Heiser</h3>
       <p class="card-roles">Program manager</p>
     </div>
-    <div class="member-card"></div>
-  </div>
-  <div class="description">
-    <h3>
-      We are engineers at <em>Sage Bionetworks</em>, a non-profit organization dedicated to the
-      world of open science and FAIR data.
-    </h3>
   </div>
 </main>
 <openchallenges-footer [version]="appVersion"></openchallenges-footer>

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -19,6 +19,7 @@
 }
 .member-pic {
   min-height: 240px;
+  max-height: 240px;
   padding: 12px 0 22px;
   -moz-border-radius: 50%;
   -webkit-border-radius: 505;

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -23,7 +23,7 @@
   align-items: center;
 }
 .member-pic {
-  width: 240px;
+  min-height: 240px;
   padding: 12px 0 22px;
   -moz-border-radius: 50%;
   -webkit-border-radius: 505;

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -14,7 +14,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: space-evenly;
+  justify-content: center;
 }
 .member-card {
   width: 300px;
@@ -24,7 +24,6 @@
 }
 .member-pic {
   width: 240px;
-  height: 240px;
   padding: 12px 0 22px;
   -moz-border-radius: 50%;
   -webkit-border-radius: 505;

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -3,11 +3,6 @@
 #team {
   text-align: center;
 }
-.team-logo {
-  width: 100px;
-  height: 100px;
-  padding: 180px 0 12px;
-}
 .member-group {
   width: 100%;
   padding: 80px 0;

--- a/libs/openchallenges/themes/src/_fonts.scss
+++ b/libs/openchallenges/themes/src/_fonts.scss
@@ -13,7 +13,7 @@ $lato: mat.define-typography-config(
   $subtitle-1: mat.define-typography-level(28px, 38px, 700, "'Lato', sans-serif", -0.1px),
   $subtitle-2: mat.define-typography-level(18px, 30px, 400, "'Lato', sans-serif", -0.1px),
   $body-1: mat.define-typography-level(21px, 32px, 400, "'Lato', sans-serif", -0.1px),
-  $body-2: mat.define-typography-level(15px, 24px, 400, "'Lato', sans-serif"),
-  $caption: mat.define-typography-level(14px, 20px, 400, "'Lato', sans-serif"),
-  $button: mat.define-typography-level(14px, 18px, 400, "'Lato', sans-serif"),
+  $body-2: mat.define-typography-level(18px, 32px, 400, "'Lato', sans-serif"),
+  $caption: mat.define-typography-level(15px, 21px, 400, "'Lato', sans-serif"),
+  $button: mat.define-typography-level(16px, 18px, 400, "'Lato', sans-serif"),
 );

--- a/libs/openchallenges/themes/src/_palettes.scss
+++ b/libs/openchallenges/themes/src/_palettes.scss
@@ -62,56 +62,6 @@ $light-blue-palette: (
   ),
 );
 
-$light-pink-palette: (
-  50: #ffedf1,
-  100: #ffd2da,
-  200: #f3a1a8,
-  300: #ed7c86,
-  400: #fb5c67,
-  500: #ff494f,
-  600: #f4424e,
-  700: #e23847,
-  800: #d53240,
-  900: #c62634,
-  contrast: (
-    50: $dark-primary-text,
-    100: $dark-primary-text,
-    200: $dark-primary-text,
-    300: $dark-primary-text,
-    400: $dark-primary-text,
-    500: $dark-primary-text,
-    600: $dark-primary-text,
-    700: $light-primary-text,
-    800: $light-primary-text,
-    900: $light-primary-text,
-  ),
-);
-
-$light-orange-palette: (
-  50: #faeeed,
-  100: #ffd8cd,
-  200: #ffbeaa,
-  300: #ffa284,
-  400: #ff8c66,
-  500: #ff774b,
-  600: #ff7146,
-  700: #ff6940,
-  800: #f2623c,
-  900: #d85533,
-  contrast: (
-    50: $dark-primary-text,
-    100: $dark-primary-text,
-    200: $dark-primary-text,
-    300: $dark-primary-text,
-    400: $dark-primary-text,
-    500: $dark-primary-text,
-    600: $dark-primary-text,
-    700: $dark-primary-text,
-    800: $dark-primary-text,
-    900: $light-primary-text,
-  ),
-);
-
 $light-green-palette: (
   50: #e8fefb,
   100: #c6fdf3,
@@ -163,27 +113,21 @@ $light-purple-palette: (
 );
 
 // Alias for "accent" usage
-$accent-pink-palette: $light-pink-palette;
-$accent-orange-palette: $light-orange-palette;
 $accent-green-palette: $light-green-palette;
 $accent-purple-palette: $light-purple-palette;
 
 // Figma palettes variables
 $figma-collection: (
   dl-color-default-navbar: map.get($dark-blue-palette, 600),
-  dl-color-default-accent1: map.get($accent-pink-palette, 100),
-  dl-color-default-accent2: map.get($accent-orange-palette, 100),
-  dl-color-default-accent3: map.get($accent-green-palette, 100),
-  dl-color-default-accent4: map.get($accent-purple-palette, 50),
+  dl-color-default-accent1: map.get($accent-green-palette, 100),
+  dl-color-default-accent2: map.get($accent-purple-palette, 50),
   dl-color-default-primary1: map.get($dark-blue-palette, 400),
   dl-color-default-primary2: $dark-focused,
   dl-color-default-navbardark: map.get($dark-blue-palette, 800),
   dl-color-default-secondary1: map.get($light-blue-palette, 300),
   dl-color-default-secondary2: map.get($accent-purple-palette, 300),
-  dl-color-default-darkaccent2: map.get($accent-orange-palette, 300),
-  dl-color-default-darkaccent3: map.get($accent-green-palette, 600),
-  dl-color-default-darkaccent4: map.get($accent-purple-palette, 200),
-  dl-color-default-darkacccent1: map.get($accent-pink-palette, 200),
+  dl-color-default-darkaccent1: map.get($accent-green-palette, 600),
+  dl-color-default-darkaccent2: map.get($accent-purple-palette, 200),
   dl-color-gray-black: #000000,
   dl-color-gray-white: #ffffff,
   dl-color-default-hover1: rgba(249, 249, 249, 1),

--- a/libs/openchallenges/ui/src/lib/footer/_footer-theme.scss
+++ b/libs/openchallenges/ui/src/lib/footer/_footer-theme.scss
@@ -23,10 +23,6 @@
 @mixin typography($theme) {
   $config: mat.get-typography-config($theme);
 
-  footer {
-    font-weight: 500;
-    line-height: normal;
-  }
   .app-info {
     font-size: 14px;
     line-height: 18px;

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -3,8 +3,8 @@
     <div class="col-8">
       <img class="logo" src="assets/images/openchallenges-white.svg" alt="OpenChallenges" />
       <ul class="footer-link-group">
-        <li><a href="/about">ABOUT</a></li>
-        <li><a href="/team">MEET OUR TEAM</a></li>
+        <li><a href="/about">About</a></li>
+        <li><a href="/team">Meet Our Team</a></li>
         <li><a href="#">API</a></li>
       </ul>
     </div>
@@ -18,8 +18,8 @@
   </div>
   <div class="footer-bottom">
     <span class="footer-links">
-      <a href="#">Terms</a> • <a href="#">Privacy</a> •
-      <a href="https://www.synapse.org">POWERED BY SAGE BIONETWORKS</a>
+      <a href="#">Terms of Use</a> • <a href="#">Privacy Policy</a> •
+      <a href="https://www.sagebionetworks.org">POWERED BY SAGE BIONETWORKS</a>
     </span>
   </div>
 </footer>

--- a/libs/openchallenges/ui/src/lib/navbar/_navbar-theme.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/_navbar-theme.scss
@@ -19,16 +19,6 @@
 
 @mixin typography($theme) {
   $typography-config: mat.get-typography-config($theme);
-
-  nav .sage-button {
-    font-weight: 400;
-  }
-
-  .home-btn {
-    font-family: mat.font-family($typography-config);
-    font-weight: 400;
-    line-height: normal;
-  }
 }
 
 @mixin theme($theme) {

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <!-- TODO: figure out if the <nav> should go inside of a <header> element. -->
 <nav class="sage-navbar-header" aria-label="Top Toolbar">
-  <a mat-button class="home-btn" routerLink="/" aria-label="Sage Angular">
+  <a mat-button routerLink="/" aria-label="Sage Angular">
     <img class="logo" src="assets/images/openchallenges-white.svg" alt="OpenChallenges" />
   </a>
 

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
@@ -20,7 +20,6 @@
 }
 
 .logo {
-  height: 26px;
-  margin: 0 4px 3px 0;
+  height: 36px;
   vertical-align: middle;
 }

--- a/libs/openchallenges/ui/src/lib/user-button/_user-button-theme.scss
+++ b/libs/openchallenges/ui/src/lib/user-button/_user-button-theme.scss
@@ -28,7 +28,8 @@
 
 @mixin typography($theme) {
   button.mat-menu-item{
-    font-size: 13px;
+    font-size: 15px;
+    font-family: 'Lato';
   }
 }
 

--- a/libs/openchallenges/ui/src/lib/user-button/user-menu-items.ts
+++ b/libs/openchallenges/ui/src/lib/user-button/user-menu-items.ts
@@ -9,14 +9,14 @@ export const USER_MENU_ITEMS: MenuItem[] = [
   },
   {
     name: 'Profile',
-    icon: 'account_circle',
+    // icon: 'account_circle',
   },
   {
     name: 'Settings',
-    icon: 'settings',
+    // icon: 'settings',
   },
   {
     name: 'Log out',
-    icon: 'exit_to_app',
+    // icon: 'exit_to_app',
   },
 ];

--- a/libs/openchallenges/user-profile/src/lib/user-profile-overview/_user-profile-overview-theme.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-overview/_user-profile-overview-theme.scss
@@ -14,7 +14,6 @@
   .section-title {
     font-weight: 400;
     font-size: 21px;
-    text-transform: uppercase;
   }
 }
 

--- a/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.html
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.html
@@ -7,7 +7,7 @@
   </div>
   <div id="orgs" class="row">
     <div class="col">
-      <p class="section-title">Organizations</p>
+      <h3>Organizations</h3>
       <div class="card-group">
         <openchallenges-organization-card
           *ngFor="let organization of organizations"

--- a/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.scss
@@ -1,0 +1,3 @@
+#orgs {
+  margin-top: 28px;
+}

--- a/libs/openchallenges/user-profile/src/lib/user-profile-stats/_user-profile-stats-theme.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-stats/_user-profile-stats-theme.scss
@@ -22,10 +22,6 @@
 }
 
 @mixin typography($theme) { 
-  .action-btn {
-    font-size: 21px;
-    text-transform: uppercase;
-  }
   .stat-item > h4 {
     line-height: 0.5;
   }


### PR DESCRIPTION
Using #1350 as a guide, this PR includes an initial cleanup to some of the more jarring issues of the app, for example: the skewed images on the Meet the Team page.

![preview](https://user-images.githubusercontent.com/9377970/228696355-6096c6ed-a1e7-42a8-a74b-e1fdca635531.gif)

> **Note** During this exercise, I noticed we also need to do a cleanup with the SCSS sheets as well (saving that for another PR).