### PR TITLE
feat: Implement new search query API for challenge input data types 

### DIFF
--- a/apps/openchallenges/challenge-service/.openapi-generator/FILES
+++ b/apps/openchallenges/challenge-service/.openapi-generator/FILES
@@ -18,7 +18,10 @@ src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/Cha
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeDirectionDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeIncentiveDto.java
+src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeDirectionDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeDto.java
+src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSearchQueryDto.java
+src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSortDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypesPageDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformDto.java
 src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformsPageDto.java

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeInputDataTypeApi.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeInputDataTypeApi.java
@@ -14,6 +14,7 @@ import javax.annotation.Generated;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.BasicErrorDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypesPageDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -31,8 +32,8 @@ public interface ChallengeInputDataTypeApi {
   /**
    * GET /challengeInputDataTypes : List challenge input data types List challenge input data types
    *
-   * @param pageNumber The page number. (optional, default to 0)
-   * @param pageSize The number of items in a single page. (optional, default to 100)
+   * @param challengeInputDataTypeSearchQuery The search query used to find challenge input data
+   *     types. (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    */
@@ -80,16 +81,11 @@ public interface ChallengeInputDataTypeApi {
       value = "/challengeInputDataTypes",
       produces = {"application/json", "application/problem+json"})
   default ResponseEntity<ChallengeInputDataTypesPageDto> listChallengeInputDataTypes(
-      @Min(0)
-          @Parameter(name = "pageNumber", description = "The page number.")
+      @Parameter(
+              name = "challengeInputDataTypeSearchQuery",
+              description = "The search query used to find challenge input data types.")
           @Valid
-          @RequestParam(value = "pageNumber", required = false, defaultValue = "0")
-          Integer pageNumber,
-      @Min(1)
-          @Parameter(name = "pageSize", description = "The number of items in a single page.")
-          @Valid
-          @RequestParam(value = "pageSize", required = false, defaultValue = "100")
-          Integer pageSize) {
-    return getDelegate().listChallengeInputDataTypes(pageNumber, pageSize);
+          ChallengeInputDataTypeSearchQueryDto challengeInputDataTypeSearchQuery) {
+    return getDelegate().listChallengeInputDataTypes(challengeInputDataTypeSearchQuery);
   }
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeInputDataTypeApiDelegate.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeInputDataTypeApiDelegate.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.openchallenges.challenge.service.api;
 
 import java.util.Optional;
 import javax.annotation.Generated;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypesPageDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -22,14 +23,14 @@ public interface ChallengeInputDataTypeApiDelegate {
   /**
    * GET /challengeInputDataTypes : List challenge input data types List challenge input data types
    *
-   * @param pageNumber The page number. (optional, default to 0)
-   * @param pageSize The number of items in a single page. (optional, default to 100)
+   * @param challengeInputDataTypeSearchQuery The search query used to find challenge input data
+   *     types. (optional)
    * @return Success (status code 200) or Invalid request (status code 400) or The request cannot be
    *     fulfilled due to an unexpected server error (status code 500)
    * @see ChallengeInputDataTypeApi#listChallengeInputDataTypes
    */
   default ResponseEntity<ChallengeInputDataTypesPageDto> listChallengeInputDataTypes(
-      Integer pageNumber, Integer pageSize) {
+      ChallengeInputDataTypeSearchQueryDto challengeInputDataTypeSearchQuery) {
     getRequest()
         .ifPresent(
             request -> {

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeInputDataTypeApiDelegateImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeInputDataTypeApiDelegateImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.openchallenges.challenge.service.api;
 
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypesPageDto;
 import org.sagebionetworks.openchallenges.challenge.service.service.ChallengeInputDataTypeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,8 +14,7 @@ public class ChallengeInputDataTypeApiDelegateImpl implements ChallengeInputData
 
   @Override
   public ResponseEntity<ChallengeInputDataTypesPageDto> listChallengeInputDataTypes(
-      Integer pageNumber, Integer pageSize) {
-    return ResponseEntity.ok(
-        challengeInputDataTypeService.listChallengeInputDataTypes(pageNumber, pageSize));
+      ChallengeInputDataTypeSearchQueryDto query) {
+    return ResponseEntity.ok(challengeInputDataTypeService.listChallengeInputDataTypes(query));
   }
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/configuration/EnumConverterConfiguration.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/configuration/EnumConverterConfiguration.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.openchallenges.challenge.service.configuration;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeDifficultyDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeDirectionDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeIncentiveDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeDirectionDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSortDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeSortDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeStatusDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeSubmissionTypeDto;
@@ -39,6 +41,26 @@ public class EnumConverterConfiguration {
       @Override
       public ChallengeIncentiveDto convert(String source) {
         return ChallengeIncentiveDto.fromValue(source);
+      }
+    };
+  }
+
+  @Bean
+  Converter<String, ChallengeInputDataTypeDirectionDto> challengeInputDataTypeDirectionConverter() {
+    return new Converter<String, ChallengeInputDataTypeDirectionDto>() {
+      @Override
+      public ChallengeInputDataTypeDirectionDto convert(String source) {
+        return ChallengeInputDataTypeDirectionDto.fromValue(source);
+      }
+    };
+  }
+
+  @Bean
+  Converter<String, ChallengeInputDataTypeSortDto> challengeInputDataTypeSortConverter() {
+    return new Converter<String, ChallengeInputDataTypeSortDto>() {
+      @Override
+      public ChallengeInputDataTypeSortDto convert(String source) {
+        return ChallengeInputDataTypeSortDto.fromValue(source);
       }
     };
   }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeDirectionDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeDirectionDto.java
@@ -1,0 +1,41 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.*;
+import javax.annotation.Generated;
+import javax.validation.constraints.*;
+
+/** The direction to sort the results by. */
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ChallengeInputDataTypeDirectionDto {
+  ASC("asc"),
+
+  DESC("desc");
+
+  private String value;
+
+  ChallengeInputDataTypeDirectionDto(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ChallengeInputDataTypeDirectionDto fromValue(String value) {
+    for (ChallengeInputDataTypeDirectionDto b : ChallengeInputDataTypeDirectionDto.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    return null;
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSearchQueryDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSearchQueryDto.java
@@ -1,0 +1,187 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.*;
+import java.util.Objects;
+import javax.annotation.Generated;
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+
+/** A challenge input data type search query. */
+@Schema(
+    name = "ChallengeInputDataTypeSearchQuery",
+    description = "A challenge input data type search query.")
+@JsonTypeName("ChallengeInputDataTypeSearchQuery")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+// TODO Add x-java-class-annotations
+public class ChallengeInputDataTypeSearchQueryDto {
+
+  @JsonProperty("pageNumber")
+  private Integer pageNumber = 0;
+
+  @JsonProperty("pageSize")
+  private Integer pageSize = 100;
+
+  @JsonProperty("sort")
+  private ChallengeInputDataTypeSortDto sort = ChallengeInputDataTypeSortDto.RELEVANCE;
+
+  @JsonProperty("direction")
+  private ChallengeInputDataTypeDirectionDto direction = null;
+
+  @JsonProperty("searchTerms")
+  private String searchTerms;
+
+  public ChallengeInputDataTypeSearchQueryDto pageNumber(Integer pageNumber) {
+    this.pageNumber = pageNumber;
+    return this;
+  }
+
+  /**
+   * The page number. minimum: 0
+   *
+   * @return pageNumber
+   */
+  @Min(0)
+  @Schema(name = "pageNumber", description = "The page number.", required = false)
+  public Integer getPageNumber() {
+    return pageNumber;
+  }
+
+  public void setPageNumber(Integer pageNumber) {
+    this.pageNumber = pageNumber;
+  }
+
+  public ChallengeInputDataTypeSearchQueryDto pageSize(Integer pageSize) {
+    this.pageSize = pageSize;
+    return this;
+  }
+
+  /**
+   * The number of items in a single page. minimum: 1
+   *
+   * @return pageSize
+   */
+  @Min(1)
+  @Schema(
+      name = "pageSize",
+      description = "The number of items in a single page.",
+      required = false)
+  public Integer getPageSize() {
+    return pageSize;
+  }
+
+  public void setPageSize(Integer pageSize) {
+    this.pageSize = pageSize;
+  }
+
+  public ChallengeInputDataTypeSearchQueryDto sort(ChallengeInputDataTypeSortDto sort) {
+    this.sort = sort;
+    return this;
+  }
+
+  /**
+   * Get sort
+   *
+   * @return sort
+   */
+  @Valid
+  @Schema(name = "sort", required = false)
+  public ChallengeInputDataTypeSortDto getSort() {
+    return sort;
+  }
+
+  public void setSort(ChallengeInputDataTypeSortDto sort) {
+    this.sort = sort;
+  }
+
+  public ChallengeInputDataTypeSearchQueryDto direction(
+      ChallengeInputDataTypeDirectionDto direction) {
+    this.direction = direction;
+    return this;
+  }
+
+  /**
+   * Get direction
+   *
+   * @return direction
+   */
+  @Valid
+  @Schema(name = "direction", required = false)
+  public ChallengeInputDataTypeDirectionDto getDirection() {
+    return direction;
+  }
+
+  public void setDirection(ChallengeInputDataTypeDirectionDto direction) {
+    this.direction = direction;
+  }
+
+  public ChallengeInputDataTypeSearchQueryDto searchTerms(String searchTerms) {
+    this.searchTerms = searchTerms;
+    return this;
+  }
+
+  /**
+   * A string of search terms used to filter the results.
+   *
+   * @return searchTerms
+   */
+  @Schema(
+      name = "searchTerms",
+      example = "genomic",
+      description = "A string of search terms used to filter the results.",
+      required = false)
+  public String getSearchTerms() {
+    return searchTerms;
+  }
+
+  public void setSearchTerms(String searchTerms) {
+    this.searchTerms = searchTerms;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ChallengeInputDataTypeSearchQueryDto challengeInputDataTypeSearchQuery =
+        (ChallengeInputDataTypeSearchQueryDto) o;
+    return Objects.equals(this.pageNumber, challengeInputDataTypeSearchQuery.pageNumber)
+        && Objects.equals(this.pageSize, challengeInputDataTypeSearchQuery.pageSize)
+        && Objects.equals(this.sort, challengeInputDataTypeSearchQuery.sort)
+        && Objects.equals(this.direction, challengeInputDataTypeSearchQuery.direction)
+        && Objects.equals(this.searchTerms, challengeInputDataTypeSearchQuery.searchTerms);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pageNumber, pageSize, sort, direction, searchTerms);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ChallengeInputDataTypeSearchQueryDto {\n");
+    sb.append("    pageNumber: ").append(toIndentedString(pageNumber)).append("\n");
+    sb.append("    pageSize: ").append(toIndentedString(pageSize)).append("\n");
+    sb.append("    sort: ").append(toIndentedString(sort)).append("\n");
+    sb.append("    direction: ").append(toIndentedString(direction)).append("\n");
+    sb.append("    searchTerms: ").append(toIndentedString(searchTerms)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSortDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSortDto.java
@@ -1,0 +1,41 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.*;
+import javax.annotation.Generated;
+import javax.validation.constraints.*;
+
+/** What to sort results by. */
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ChallengeInputDataTypeSortDto {
+  CREATED("created"),
+
+  RELEVANCE("relevance");
+
+  private String value;
+
+  ChallengeInputDataTypeSortDto(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ChallengeInputDataTypeSortDto fromValue(String value) {
+    for (ChallengeInputDataTypeSortDto b : ChallengeInputDataTypeSortDto.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSortDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeInputDataTypeSortDto.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.*;
 /** What to sort results by. */
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum ChallengeInputDataTypeSortDto {
-  CREATED("created"),
+  NAME("name"),
 
   RELEVANCE("relevance");
 

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeInputDataTypeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeInputDataTypeEntity.java
@@ -11,6 +11,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 @Entity
 @Table(name = "challenge_input_data_type")
@@ -18,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Indexed(index = "openchallenges-challenge-input-data-type")
 public class ChallengeInputDataTypeEntity {
 
   @Id
@@ -29,6 +32,7 @@ public class ChallengeInputDataTypeEntity {
   private String slug;
 
   @Column(nullable = false)
+  @FullTextField()
   private String name;
 
   @Column(name = "created_at")

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeInputDataTypeService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeInputDataTypeService.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.openchallenges.challenge.service.service;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSearchQueryDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypesPageDto;
 import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengeInputDataTypeEntity;
 import org.sagebionetworks.openchallenges.challenge.service.model.mapper.ChallengeInputDataTypeMapper;
@@ -25,8 +26,12 @@ public class ChallengeInputDataTypeService {
 
   @Transactional(readOnly = true)
   public ChallengeInputDataTypesPageDto listChallengeInputDataTypes(
-      Integer pageNumber, Integer pageSize) {
-    Pageable pageable = PageRequest.of(pageNumber, pageSize);
+      ChallengeInputDataTypeSearchQueryDto query) {
+
+    log.info("query {}", query);
+
+    Pageable pageable = PageRequest.of(query.getPageNumber(), query.getPageSize());
+
     Page<ChallengeInputDataTypeEntity> entitiesPage =
         challengeInputDataTypeRepository.findAll(pageable);
 

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -770,7 +770,7 @@ components:
       default: relevance
       description: What to sort results by.
       enum:
-      - created
+      - name
       - relevance
       type: string
     ChallengeInputDataTypeDirection:

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -103,27 +103,13 @@ paths:
       description: List challenge input data types
       operationId: listChallengeInputDataTypes
       parameters:
-      - description: The page number.
+      - description: The search query used to find challenge input data types.
         explode: true
         in: query
-        name: pageNumber
+        name: challengeInputDataTypeSearchQuery
         required: false
         schema:
-          default: 0
-          format: int32
-          minimum: 0
-          type: integer
-        style: form
-      - description: The number of items in a single page.
-        explode: true
-        in: query
-        name: pageSize
-        required: false
-        schema:
-          default: 100
-          format: int32
-          minimum: 1
-          type: integer
+          $ref: '#/components/schemas/ChallengeInputDataTypeSearchQuery'
         style: form
       responses:
         "200":
@@ -263,6 +249,15 @@ components:
       schema:
         $ref: '#/components/schemas/ChallengeId'
       style: simple
+    challengeInputDataTypeSearchQuery:
+      description: The search query used to find challenge input data types.
+      explode: true
+      in: query
+      name: challengeInputDataTypeSearchQuery
+      required: false
+      schema:
+        $ref: '#/components/schemas/ChallengeInputDataTypeSearchQuery'
+      style: form
     pageNumber:
       description: The page number.
       explode: true
@@ -771,6 +766,44 @@ components:
       type: object
       x-java-class-annotations:
       - '@lombok.Builder'
+    ChallengeInputDataTypeSort:
+      default: relevance
+      description: What to sort results by.
+      enum:
+      - created
+      - relevance
+      type: string
+    ChallengeInputDataTypeDirection:
+      description: The direction to sort the results by.
+      enum:
+      - asc
+      - desc
+      nullable: true
+      type: string
+    ChallengeInputDataTypeSearchQuery:
+      description: A challenge input data type search query.
+      properties:
+        pageNumber:
+          default: 0
+          description: The page number.
+          format: int32
+          minimum: 0
+          type: integer
+        pageSize:
+          default: 100
+          description: The number of items in a single page.
+          format: int32
+          minimum: 1
+          type: integer
+        sort:
+          $ref: '#/components/schemas/ChallengeInputDataTypeSort'
+        direction:
+          $ref: '#/components/schemas/ChallengeInputDataTypeDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          example: genomic
+          type: string
+      type: object
     ChallengeInputDataType:
       description: A challenge input data type.
       properties:

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -68,8 +68,7 @@ paths:
       description: List challenge input data types
       operationId: listChallengeInputDataTypes
       parameters:
-        - $ref: '#/components/parameters/pageNumber'
-        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/challengeInputDataTypeSearchQuery'
       responses:
         '200':
           content:
@@ -494,6 +493,44 @@ components:
         - status
       x-java-class-annotations:
         - '@lombok.Builder'
+    ChallengeInputDataTypeSort:
+      description: What to sort results by.
+      type: string
+      default: relevance
+      enum:
+        - created
+        - relevance
+    ChallengeInputDataTypeDirection:
+      description: The direction to sort the results by.
+      type: string
+      nullable: true
+      enum:
+        - asc
+        - desc
+    ChallengeInputDataTypeSearchQuery:
+      type: object
+      description: A challenge input data type search query.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+        sort:
+          $ref: '#/components/schemas/ChallengeInputDataTypeSort'
+        direction:
+          $ref: '#/components/schemas/ChallengeInputDataTypeDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          type: string
+          example: genomic
     ChallengeInputDataType:
       type: object
       description: A challenge input data type.
@@ -598,6 +635,12 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/ChallengeId'
+    challengeInputDataTypeSearchQuery:
+      name: challengeInputDataTypeSearchQuery
+      description: The search query used to find challenge input data types.
+      in: query
+      schema:
+        $ref: '#/components/schemas/ChallengeInputDataTypeSearchQuery'
     pageNumber:
       name: pageNumber
       description: The page number.

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -498,7 +498,7 @@ components:
       type: string
       default: relevance
       enum:
-        - created
+        - name
         - relevance
     ChallengeInputDataTypeDirection:
       description: The direction to sort the results by.

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -652,7 +652,7 @@ components:
       type: string
       default: relevance
       enum:
-        - created
+        - name
         - relevance
     ChallengeInputDataTypeDirection:
       description: The direction to sort the results by.

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -74,8 +74,7 @@ paths:
       description: List challenge input data types
       operationId: listChallengeInputDataTypes
       parameters:
-        - $ref: '#/components/parameters/pageNumber'
-        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/challengeInputDataTypeSearchQuery'
       responses:
         '200':
           content:
@@ -648,6 +647,44 @@ components:
         - status
       x-java-class-annotations:
         - '@lombok.Builder'
+    ChallengeInputDataTypeSort:
+      description: What to sort results by.
+      type: string
+      default: relevance
+      enum:
+        - created
+        - relevance
+    ChallengeInputDataTypeDirection:
+      description: The direction to sort the results by.
+      type: string
+      nullable: true
+      enum:
+        - asc
+        - desc
+    ChallengeInputDataTypeSearchQuery:
+      type: object
+      description: A challenge input data type search query.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+        sort:
+          $ref: '#/components/schemas/ChallengeInputDataTypeSort'
+        direction:
+          $ref: '#/components/schemas/ChallengeInputDataTypeDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          type: string
+          example: genomic
     ChallengeInputDataType:
       type: object
       description: A challenge input data type.
@@ -1044,6 +1081,12 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/ChallengeId'
+    challengeInputDataTypeSearchQuery:
+      name: challengeInputDataTypeSearchQuery
+      description: The search query used to find challenge input data types.
+      in: query
+      schema:
+        $ref: '#/components/schemas/ChallengeInputDataTypeSearchQuery'
     pageNumber:
       name: pageNumber
       description: The page number.

--- a/libs/openchallenges/api-description/src/components/parameters/query/challengeInputDataTypeSearchQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/parameters/query/challengeInputDataTypeSearchQuery.yaml
@@ -1,0 +1,5 @@
+name: challengeInputDataTypeSearchQuery
+description: The search query used to find challenge input data types.
+in: query
+schema:
+  $ref: ../../schemas/ChallengeInputDataTypeSearchQuery.yaml

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeDirection.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeDirection.yaml
@@ -1,0 +1,6 @@
+description: The direction to sort the results by.
+type: string
+nullable: true
+enum:
+  - asc
+  - desc

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeSearchQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeSearchQuery.yaml
@@ -1,0 +1,23 @@
+type: object
+description: A challenge input data type search query.
+properties:
+  pageNumber:
+    description: The page number.
+    type: integer
+    format: int32
+    default: 0
+    minimum: 0
+  pageSize:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    default: 100
+    minimum: 1
+  sort:
+    $ref: ChallengeInputDataTypeSort.yaml
+  direction:
+    $ref: ChallengeInputDataTypeDirection.yaml
+  searchTerms:
+    description: A string of search terms used to filter the results.
+    type: string
+    example: genomic

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeSort.yaml
@@ -1,0 +1,6 @@
+description: What to sort results by.
+type: string
+default: relevance
+enum:
+  - created
+  - relevance

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeInputDataTypeSort.yaml
@@ -2,5 +2,5 @@ description: What to sort results by.
 type: string
 default: relevance
 enum:
-  - created
+  - name
   - relevance

--- a/libs/openchallenges/api-description/src/paths/challengeInputDataTypes.yaml
+++ b/libs/openchallenges/api-description/src/paths/challengeInputDataTypes.yaml
@@ -5,8 +5,7 @@ get:
   description: List challenge input data types
   operationId: listChallengeInputDataTypes
   parameters:
-    - $ref: ../components/parameters/query/pageNumber.yaml
-    - $ref: ../components/parameters/query/pageSize.yaml
+    - $ref: ../components/parameters/query/challengeInputDataTypeSearchQuery.yaml
   responses:
     '200':
       content:


### PR DESCRIPTION
Fixes #1447

## Changelog

- Implement same search query API for challenge input data types as for challenges and organization.

## Notes

- This PR updates the API description and the challenge service.
- This PR does not update any OC API client libraries.

## Preview

### Challenge input data types can now be sorted by relevance and name (default)

List the challenge input data types:

```
GET {{basePath}}/challengeInputDataTypes
GET {{basePath}}/challengeInputDataTypes?sort=name # more specific

HTTP/1.1 200 
{
  "number": 0,
  "size": 100,
  "totalElements": 4,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challengeInputDataTypes": [
    {
      "id": 3,
      "slug": "gene-expression",
      "name": "gene expression",
      "createdAt": "2023-04-03T23:44:58Z",
      "updatedAt": "2023-04-03T23:44:58Z"
    },
    {
      "id": 1,
      "slug": "genomic",
      "name": "genomic",
      "createdAt": "2023-04-03T23:44:58Z",
      "updatedAt": "2023-04-03T23:44:58Z"
    },
    {
      "id": 4,
      "slug": "metabolomic",
      "name": "metabolomic",
      "createdAt": "2023-04-03T23:44:58Z",
      "updatedAt": "2023-04-03T23:44:58Z"
    },
    {
      "id": 2,
      "slug": "proteomic",
      "name": "proteomic",
      "createdAt": "2023-04-03T23:44:58Z",
      "updatedAt": "2023-04-03T23:44:58Z"
    }
  ]
}
```

### Challenge input data types now support full-text search

List the challenge input data types that match the full-text search terms "proteomic"

```
GET {{basePath}}/challengeInputDataTypes?searchTerms=proteomic

HTTP/1.1 200
{
  "number": 0,
  "size": 100,
  "totalElements": 1,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challengeInputDataTypes": [
    {
      "id": 2,
      "slug": "proteomic",
      "name": "proteomic",
      "createdAt": "2023-04-04T00:02:46Z",
      "updatedAt": "2023-04-04T00:02:46Z"
    }
  ]
}
```

### New documents stored in Elasticsearch

New documents stored in ES to enable full-text search and sorting.

`http://localhost:9200/openchallenges-challenge-input-data-type-000001/_search?q=*:*`

```json
{
  "took": 21,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 4,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "openchallenges-challenge-input-data-type-000001",
        "_type": "_doc",
        "_id": "1",
        "_score": 1,
        "_source": {
          "name": "genomic",
          "name_sort": "genomic",
          "_entity_type": "ChallengeInputDataTypeEntity"
        }
      },
      {
        "_index": "openchallenges-challenge-input-data-type-000001",
        "_type": "_doc",
        "_id": "2",
        "_score": 1,
        "_source": {
          "name": "proteomic",
          "name_sort": "proteomic",
          "_entity_type": "ChallengeInputDataTypeEntity"
        }
      },
...
```