### PR TITLE
feat: Backup and restore Grafana data from/to S3

### DIFF
--- a/apps/openchallenges/challenge-service/build.gradle
+++ b/apps/openchallenges/challenge-service/build.gradle
@@ -61,6 +61,8 @@ dependencies {
   implementation "org.springframework.cloud:spring-cloud-sleuth-zipkin:${springCloudVersion}"
 
   implementation "org.sagebionetworks.openchallenges:openchallenges-app-config-data:${openchallengesVersion}"
+  
+  implementation 'io.micrometer:micrometer-registry-prometheus:1.10.4'
 }
 
 group = 'org.sagebionetworks.openchallenges'

--- a/apps/openchallenges/grafana/.gitignore
+++ b/apps/openchallenges/grafana/.gitignore
@@ -1,0 +1,2 @@
+**/_OUTPUT_
+.grafana-backup.json

--- a/apps/openchallenges/grafana/README.md
+++ b/apps/openchallenges/grafana/README.md
@@ -1,0 +1,51 @@
+# OpenChallenges Grafana
+
+## Overview
+
+## Preparation
+
+### Create AWS Resources
+
+> **Note** The following resources have already been created for the OpenChallenges development
+> team.
+
+- S3 bucket `openchallenges-grafana`
+- IAM policy `openchallenges-grafana` with write access to the S3 bucket
+- IAM user `openchallenges-grafana` with the above policy
+
+IAM policy:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject",
+                "s3:GetObject*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::openchallenges-grafana",
+                "arn:aws:s3:::openchallenges-grafana/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": [
+                "arn:aws:s3:::openchallenges-grafana/*"
+            ]
+        }
+    ]
+}
+```
+
+## Usage
+
+### Starting Grafana
+
+```console
+nx serve-detach openchallenges-grafana
+```

--- a/apps/openchallenges/grafana/README.md
+++ b/apps/openchallenges/grafana/README.md
@@ -2,50 +2,102 @@
 
 ## Overview
 
-## Preparation
+[Grafana] is a multi-platform open source analytics and interactive visualization web application.
+It provides charts, graphs, and alerts for the web when connected to supported data sources.
 
-### Create AWS Resources
+### Data Sources
 
-> **Note** The following resources have already been created for the OpenChallenges development
-> team.
+OpenChallenges supports these data sources:
 
-- S3 bucket `openchallenges-grafana`
-- IAM policy `openchallenges-grafana` with write access to the S3 bucket
-- IAM user `openchallenges-grafana` with the above policy
-
-IAM policy:
-
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket",
-                "s3:GetObject",
-                "s3:GetObject*"
-            ],
-            "Resource": [
-                "arn:aws:s3:::openchallenges-grafana",
-                "arn:aws:s3:::openchallenges-grafana/*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": "s3:*Object",
-            "Resource": [
-                "arn:aws:s3:::openchallenges-grafana/*"
-            ]
-        }
-    ]
-}
-```
+- [Prometheus] to capture compute metrics and logs of Spring components (e.g. microservices, API
+  gateway, config server).
 
 ## Usage
+
+### Preparation
+
+Create the config files with:
+
+```console
+nx prepare openchallenges-grafana
+```
+
+The default config file (`.env` located in this project folder) can be used as-is.
 
 ### Starting Grafana
 
 ```console
 nx serve-detach openchallenges-grafana
 ```
+
+### Open Grafana Web Console
+
+1. Open your browser and navigate to http://localhost:3000.
+2. Authenticate with the credentials defined in `.env`.
+
+
+## Save and restore Grafana data
+
+### Create a Grafana API key
+
+Create a Grafana API key for an Admin user.
+
+```console
+$ nx create-api-key openchallenges-grafana
+
+{"id":3,"name":"grafana-backup-tool","key":"eyJrIjoiaURiZEZ3Um1ycVdVWlUwd0YzRHNraThmZWZMWjV6U1MiLCJuIjoiYXBpa2V5Y3VybCIsImlkIjoxfQ=="}
+```
+
+If the API key already exists, delete it first using Grafana Web Console:
+
+- Gear icon in the left menu > API keys > Delete the key named "grafana-backup-tool".
+
+In `tools/grafana-backup-tool/.env`, set the value of the property `GRAFANA_TOKEN` to the value of the API key.
+
+> **Note** The properties `GRAFANA_ADMIN_ACCOUNT` and `GRAFANA_ADMIN_PASSWORD` may seem redundant to
+> specifying the API key, but they are actually required when restoring Grafana data.
+
+### Specify the credentials to the AWS S3 bucket
+
+In `tools/grafana-backup-tool/.env`, set the value of `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` so that the [Grafana backup tool] can save and/or restore data to/from the
+S3 bucket. The Grafana backup tool requires Docker to be installed.
+
+> **Note** Members of the OpenChallenges team can find the AWS credentials in LastPass (item:
+> `openchallenges-grafana`).
+
+### Backup Grafana data to the S3 bucket
+
+The Grafana container must be running in order to backup its data.
+
+```
+$ nx save-data openchallenges-grafana
+
+...
+created archive at: _OUTPUT_/202303292349.tar.gz
+Upload archives to S3:
+Upload to S3 was successful
+```
+
+### Restore Grafana data from the S3 bucket
+
+The Grafana container must be running in order to restore the data. The ID of the backup to restore
+is defined in the script `tools/restore-from-s3.sh`.
+
+```
+nx restore-data openchallenges-grafana
+```
+
+> **Note** Existing Grafana resources cannot be overwritten by the Grafana backup tool. The solution
+> is to wipe Grafana data clean, e.g. by removing Grafana container and volume.
+
+```console
+docker rm -f openchallenges-grafana
+docker volume rm openchallenges-grafana-data
+```
+
+<!-- Links -->
+
+[grafana]: https://grafana.com/
+[Prometheus]: https://prometheus.io/
+[Grafana backup tool]: https://github.com/ysde/grafana-backup-tool

