### PR TITLE
feat: Implement new search query API for challenge platforms

### DIFF
--- a/apps/openchallenges/challenge-service/.openapi-generator/FILES
+++ b/apps/openchallenges/challenge-service/.openapi-generator/FILES
@@ -23,7 +23,10 @@ src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/Cha
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSearchQueryDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSortDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypesPageDto.java
+src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformDirectionDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformDto.java
+src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSearchQueryDto.java
+src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSortDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformsPageDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSearchQueryDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSortDto.java

--- a/apps/openchallenges/challenge-service/requests.http
+++ b/apps/openchallenges/challenge-service/requests.http
@@ -72,6 +72,10 @@ GET {{basePath}}/challenges?sort=recently_ended
 
 GET {{basePath}}/challengePlatforms
 
+### List the challenges platforms for the search terms 'synapse'.
+
+GET {{basePath}}/challengePlatforms?searchTerms=synapse
+
 ### Get a challenge platform by ID.
 
 GET {{basePath}}/challengePlatforms/synapse

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApi.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApi.java
@@ -15,6 +15,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.BasicErrorDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformsPageDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -94,8 +95,8 @@ public interface ChallengePlatformApi {
   /**
    * GET /challengePlatforms : List challenge platforms List challenge platforms
    *
-   * @param pageNumber The page number. (optional, default to 0)
-   * @param pageSize The number of items in a single page. (optional, default to 100)
+   * @param challengePlatformSearchQuery The search query used to find challenge platforms.
+   *     (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    */
@@ -143,16 +144,11 @@ public interface ChallengePlatformApi {
       value = "/challengePlatforms",
       produces = {"application/json", "application/problem+json"})
   default ResponseEntity<ChallengePlatformsPageDto> listChallengePlatforms(
-      @Min(0)
-          @Parameter(name = "pageNumber", description = "The page number.")
+      @Parameter(
+              name = "challengePlatformSearchQuery",
+              description = "The search query used to find challenge platforms.")
           @Valid
-          @RequestParam(value = "pageNumber", required = false, defaultValue = "0")
-          Integer pageNumber,
-      @Min(1)
-          @Parameter(name = "pageSize", description = "The number of items in a single page.")
-          @Valid
-          @RequestParam(value = "pageSize", required = false, defaultValue = "100")
-          Integer pageSize) {
-    return getDelegate().listChallengePlatforms(pageNumber, pageSize);
+          ChallengePlatformSearchQueryDto challengePlatformSearchQuery) {
+    return getDelegate().listChallengePlatforms(challengePlatformSearchQuery);
   }
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApiDelegate.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApiDelegate.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.openchallenges.challenge.service.api;
 import java.util.Optional;
 import javax.annotation.Generated;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformsPageDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -54,14 +55,14 @@ public interface ChallengePlatformApiDelegate {
   /**
    * GET /challengePlatforms : List challenge platforms List challenge platforms
    *
-   * @param pageNumber The page number. (optional, default to 0)
-   * @param pageSize The number of items in a single page. (optional, default to 100)
+   * @param challengePlatformSearchQuery The search query used to find challenge platforms.
+   *     (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    * @see ChallengePlatformApi#listChallengePlatforms
    */
   default ResponseEntity<ChallengePlatformsPageDto> listChallengePlatforms(
-      Integer pageNumber, Integer pageSize) {
+      ChallengePlatformSearchQueryDto challengePlatformSearchQuery) {
     getRequest()
         .ifPresent(
             request -> {

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApiDelegateImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApiDelegateImpl.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.openchallenges.challenge.service.api;
 
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformsPageDto;
 import org.sagebionetworks.openchallenges.challenge.service.service.ChallengePlatformService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ public class ChallengePlatformApiDelegateImpl implements ChallengePlatformApiDel
 
   @Override
   public ResponseEntity<ChallengePlatformsPageDto> listChallengePlatforms(
-      Integer pageNumber, Integer pageSize) {
-    return ResponseEntity.ok(challengePlatformService.listChallengePlatforms(pageNumber, pageSize));
+      ChallengePlatformSearchQueryDto query) {
+    return ResponseEntity.ok(challengePlatformService.listChallengePlatforms(query));
   }
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/configuration/EnumConverterConfiguration.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/configuration/EnumConverterConfiguration.java
@@ -5,6 +5,8 @@ import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeD
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeIncentiveDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeDirectionDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSortDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformDirectionDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSortDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeSortDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeSubmissionTypeDto;
@@ -61,6 +63,26 @@ public class EnumConverterConfiguration {
       @Override
       public ChallengeInputDataTypeSortDto convert(String source) {
         return ChallengeInputDataTypeSortDto.fromValue(source);
+      }
+    };
+  }
+
+  @Bean
+  Converter<String, ChallengePlatformDirectionDto> challengePlatformDirectionConverter() {
+    return new Converter<String, ChallengePlatformDirectionDto>() {
+      @Override
+      public ChallengePlatformDirectionDto convert(String source) {
+        return ChallengePlatformDirectionDto.fromValue(source);
+      }
+    };
+  }
+
+  @Bean
+  Converter<String, ChallengePlatformSortDto> challengePlatformSortConverter() {
+    return new Converter<String, ChallengePlatformSortDto>() {
+      @Override
+      public ChallengePlatformSortDto convert(String source) {
+        return ChallengePlatformSortDto.fromValue(source);
       }
     };
   }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformDirectionDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformDirectionDto.java
@@ -1,0 +1,41 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.*;
+import javax.annotation.Generated;
+import javax.validation.constraints.*;
+
+/** The direction to sort the results by. */
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ChallengePlatformDirectionDto {
+  ASC("asc"),
+
+  DESC("desc");
+
+  private String value;
+
+  ChallengePlatformDirectionDto(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ChallengePlatformDirectionDto fromValue(String value) {
+    for (ChallengePlatformDirectionDto b : ChallengePlatformDirectionDto.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    return null;
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSearchQueryDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSearchQueryDto.java
@@ -1,0 +1,184 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.*;
+import java.util.Objects;
+import javax.annotation.Generated;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+/** A challenge platform search query. */
+@Schema(name = "ChallengePlatformSearchQuery", description = "A challenge platform search query.")
+@JsonTypeName("ChallengePlatformSearchQuery")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+// TODO Add x-java-class-annotations
+public class ChallengePlatformSearchQueryDto {
+
+  @JsonProperty("pageNumber")
+  private Integer pageNumber = 0;
+
+  @JsonProperty("pageSize")
+  private Integer pageSize = 100;
+
+  @JsonProperty("sort")
+  private ChallengePlatformSortDto sort = ChallengePlatformSortDto.RELEVANCE;
+
+  @JsonProperty("direction")
+  private ChallengePlatformDirectionDto direction = null;
+
+  @JsonProperty("searchTerms")
+  private String searchTerms;
+
+  public ChallengePlatformSearchQueryDto pageNumber(Integer pageNumber) {
+    this.pageNumber = pageNumber;
+    return this;
+  }
+
+  /**
+   * The page number. minimum: 0
+   *
+   * @return pageNumber
+   */
+  @Min(0)
+  @Schema(name = "pageNumber", description = "The page number.", required = false)
+  public Integer getPageNumber() {
+    return pageNumber;
+  }
+
+  public void setPageNumber(Integer pageNumber) {
+    this.pageNumber = pageNumber;
+  }
+
+  public ChallengePlatformSearchQueryDto pageSize(Integer pageSize) {
+    this.pageSize = pageSize;
+    return this;
+  }
+
+  /**
+   * The number of items in a single page. minimum: 1
+   *
+   * @return pageSize
+   */
+  @Min(1)
+  @Schema(
+      name = "pageSize",
+      description = "The number of items in a single page.",
+      required = false)
+  public Integer getPageSize() {
+    return pageSize;
+  }
+
+  public void setPageSize(Integer pageSize) {
+    this.pageSize = pageSize;
+  }
+
+  public ChallengePlatformSearchQueryDto sort(ChallengePlatformSortDto sort) {
+    this.sort = sort;
+    return this;
+  }
+
+  /**
+   * Get sort
+   *
+   * @return sort
+   */
+  @Valid
+  @Schema(name = "sort", required = false)
+  public ChallengePlatformSortDto getSort() {
+    return sort;
+  }
+
+  public void setSort(ChallengePlatformSortDto sort) {
+    this.sort = sort;
+  }
+
+  public ChallengePlatformSearchQueryDto direction(ChallengePlatformDirectionDto direction) {
+    this.direction = direction;
+    return this;
+  }
+
+  /**
+   * Get direction
+   *
+   * @return direction
+   */
+  @Valid
+  @Schema(name = "direction", required = false)
+  public ChallengePlatformDirectionDto getDirection() {
+    return direction;
+  }
+
+  public void setDirection(ChallengePlatformDirectionDto direction) {
+    this.direction = direction;
+  }
+
+  public ChallengePlatformSearchQueryDto searchTerms(String searchTerms) {
+    this.searchTerms = searchTerms;
+    return this;
+  }
+
+  /**
+   * A string of search terms used to filter the results.
+   *
+   * @return searchTerms
+   */
+  @Schema(
+      name = "searchTerms",
+      example = "synapse",
+      description = "A string of search terms used to filter the results.",
+      required = false)
+  public String getSearchTerms() {
+    return searchTerms;
+  }
+
+  public void setSearchTerms(String searchTerms) {
+    this.searchTerms = searchTerms;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ChallengePlatformSearchQueryDto challengePlatformSearchQuery =
+        (ChallengePlatformSearchQueryDto) o;
+    return Objects.equals(this.pageNumber, challengePlatformSearchQuery.pageNumber)
+        && Objects.equals(this.pageSize, challengePlatformSearchQuery.pageSize)
+        && Objects.equals(this.sort, challengePlatformSearchQuery.sort)
+        && Objects.equals(this.direction, challengePlatformSearchQuery.direction)
+        && Objects.equals(this.searchTerms, challengePlatformSearchQuery.searchTerms);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pageNumber, pageSize, sort, direction, searchTerms);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ChallengePlatformSearchQueryDto {\n");
+    sb.append("    pageNumber: ").append(toIndentedString(pageNumber)).append("\n");
+    sb.append("    pageSize: ").append(toIndentedString(pageSize)).append("\n");
+    sb.append("    sort: ").append(toIndentedString(sort)).append("\n");
+    sb.append("    direction: ").append(toIndentedString(direction)).append("\n");
+    sb.append("    searchTerms: ").append(toIndentedString(searchTerms)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSortDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSortDto.java
@@ -1,0 +1,41 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.*;
+import javax.annotation.Generated;
+import javax.validation.constraints.*;
+
+/** What to sort results by. */
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ChallengePlatformSortDto {
+  CREATED("created"),
+
+  RELEVANCE("relevance");
+
+  private String value;
+
+  ChallengePlatformSortDto(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ChallengePlatformSortDto fromValue(String value) {
+    for (ChallengePlatformSortDto b : ChallengePlatformSortDto.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengePlatformEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengePlatformEntity.java
@@ -11,6 +11,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 @Entity
 @Table(name = "challenge_platform")
@@ -18,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Indexed(index = "openchallenges-challenge-platform")
 public class ChallengePlatformEntity {
 
   @Id
@@ -29,6 +32,7 @@ public class ChallengePlatformEntity {
   private String slug;
 
   @Column(nullable = false)
+  @FullTextField()
   private String name;
 
   @Column(name = "avatar_url", nullable = false)

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/ChallengePlatformRepository.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/ChallengePlatformRepository.java
@@ -4,7 +4,8 @@ import java.util.Optional;
 import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengePlatformEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChallengePlatformRepository extends JpaRepository<ChallengePlatformEntity, Long> {
+public interface ChallengePlatformRepository
+    extends JpaRepository<ChallengePlatformEntity, Long>, CustomChallengePlatformRepository {
 
   Optional<ChallengePlatformEntity> findByName(String name);
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengePlatformRepository.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengePlatformRepository.java
@@ -1,0 +1,12 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.repository;
+
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSearchQueryDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengePlatformEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomChallengePlatformRepository {
+
+  Page<ChallengePlatformEntity> findAll(
+      Pageable pageable, ChallengePlatformSearchQueryDto query, String... fields);
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengePlatformRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengePlatformRepositoryImpl.java
@@ -11,7 +11,6 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSearchQueryDto;
-import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengeEntity;
 import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengePlatformEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengePlatformRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengePlatformRepositoryImpl.java
@@ -1,0 +1,88 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.hibernate.search.engine.search.common.BooleanOperator;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSearchQueryDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengeEntity;
+import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengePlatformEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CustomChallengePlatformRepositoryImpl implements CustomChallengePlatformRepository {
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @Override
+  public Page<ChallengePlatformEntity> findAll(
+      Pageable pageable, ChallengePlatformSearchQueryDto query, String... fields) {
+    SearchResult<ChallengePlatformEntity> result = getSearchResult(pageable, query, fields);
+    return new PageImpl<>(result.hits(), pageable, result.total().hitCount());
+  }
+
+  private SearchResult<ChallengePlatformEntity> getSearchResult(
+      Pageable pageable, ChallengePlatformSearchQueryDto query, String[] fields) {
+    SearchSession searchSession = Search.session(entityManager);
+    SearchPredicateFactory pf = searchSession.scope(ChallengePlatformEntity.class).predicate();
+    List<SearchPredicate> predicates = new ArrayList<>();
+
+    if (query.getSearchTerms() != null && !query.getSearchTerms().isBlank()) {
+      predicates.add(getSearchTermsPredicate(pf, query, fields));
+    }
+
+    SearchPredicate topLevelPredicate = buildTopLevelPredicate(pf, predicates);
+
+    SearchResult<ChallengePlatformEntity> result =
+        searchSession
+            .search(ChallengePlatformEntity.class)
+            .where(topLevelPredicate)
+            .fetch((int) pageable.getOffset(), pageable.getPageSize());
+    return result;
+  }
+
+  /**
+   * Searches the challenge platforms using the search terms specified.
+   *
+   * @param pf
+   * @param query
+   * @param fields
+   * @return
+   */
+  private SearchPredicate getSearchTermsPredicate(
+      SearchPredicateFactory pf, ChallengePlatformSearchQueryDto query, String[] fields) {
+    return pf.simpleQueryString()
+        .fields(fields)
+        .matching(query.getSearchTerms())
+        .defaultOperator(BooleanOperator.AND)
+        .toPredicate();
+  }
+
+  /**
+   * Combines the search predicates.
+   *
+   * @param pf
+   * @param predicates
+   * @return
+   */
+  private SearchPredicate buildTopLevelPredicate(
+      SearchPredicateFactory pf, List<SearchPredicate> predicates) {
+    return pf.bool(
+            b -> {
+              b.must(f -> f.matchAll());
+              for (SearchPredicate predicate : predicates) {
+                b.must(predicate);
+              }
+            })
+        .toPredicate();
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengePlatformService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengePlatformService.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.openchallenges.challenge.service.service;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.openchallenges.challenge.service.exception.ChallengePlatformNotFoundException;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengePlatformsPageDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengePlatformEntity;
 import org.sagebionetworks.openchallenges.challenge.service.model.mapper.ChallengePlatformMapper;
@@ -23,6 +25,8 @@ public class ChallengePlatformService {
 
   private ChallengePlatformMapper challengePlatformMapper = new ChallengePlatformMapper();
 
+  private static final List<String> SEARCHABLE_FIELDS = Arrays.asList("name");
+
   @Transactional(readOnly = true)
   public ChallengePlatformDto getChallengePlatform(String challengePlatformName) {
     ChallengePlatformEntity entity =
@@ -39,9 +43,16 @@ public class ChallengePlatformService {
   }
 
   @Transactional(readOnly = true)
-  public ChallengePlatformsPageDto listChallengePlatforms(Integer pageNumber, Integer pageSize) {
-    Pageable pageable = PageRequest.of(pageNumber, pageSize);
-    Page<ChallengePlatformEntity> entitiesPage = challengePlatformRepository.findAll(pageable);
+  public ChallengePlatformsPageDto listChallengePlatforms(ChallengePlatformSearchQueryDto query) {
+    log.info("query {}", query);
+
+    Pageable pageable = PageRequest.of(query.getPageNumber(), query.getPageSize());
+
+    List<String> fieldsToSearchBy = SEARCHABLE_FIELDS;
+    Page<ChallengePlatformEntity> entitiesPage =
+        challengePlatformRepository.findAll(
+            pageable, query, fieldsToSearchBy.toArray(new String[0]));
+    log.info("entitiesPage {}", entitiesPage);
 
     List<ChallengePlatformDto> challengePlatforms =
         challengePlatformMapper.convertToDtoList(entitiesPage.getContent());

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -142,27 +142,13 @@ paths:
       description: List challenge platforms
       operationId: listChallengePlatforms
       parameters:
-      - description: The page number.
+      - description: The search query used to find challenge platforms.
         explode: true
         in: query
-        name: pageNumber
+        name: challengePlatformSearchQuery
         required: false
         schema:
-          default: 0
-          format: int32
-          minimum: 0
-          type: integer
-        style: form
-      - description: The number of items in a single page.
-        explode: true
-        in: query
-        name: pageSize
-        required: false
-        schema:
-          default: 100
-          format: int32
-          minimum: 1
-          type: integer
+          $ref: '#/components/schemas/ChallengePlatformSearchQuery'
         style: form
       responses:
         "200":
@@ -258,29 +244,14 @@ components:
       schema:
         $ref: '#/components/schemas/ChallengeInputDataTypeSearchQuery'
       style: form
-    pageNumber:
-      description: The page number.
+    challengePlatformSearchQuery:
+      description: The search query used to find challenge platforms.
       explode: true
       in: query
-      name: pageNumber
+      name: challengePlatformSearchQuery
       required: false
       schema:
-        default: 0
-        format: int32
-        minimum: 0
-        type: integer
-      style: form
-    pageSize:
-      description: The number of items in a single page.
-      explode: true
-      in: query
-      name: pageSize
-      required: false
-      schema:
-        default: 100
-        format: int32
-        minimum: 1
-        type: integer
+        $ref: '#/components/schemas/ChallengePlatformSearchQuery'
       style: form
     challengePlatformName:
       description: The unique identifier of the challenge platform.
@@ -848,6 +819,44 @@ components:
       type: object
       x-java-class-annotations:
       - '@lombok.Builder'
+    ChallengePlatformSort:
+      default: relevance
+      description: What to sort results by.
+      enum:
+      - created
+      - relevance
+      type: string
+    ChallengePlatformDirection:
+      description: The direction to sort the results by.
+      enum:
+      - asc
+      - desc
+      nullable: true
+      type: string
+    ChallengePlatformSearchQuery:
+      description: A challenge platform search query.
+      properties:
+        pageNumber:
+          default: 0
+          description: The page number.
+          format: int32
+          minimum: 0
+          type: integer
+        pageSize:
+          default: 100
+          description: The number of items in a single page.
+          format: int32
+          minimum: 1
+          type: integer
+        sort:
+          $ref: '#/components/schemas/ChallengePlatformSort'
+        direction:
+          $ref: '#/components/schemas/ChallengePlatformDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          example: synapse
+          type: string
+      type: object
     ChallengePlatform:
       description: A challenge platform
       example:

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -678,24 +678,6 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/ChallengeInputDataTypeSearchQuery'
-    pageNumber:
-      name: pageNumber
-      description: The page number.
-      in: query
-      schema:
-        type: integer
-        format: int32
-        default: 0
-        minimum: 0
-    pageSize:
-      name: pageSize
-      description: The number of items in a single page.
-      in: query
-      schema:
-        type: integer
-        format: int32
-        default: 100
-        minimum: 1
     challengePlatformSearchQuery:
       name: challengePlatformSearchQuery
       description: The search query used to find challenge platforms.

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -89,8 +89,7 @@ paths:
       description: List challenge platforms
       operationId: listChallengePlatforms
       parameters:
-        - $ref: '#/components/parameters/pageNumber'
-        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/challengePlatformSearchQuery'
       responses:
         '200':
           content:
@@ -534,6 +533,44 @@ components:
             - challengeInputDataTypes
       x-java-class-annotations:
         - '@lombok.Builder'
+    ChallengePlatformSort:
+      description: What to sort results by.
+      type: string
+      default: relevance
+      enum:
+        - created
+        - relevance
+    ChallengePlatformDirection:
+      description: The direction to sort the results by.
+      type: string
+      nullable: true
+      enum:
+        - asc
+        - desc
+    ChallengePlatformSearchQuery:
+      type: object
+      description: A challenge platform search query.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+        sort:
+          $ref: '#/components/schemas/ChallengePlatformSort'
+        direction:
+          $ref: '#/components/schemas/ChallengePlatformDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          type: string
+          example: synapse
     ChallengePlatform:
       type: object
       description: A challenge platform
@@ -616,6 +653,12 @@ components:
         format: int32
         default: 100
         minimum: 1
+    challengePlatformSearchQuery:
+      name: challengePlatformSearchQuery
+      description: The search query used to find challenge platforms.
+      in: query
+      schema:
+        $ref: '#/components/schemas/ChallengePlatformSearchQuery'
     challengePlatformName:
       name: challengePlatformName
       in: path

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -95,8 +95,7 @@ paths:
       description: List challenge platforms
       operationId: listChallengePlatforms
       parameters:
-        - $ref: '#/components/parameters/pageNumber'
-        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/challengePlatformSearchQuery'
       responses:
         '200':
           content:
@@ -688,6 +687,44 @@ components:
             - challengeInputDataTypes
       x-java-class-annotations:
         - '@lombok.Builder'
+    ChallengePlatformSort:
+      description: What to sort results by.
+      type: string
+      default: relevance
+      enum:
+        - created
+        - relevance
+    ChallengePlatformDirection:
+      description: The direction to sort the results by.
+      type: string
+      nullable: true
+      enum:
+        - asc
+        - desc
+    ChallengePlatformSearchQuery:
+      type: object
+      description: A challenge platform search query.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+        sort:
+          $ref: '#/components/schemas/ChallengePlatformSort'
+        direction:
+          $ref: '#/components/schemas/ChallengePlatformDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          type: string
+          example: synapse
     ChallengePlatform:
       type: object
       description: A challenge platform
@@ -1062,6 +1099,12 @@ components:
         format: int32
         default: 100
         minimum: 1
+    challengePlatformSearchQuery:
+      name: challengePlatformSearchQuery
+      description: The search query used to find challenge platforms.
+      in: query
+      schema:
+        $ref: '#/components/schemas/ChallengePlatformSearchQuery'
     challengePlatformName:
       name: challengePlatformName
       in: path

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -1124,24 +1124,6 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/ChallengeInputDataTypeSearchQuery'
-    pageNumber:
-      name: pageNumber
-      description: The page number.
-      in: query
-      schema:
-        type: integer
-        format: int32
-        default: 0
-        minimum: 0
-    pageSize:
-      name: pageSize
-      description: The number of items in a single page.
-      in: query
-      schema:
-        type: integer
-        format: int32
-        default: 100
-        minimum: 1
     challengePlatformSearchQuery:
       name: challengePlatformSearchQuery
       description: The search query used to find challenge platforms.
@@ -1175,6 +1157,24 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganizationLogin'
+    pageNumber:
+      name: pageNumber
+      description: The page number.
+      in: query
+      schema:
+        type: integer
+        format: int32
+        default: 0
+        minimum: 0
+    pageSize:
+      name: pageSize
+      description: The number of items in a single page.
+      in: query
+      schema:
+        type: integer
+        format: int32
+        default: 100
+        minimum: 1
     userId:
       name: userId
       in: path

--- a/libs/openchallenges/api-description/src/components/parameters/query/challengePlatformSearchQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/parameters/query/challengePlatformSearchQuery.yaml
@@ -1,0 +1,5 @@
+name: challengePlatformSearchQuery
+description: The search query used to find challenge platforms.
+in: query
+schema:
+  $ref: ../../schemas/ChallengePlatformSearchQuery.yaml

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformDirection.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformDirection.yaml
@@ -1,0 +1,6 @@
+description: The direction to sort the results by.
+type: string
+nullable: true
+enum:
+  - asc
+  - desc

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformSearchQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformSearchQuery.yaml
@@ -1,0 +1,23 @@
+type: object
+description: A challenge platform search query.
+properties:
+  pageNumber:
+    description: The page number.
+    type: integer
+    format: int32
+    default: 0
+    minimum: 0
+  pageSize:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    default: 100
+    minimum: 1
+  sort:
+    $ref: ChallengePlatformSort.yaml
+  direction:
+    $ref: ChallengePlatformDirection.yaml
+  searchTerms:
+    description: A string of search terms used to filter the results.
+    type: string
+    example: synapse

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformSort.yaml
@@ -1,0 +1,6 @@
+description: What to sort results by.
+type: string
+default: relevance
+enum:
+  - created
+  - relevance

--- a/libs/openchallenges/api-description/src/paths/challengePlatforms.yaml
+++ b/libs/openchallenges/api-description/src/paths/challengePlatforms.yaml
@@ -37,8 +37,7 @@ get:
   description: List challenge platforms
   operationId: listChallengePlatforms
   parameters:
-    - $ref: ../components/parameters/query/pageNumber.yaml
-    - $ref: ../components/parameters/query/pageSize.yaml
+    - $ref: ../components/parameters/query/challengePlatformSearchQuery.yaml
   responses:
     '200':
       content:

--- a/libs/openchallenges/api-description/src/paths/challenges.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges.yaml
@@ -35,16 +35,7 @@ get:
   description: List challenges
   operationId: listChallenges
   parameters:
-    # - $ref: ../components/parameters/query/pageNumber.yaml
-    # - $ref: ../components/parameters/query/pageSize.yaml
-    # - $ref: parameters/sort.yaml
-    # - $ref: parameters/direction.yaml
-    # - $ref: parameters/topics.yaml
-    # - $ref: parameters/inputDataTypes.yaml
     - $ref: ../components/parameters/query/challengeSearchQuery.yaml
-    # - $ref: parameters/challenge/orgIds.yaml
-    # - $ref: parameters/challenge/organizerIds.yaml
-    # - $ref: parameters/challenge/sponsorIds.yaml
   responses:
     '200':
       content:


### PR DESCRIPTION
Fixes #1445

## Changelog

- Add full-text search to challenge platforms

## Notes

- This PR is expected to break UI features that relies on searching challenge platforms. This issue will be fixed when the new UI widget to search challenge platforms, challenge input data types, etc. will be merged to `main`.

## Preview

List the challenges platforms for the search terms 'synapse'.

```
GET {{basePath}}/challengePlatforms?searchTerms=synapse

HTTP/1.1 200
{
  "number": 0,
  "size": 100,
  "totalElements": 1,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challengePlatforms": [
    {
      "id": 1,
      "slug": "synapse",
      "name": "Synapse",
      "avatarUrl": "https://via.placeholder.com/300.png",
      "websiteUrl": "https://synapse.org/",
      "createdAt": "2023-04-25T22:38:29Z",
      "updatedAt": "2023-04-25T22:38:29Z"
    }
  ]
}
```