### PR TITLE
feat: Add image from the image service to the About page

### DIFF
--- a/apps/openchallenges/image-service/README.md
+++ b/apps/openchallenges/image-service/README.md
@@ -16,6 +16,12 @@ nx prepare openchallenges-image-service
 
 > **Note** The task `prepare` does not overwrites the config file `.env` if it already exists.
 
+### Build the Docker image
+
+```console
+nx build-image openchallenges-image-service
+```
+
 ## Prepare the dependencies
 
 This project depends on this list of components. Please check that they are properly configured
@@ -29,4 +35,16 @@ Start the image service and its dependencies:
 
 ```console
 nx serve-detach openchallenges-image-service
+```
+
+### Start the service in development mode
+
+The approach is to first start the service and its dependencies as a container with `serve-detach`
+(see above), then stop and remove the container before starting the service with `serve`.
+
+```console
+nx serve-detach openchallenges-image-service
+docker rm -f openchallenges-image-service
+
+nx serve openchallenges-image-service
 ```

--- a/apps/openchallenges/image-service/README.md
+++ b/apps/openchallenges/image-service/README.md
@@ -39,8 +39,8 @@ nx serve-detach openchallenges-image-service
 
 ### Start the service in development mode
 
-The approach is to first start the service and its dependencies as a container with `serve-detach`
-(see above), then stop and remove the container before starting the service with `serve`.
+The approach is to first start the service and its dependencies as a container with `serve-detach`,
+then stop and remove the container before starting the service with `serve`.
 
 ```console
 nx serve-detach openchallenges-image-service

--- a/apps/openchallenges/image-service/README.md
+++ b/apps/openchallenges/image-service/README.md
@@ -1,0 +1,32 @@
+# OpenChallenges Image Service
+
+## Overview
+
+This service manages images for the OpenChallenges app.
+
+## Usage
+
+### Prepare the service
+
+Run this command to prepare this project, including creating the config file `.env`.
+
+```console
+nx prepare openchallenges-image-service
+```
+
+> **Note** The task `prepare` does not overwrites the config file `.env` if it already exists.
+
+## Prepare the dependencies
+
+This project depends on this list of components. Please check that they are properly configured
+before using this project.
+
+- openchallenges-thumbor
+
+### Start the image service
+
+Start the image service and its dependencies:
+
+```console
+nx serve-detach openchallenges-image-service
+```

--- a/apps/openchallenges/thumbor/README.md
+++ b/apps/openchallenges/thumbor/README.md
@@ -12,6 +12,12 @@ nx prepare openchallenges-thumbor
 
 > **Note** The task `prepare` does not overwrites the config file `.env` if it already exists.
 
+### Build the Docker image
+
+```console
+nx build-image openchallenges-thumbor
+```
+
 ### Start Thumbor
 
 Start Thumbor and its dependencies:

--- a/apps/openchallenges/thumbor/README.md
+++ b/apps/openchallenges/thumbor/README.md
@@ -4,17 +4,29 @@
 
 ### Prepare the service
 
+Run this command to prepare this project, including creating the config file `.env`.
+
 ```console
 nx prepare openchallenges-thumbor
 ```
 
-### Start Thumbor and MinIO
+> **Note** The task `prepare` does not overwrites the config file `.env` if it already exists.
+
+### Start Thumbor
+
+Start Thumbor and its dependencies:
 
 ```console
 nx serve-detach openchallenges-thumbor
 ```
 
-### Upload an image to MinIO
+### Update an image to AWS S3 bucket
+
+Add images to the AWS S3 bucket `openchallenges-img`.
+
+See below for information on how to create and configure the AWS S3 buckets.
+
+### Upload an image to MinIO (deprecated)
 
 1. Open MinIO web console http://localhost:9001/.
 2. Login into MinIO (see MinIO project folder for the default credentials).

--- a/docker/openchallenges/services/app.yml
+++ b/docker/openchallenges/services/app.yml
@@ -20,6 +20,8 @@ services:
         condition: service_healthy
       openchallenges-challenge-service:
         condition: service_started
+      openchallenges-image-service:
+        condition: service_healthy
       # openchallenges-keycloak:
       #   condition: service_started
       openchallenges-organization-service:

--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -2,7 +2,8 @@
   <section class="title">
     <div class="container">
       <div class="section-outer">
-        <img class="logo" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
+        <!-- <img class="logo" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" /> -->
+        <img class="logo" [src]="(triforceImg$ | async)?.url" alt="OpenChallenges Icon" />
         <h2>About OpenChallenges</h2>
       </div>
     </div>
@@ -10,8 +11,8 @@
   <section class="vision">
     <div class="container">
       <h4 class="welcome-msg">
-        Welcome to <span>OpenChallenges</span>, the centralized hub for
-        all challenges biomedical and more.
+        Welcome to <span>OpenChallenges</span>, the centralized hub for all challenges biomedical
+        and more.
       </h4>
       <div class="section-inner">
         <p>
@@ -20,10 +21,9 @@
           while Organizers struggle to find a streamlined solution to reaching a wide audience.
         </p>
         <p>
-          OpenChallenges (OC) strives to address some of the friction in the
-          Challenge experience by providing a centralized hub to reduce participant search cost and
-          increasing Challenge visibility. Think of the ROCC like an EventBrite for the scientific
-          benchmarking space!
+          OpenChallenges (OC) strives to address some of the friction in the Challenge experience by
+          providing a centralized hub to reduce participant search cost and increasing Challenge
+          visibility. Think of the ROCC like an EventBrite for the scientific benchmarking space!
         </p>
       </div>
     </div>

--- a/libs/openchallenges/about/src/lib/about.component.ts
+++ b/libs/openchallenges/about/src/lib/about.component.ts
@@ -1,18 +1,32 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import {
+  Image,
+  ImageService,
+} from '@sagebionetworks/openchallenges/api-client-angular';
 import { ConfigService } from '@sagebionetworks/openchallenges/config';
 import { FooterComponent } from '@sagebionetworks/openchallenges/ui';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-about',
   standalone: true,
-  imports: [FooterComponent],
+  imports: [FooterComponent, CommonModule],
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss'],
 })
-export class AboutComponent {
+export class AboutComponent implements OnInit {
   public appVersion: string;
+  public triforceImg$: Observable<Image> | undefined;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private imageService: ImageService
+  ) {
     this.appVersion = this.configService.config.appVersion;
+  }
+
+  ngOnInit() {
+    this.triforceImg$ = this.imageService.getImage('triforce.png');
   }
 }


### PR DESCRIPTION
Fixes #1443

## Changelog

- Start the image service and Thumbor when the app is started with Docker Compose.
- Demonstrate how to consume an image from the image service in the OC app.
- Document how to configure and use the image service and its dependencies (Thumbor).

## Notes

- We will continue to store asset images in SVG format on the GitHub repo for 1) the sake of version controlling them and 2) so that the asset images are displayed quickly when the app first load. But GH is not made to store bitmap files such as the logo of organization and banner of challenges. These images are also too large to be included in the app bundle. That's where the image service becomes handy.
- Maybe I shouldn't have "replaced" the app logo in the about page. The line for the original image is still in the code, I just commented it out. Once this PR is merged, it's fine to revert back to the svg image in the code base. That way we have at least one example of how to use the image service somewhere in the git history.

## Preview

### About page

The logo of the Triforce displayed below is stored in an AWS S3 bucket, processed by Thumbor and consumed in the app via the OC image service.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3056480/229855732-3c3382b9-f635-48f0-967b-aeba92114374.png">