--- a/apps/openchallenges/grafana/docs/create-aws-resources.md
+++ b/apps/openchallenges/grafana/docs/create-aws-resources.md
@@ -1,0 +1,37 @@
+# Create AWS Resources
+
+> **Note** The following resources have already been created for the OpenChallenges development
+> team.
+
+- S3 bucket `openchallenges-grafana`
+- IAM policy `openchallenges-grafana` with write access to the S3 bucket
+- IAM user `openchallenges-grafana` with the above policy
+
+IAM policy:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject",
+                "s3:GetObject*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::openchallenges-grafana",
+                "arn:aws:s3:::openchallenges-grafana/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": [
+                "arn:aws:s3:::openchallenges-grafana/*"
+            ]
+        }
+    ]
+}
+```

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -7,7 +7,10 @@
     "prepare": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
+        "commands": [
+          "shx cp -n .env.example .env",
+          "shx cp -n tools/grafana-backup-tool/.env.example tools/grafana-backup-tool/.env"
+        ],
         "cwd": "apps/openchallenges/grafana"
       }
     },
@@ -24,6 +27,27 @@
         "context": "apps/openchallenges/grafana",
         "push": false,
         "tags": ["sagebionetworks/openchallenges-grafana:latest"]
+      }
+    },
+    "create-api-key": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./tools/create-api-key.sh",
+        "cwd": "apps/openchallenges/grafana"
+      }
+    },
+    "save-data": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./tools/backup-to-s3.sh",
+        "cwd": "apps/openchallenges/grafana"
+      }
+    },
+    "restore-data": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./tools/restore-from-s3.sh",
+        "cwd": "apps/openchallenges/grafana"
       }
     }
   },

--- a/apps/openchallenges/grafana/tools/backup-to-s3.sh
+++ b/apps/openchallenges/grafana/tools/backup-to-s3.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+docker run \
+  --rm \
+  --name grafana-backup-tool \
+  --env-file tools/grafana-backup-tool/.env \
+  --network openchallenges \
+  ysde/docker-grafana-backup-tool:1.2.6-slim

--- a/apps/openchallenges/grafana/tools/create-api-key.sh
+++ b/apps/openchallenges/grafana/tools/create-api-key.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+api_token_name=apikeycurl
+
+# Delete the existing admin key
+curl -X DELETE \
+  --silent \
+  -H "Content-Type: application/json" \
+  http://openchallenges:changeme@openchallenges-grafana:3000/api/auth/keys/2
+
+# TODO: Read username, password and host from .env file
+curl -X POST \
+  --silent \
+  -H "Content-Type: application/json" \
+  -d '{"name":"'${api_token_name}'", "role": "Admin"}' \
+  http://openchallenges:changeme@openchallenges-grafana:3000/api/auth/keys

--- a/apps/openchallenges/grafana/tools/grafana-backup-tool/.env.example
+++ b/apps/openchallenges/grafana/tools/grafana-backup-tool/.env.example
@@ -1,0 +1,10 @@
+GRAFANA_TOKEN=
+GRAFANA_URL=http://openchallenges-grafana:3000
+GRAFANA_ADMIN_ACCOUNT=openchallenges
+GRAFANA_ADMIN_PASSWORD=changeme
+VERIFY_SSL=true
+AWS_S3_BUCKET_NAME=openchallenges-img-cache
+AWS_S3_BUCKET_KEY=grafana
+AWS_DEFAULT_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=

--- a/apps/openchallenges/grafana/tools/restore-from-s3.sh
+++ b/apps/openchallenges/grafana/tools/restore-from-s3.sh
@@ -6,5 +6,5 @@ docker run \
   --env-file tools/grafana-backup-tool/.env \
   --network openchallenges \
   -e RESTORE="true" \
-  -e ARCHIVE_FILE="202303290018.tar.gz" \
+  -e ARCHIVE_FILE="202303292349.tar.gz" \
   ysde/docker-grafana-backup-tool:1.2.6-slim

--- a/apps/openchallenges/grafana/tools/restore-from-s3.sh
+++ b/apps/openchallenges/grafana/tools/restore-from-s3.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker run \
+  --rm \
+  --name grafana-backup-tool \
+  --env-file tools/grafana-backup-tool/.env \
+  --network openchallenges \
+  -e RESTORE="true" \
+  -e ARCHIVE_FILE="202303290018.tar.gz" \
+  ysde/docker-grafana-backup-tool:1.2.6-slim

--- a/apps/openchallenges/grafana/tools/restore-from-s3.sh
+++ b/apps/openchallenges/grafana/tools/restore-from-s3.sh
@@ -6,5 +6,5 @@ docker run \
   --env-file tools/grafana-backup-tool/.env \
   --network openchallenges \
   -e RESTORE="true" \
-  -e ARCHIVE_FILE="202303300020.tar.gz" \
+  -e ARCHIVE_FILE="202303300025.tar.gz" \
   ysde/docker-grafana-backup-tool:1.2.6-slim

--- a/apps/openchallenges/grafana/tools/restore-from-s3.sh
+++ b/apps/openchallenges/grafana/tools/restore-from-s3.sh
@@ -6,5 +6,5 @@ docker run \
   --env-file tools/grafana-backup-tool/.env \
   --network openchallenges \
   -e RESTORE="true" \
-  -e ARCHIVE_FILE="202303292349.tar.gz" \
+  -e ARCHIVE_FILE="202303300020.tar.gz" \
   ysde/docker-grafana-backup-tool:1.2.6-slim

--- a/apps/openchallenges/grafana/tools/restore-from-s3.sh
+++ b/apps/openchallenges/grafana/tools/restore-from-s3.sh
@@ -6,5 +6,5 @@ docker run \
   --env-file tools/grafana-backup-tool/.env \
   --network openchallenges \
   -e RESTORE="true" \
-  -e ARCHIVE_FILE="202303300025.tar.gz" \
+  -e ARCHIVE_FILE="202303302354.tar.gz" \
   ysde/docker-grafana-backup-tool:1.2.6-slim

--- a/apps/openchallenges/prometheus/config/prometheus.yml
+++ b/apps/openchallenges/prometheus/config/prometheus.yml
@@ -13,6 +13,11 @@ scrape_configs:
     metrics_path: '/actuator/metrics'
     static_configs:
       - targets: ['openchallenges-organization-service:8084']
+  - job_name: 'openchallenges-challenge-service'
+    scrape_interval: 1m
+    metrics_path: '/actuator/metrics'
+    static_configs:
+      - targets: ['openchallenges-challenge-service:8085']
 
   # - job_name: 'gateway-service'
   #   scrape_interval: 1m

--- a/docker/openchallenges/services/prometheus.yml
+++ b/docker/openchallenges/services/prometheus.yml
@@ -14,9 +14,9 @@ services:
     volumes:
       - ../../../apps/openchallenges/prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - openchallenges-prometheus-data:/prometheus
-    depends_on:
-      openchallenges-organization-service:
-        condition: service_healthy
+    # depends_on:
+    #   openchallenges-organization-service:
+    #     condition: service_healthy
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Fixes #1344 

## Changelog

- Enable to save the Grafana data (organizations, users, dashboards) to AWS S3.
- Restore Grafana data from AWS S3.
- Add README to the openchallenges-grafana project.
- Enable Prometheus to collect data from the challenge service.
- Add micrometer dashboard (community dashboard)

## Notes

- One limitation is that restoring data does not overwrite existing data. The solution is described in the README. It involves wiping the Grafana data clean and then restart Grafana container. An API key must then be regenerated and specified in the file `tools/grafana-backup-tool/.env` before being able to restore the data to get access to the latest version of the dashboard. This behavior is a bit cumbersome and I'm hoping that we can improve it in the future, e.g. by deleting specific resources first (but not the API key!). An alternative approach would be to deploy Grafana on AWS with the existing dashboard ready and the developers would then configure the OC stack to push metrics and logs to the remote Grafana instance. 

## Preview

### Restoring Grafana data

1. Follow the instructions given in the README of the project `openchallenges-grafana`.
2. Open your browser and navigate to Grafana Web Console (see README)
3. Click on the "Starred" button from the left menu > Click on "OpenChallenges Dashboard"
4. You should be presented with one plot that shows the memory usage of the organization service (if it's running).

![image](https://user-images.githubusercontent.com/3056480/228697047-3d20ed45-1f09-44a2-8977-fc07efe97ef5.png)

### Micrometer dashboard (community dashboard)

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/3056480/228989958-098ba421-e5ea-4f51-a0b3-76dacbc81c41.png">

### Enable Prometheus to collect data from the challenge service

![image](https://user-images.githubusercontent.com/3056480/228982360-462f5209-754c-4ebb-b114-6fcd76b84e9e.png)

