### PR TITLE
fix(ui): UI cleanup

### DIFF
--- a/apps/openchallenges/app/src/_app-theme.scss
+++ b/apps/openchallenges/app/src/_app-theme.scss
@@ -8,7 +8,7 @@
 @include mat.legacy-core();
 
 $primary: mat.define-palette(palettes.$dark-blue-palette, 600);
-$accent: mat.define-palette(palettes.$accent-pink-palette, 400);
+$accent: mat.define-palette(palettes.$accent-purple-palette, 400);
 
 $theme: mat.define-light-theme(
   (

--- a/apps/schematic/app/src/_app-theme.scss
+++ b/apps/schematic/app/src/_app-theme.scss
@@ -8,7 +8,7 @@
 @include mat.legacy-core();
 
 $primary: mat.define-palette(palettes.$dark-blue-palette, 600);
-$accent: mat.define-palette(palettes.$accent-pink-palette, 400);
+$accent: mat.define-palette(palettes.$accent-purple-palette, 400);
 
 $theme: mat.define-light-theme(
   (

--- a/libs/openchallenges/about/src/lib/_about-theme.scss
+++ b/libs/openchallenges/about/src/lib/_about-theme.scss
@@ -5,13 +5,6 @@
   $config: mat.get-color-config($theme);
   $primary: map.get($config, primary);
   $accent: map.get($config, accent);
-  $warn: map.get($config, warn);
-  $background: map.get($config, background);
-  $foreground: map.get($config, foreground);
-
-  .welcome-msg > span {
-    color: mat.get-color-from-palette($primary, default);
-  }
 }
 
 @mixin typography($theme) {

--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -2,7 +2,7 @@
   <section class="title">
     <div class="container">
       <div class="section-outer">
-        <img class="logo" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
+        <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
         <!-- <img class="logo" [src]="(triforceImg$ | async)?.url" alt="OpenChallenges Icon" /> -->
         <h2>About OpenChallenges</h2>
       </div>
@@ -23,7 +23,7 @@
         <p>
           OpenChallenges (OC) strives to address some of the friction in the Challenge experience by
           providing a centralized hub to reduce participant search cost and increasing Challenge
-          visibility. Think of the ROCC like an EventBrite for the scientific benchmarking space!
+          visibility. Think of OpenChallenges like an EventBrite for the scientific benchmarking space!
         </p>
       </div>
     </div>

--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -10,8 +10,8 @@
   </section>
   <section class="vision">
     <div class="container">
-      <h4 class="welcome-msg">
-        Welcome to <span>OpenChallenges</span>, the centralized hub for all challenges biomedical
+      <h4 class="mat-body-strong welcome-msg">
+        Welcome to <em>OpenChallenges</em>, the centralized hub for all challenges biomedical
         and more.
       </h4>
       <div class="section-inner">

--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -2,8 +2,8 @@
   <section class="title">
     <div class="container">
       <div class="section-outer">
-        <!-- <img class="logo" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" /> -->
-        <img class="logo" [src]="(triforceImg$ | async)?.url" alt="OpenChallenges Icon" />
+        <img class="logo" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
+        <!-- <img class="logo" [src]="(triforceImg$ | async)?.url" alt="OpenChallenges Icon" /> -->
         <h2>About OpenChallenges</h2>
       </div>
     </div>

--- a/libs/openchallenges/about/src/lib/about.component.scss
+++ b/libs/openchallenges/about/src/lib/about.component.scss
@@ -36,11 +36,6 @@ h4 {
     text-align: center;
     margin-bottom: 40px;
 
-    .logo {
-      width: 140px;
-      height: 140px;
-    }
-
     h2 {
       margin: 8px 0;
     }

--- a/libs/openchallenges/about/src/lib/about.component.scss
+++ b/libs/openchallenges/about/src/lib/about.component.scss
@@ -22,7 +22,7 @@ main {
 
 h2,
 h3,
-h4 {
+.welcome-msg {
   text-align: center;
 }
 

--- a/libs/openchallenges/challenge-search/src/lib/_challenge-search-theme.scss
+++ b/libs/openchallenges/challenge-search/src/lib/_challenge-search-theme.scss
@@ -39,8 +39,14 @@
     font-weight: bolder;
   }
   .mat-checkbox,
-  .mat-select {
-    font-family: 'Lato', sans-serif;
+  .mat-select,
+  .p-component {
+    font-family: 'Lato', sans-serif !important;
+    font-size: 15px !important;
+    line-height: 20px !important;
+  }
+  .p-panel .p-panel-header .p-panel-title {
+    font-size: 16px;
   }
   .sort-title {
     font-weight: 700;

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search-filters.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search-filters.ts
@@ -2,7 +2,7 @@ import { Filter } from '@sagebionetworks/openchallenges/ui';
 import {
   challengeStartYearRangeFilterValues,
   challengeStatusFilterValues,
-  challengeDifficultyFilterValues,
+  // challengeDifficultyFilterValues,
   challengeInputDataTypeFilterValues,
   challengeSubmissionTypesFilterValues,
   challengeIncentiveTypesFilterValues,
@@ -25,12 +25,12 @@ export const challengeStatusFilter: Filter = {
   collapsed: false,
 };
 
-export const challengeDifficultyFilter: Filter = {
-  query: 'difficulties',
-  label: 'Difficulty',
-  values: challengeDifficultyFilterValues,
-  collapsed: true,
-};
+// export const challengeDifficultyFilter: Filter = {
+//   query: 'difficulties',
+//   label: 'Difficulty',
+//   values: challengeDifficultyFilterValues,
+//   collapsed: true,
+// };
 
 export const challengeSubmissionTypesFilter: Filter = {
   query: 'submissionTypes',

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -7,7 +7,7 @@
     </div>
     <div id="title" class="row">
       <div class="col col-10">
-        <h2>Search the OpenChallenges</h2>
+        <h2>Search OpenChallenges</h2>
         <!-- TODO: add "Add Challenge" button when service is available -->
       </div>
       <div class="col col-2">

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -17,7 +17,7 @@ import { Filter, FilterValue } from '@sagebionetworks/openchallenges/ui';
 import {
   challengeStartYearRangeFilter,
   challengeStatusFilter,
-  challengeDifficultyFilter,
+  // challengeDifficultyFilter,
   challengeSubmissionTypesFilter,
   challengeInputDataTypeFilter,
   challengeIncentiveTypesFilter,
@@ -80,7 +80,7 @@ export class ChallengeSearchComponent
 
   checkboxFilters: Filter[] = [
     challengeStatusFilter,
-    challengeDifficultyFilter,
+    // challengeDifficultyFilter,
     challengeSubmissionTypesFilter,
     challengeIncentiveTypesFilter,
     challengePlatformFilter,

--- a/libs/openchallenges/challenge/src/lib/challenge-details/challenge-details.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-details/challenge-details.component.html
@@ -62,7 +62,7 @@
       </tr>
     </table>
     <span class="created-updated-dates"
-      >Added to the ROCC on {{ challenge.createdAt }} and last modified on {{ challenge.updatedAt }}
+      >Added to the OC on {{ challenge.createdAt }} and last modified on {{ challenge.updatedAt }}
     </span>
   </div>
 </main>

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/_challenge-overview-theme.scss
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/_challenge-overview-theme.scss
@@ -18,7 +18,6 @@
   .section-title {
     font-weight: 400;
     font-size: 21px;
-    text-transform: uppercase;
   }
 }
 

--- a/libs/openchallenges/challenge/src/lib/challenge-stats/_challenge-stats-theme.scss
+++ b/libs/openchallenges/challenge/src/lib/challenge-stats/_challenge-stats-theme.scss
@@ -24,7 +24,6 @@
 @mixin typography($theme) {
   .action-btn {
     font-size: 21px;
-    text-transform: uppercase;
   }
   .stat-item > h4 {
     line-height: 0.5;

--- a/libs/openchallenges/challenge/src/lib/challenge.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.html
@@ -2,10 +2,10 @@
   <div *ngIf="challenge$ | async as challenge">
     <section id="top" class="row">
       <div class="link" class="row">
-        <mat-icon aria-hidden="true" class="link-home">home</mat-icon>
-        <mat-icon aria-hidden="true" class="link-home">chevron_right</mat-icon>
+        <mat-icon aria-hidden="true">home</mat-icon>
+        <mat-icon aria-hidden="true">chevron_right</mat-icon>
         <a routerLink="/challenge">challenges</a>
-        <mat-icon aria-hidden="true" class="link-home">chevron_right</mat-icon>
+        <mat-icon aria-hidden="true">chevron_right</mat-icon>
         <span>{{ challenge.name }}</span>
       </div>
       <div class="profile-pic-container">

--- a/libs/openchallenges/challenge/src/lib/challenge.component.scss
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.scss
@@ -110,9 +110,6 @@
   #details {
     text-align: center;
   }
-  .user-tag {
-    align-self: center;
-  }
 }
 
 @media screen and (min-width: 800px) {

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.html
@@ -1,6 +1,6 @@
 <section id="organizations" class="mat-typography">
   <div class="container">
-    <h3 class="section-title">Discover challenge hosts</h3>
+    <h3 class="section-title">Discover Platforms and Organizations</h3>
     <div class="row">
       <div class="card-group">
         <openchallenges-organization-card

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
@@ -19,7 +19,7 @@
         information about relevant challenges, as well as organizers with standardized challenge
         templates and intelligence.
       </p>
-      <h4>Let us help find the perfect challenge for you!</h4>
+      <p class="mat-body-strong">Let us help find the perfect challenge for you!</p>
       <div class="search field field-grouped">
         <div class="control control-expanded">
           <input

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
@@ -14,12 +14,12 @@
         </ngx-typed-js>
       </h1>
       <p class="mat-body-strong about-rocc">
-        The OpenChallenges strives to provide a centralized hub of biomedical challenges from
-        various hosting organizations. Our goal is to empower both participants with the most
-        up-to-date information about relevant challenges, as well as organizers with standardized
-        challenge templates and intelligence.
+        OpenChallenges strives to provide a centralized hub of biomedical challenges from various
+        hosting organizations. Our goal is to empower both participants with the most up-to-date 
+        information about relevant challenges, as well as organizers with standardized challenge
+        templates and intelligence.
       </p>
-      <h4>Let the ROCC help find the perfect challenge for you!</h4>
+      <h4>Let us help find the perfect challenge for you!</h4>
       <div class="search field field-grouped">
         <div class="control control-expanded">
           <input

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
@@ -94,10 +94,6 @@ a:active {
   padding: 210px 64px 72px;
   background-color: #F8F8F8;
 }
-.about-rocc {
-  margin-bottom: 40px;
-  max-width: 100%;
-}
 #landing {
   .search {
   max-width: 360px;
@@ -105,12 +101,6 @@ a:active {
   }
 }
 @media (min-width: $screen-sm) {
-  .about-rocc {
-    font-size: 18px;
-    line-height: 32px;
-    letter-spacing: -0.1px;
-    max-width: 90%;
-  }
   #landing {
     height: 100%;
     

--- a/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
+++ b/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="cards-inner section-inner">
       <div class="cards-header text-center">
-        <h3 class="section-title">Featured challenges</h3>
+        <h3 class="section-title">Featured Challenges</h3>
         <p class="text-sm">
           Not sure where to start? Try one of the following featured challenges!
         </p>

--- a/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
+++ b/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
@@ -2,6 +2,7 @@
   <div class="container">
     <div class="cards-inner section-inner">
       <div class="cards-header text-center">
+        <h3 class="section-title">Featured Challenges</h3>
         Not sure where to start? Try one of the following featured challenges!
       </div>
       <div class="cards-wrap">

--- a/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
+++ b/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.html
@@ -2,10 +2,7 @@
   <div class="container">
     <div class="cards-inner section-inner">
       <div class="cards-header text-center">
-        <h3 class="section-title">Featured Challenges</h3>
-        <p class="text-sm">
-          Not sure where to start? Try one of the following featured challenges!
-        </p>
+        Not sure where to start? Try one of the following featured challenges!
       </div>
       <div class="cards-wrap">
         <div class="card-group">

--- a/libs/openchallenges/home/src/lib/home.component.html
+++ b/libs/openchallenges/home/src/lib/home.component.html
@@ -1,7 +1,7 @@
 <main class="base mat-typography">
   <openchallenges-challenge-search></openchallenges-challenge-search>
   <openchallenges-statistics-viewer></openchallenges-statistics-viewer>
-  <openchallenges-topics-viewer></openchallenges-topics-viewer>
+  <!-- <openchallenges-topics-viewer></openchallenges-topics-viewer> -->
   <openchallenges-challenge-host-list *sageAppShellNoRender></openchallenges-challenge-host-list>
   <openchallenges-challenge-registration
     *sageAppShellNoRender

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
@@ -1,6 +1,6 @@
 <section id="acknowledgements" class="mat-typography">
   <div class="container">
-    <h4 class="section-title text-center">The ROCC project was made possible by...</h4>
+    <h4 class="section-title text-center">OpenChallenges was made possible by...</h4>
     <div class="row">
       <div class="col text-center sponsor-item">
         <h3>ITCR grant</h3>

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
@@ -1,6 +1,6 @@
 <section id="acknowledgements" class="mat-typography">
   <div class="container">
-    <h4 class="section-title text-center">OpenChallenges was made possible by...</h4>
+    <p class="mat-body-strong text-center">OpenChallenges was made possible by...</p>
     <div class="row">
       <div class="col text-center sponsor-item">
         <h3>ITCR grant</h3>

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.scss
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.scss
@@ -9,9 +9,6 @@
   text-align: center;
   margin-bottom: 42px;
 }
-.text-center {
-  text-align: center;
-}
 .sponsor-item {
   display: flex;
   justify-content: center;

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -1,13 +1,13 @@
 <section id="statistics" class="mat-typography">
   <div class="container">
-    <h3 class="section-title">Current landscape</h3>
+    <h3 class="section-title">Current Landscape</h3>
     <div class="row">
       <div class="col text-center">
-        <h2 [countUp]="92">0</h2>
+        <h2 [countUp]="166">0</h2>
         <p>annotated challenges</p>
       </div>
       <div class="col text-center">
-        <h2 [countUp]="11">0</h2>
+        <h2 [countUp]="238">0</h2>
         <p>organizations & hosting societies</p>
       </div>
       <div class="col text-center">

--- a/libs/openchallenges/login/src/lib/login.component.html
+++ b/libs/openchallenges/login/src/lib/login.component.html
@@ -1,7 +1,7 @@
 <main class="base mat-typography">
   <div class="login-container">
     <div class="title">
-      <img src="assets/images/registry_b.png" alt="OpenChallenges" />
+      <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
       <h3>Welcome back!</h3>
     </div>
     <form class="form-container" [formGroup]="loginForm" novalidate>

--- a/libs/openchallenges/org-profile/src/lib/_org-profile-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/_org-profile-theme.scss
@@ -23,7 +23,7 @@
   .username {
     color: map.get($figma, dl-color-default-secondary1);
   }
-  .user-tag {
+  .profile-type {
     border-color: map.get($figma, dl-color-default-secondary2);
     background-color: map.get($figma, dl-color-default-accent2);
   }

--- a/libs/openchallenges/org-profile/src/lib/_org-profile-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/_org-profile-theme.scss
@@ -18,14 +18,14 @@
   }
   .verified {
     border-color: transparent;
-    color: map.get($figma, dl-color-default-darkaccent3);
+    color: map.get($figma, dl-color-default-darkaccent1);
   }
   .username {
     color: map.get($figma, dl-color-default-secondary1);
   }
   .user-tag {
     border-color: map.get($figma, dl-color-default-secondary2);
-    background-color: map.get($figma, dl-color-default-accent4);
+    background-color: map.get($figma, dl-color-default-accent2);
   }
   .base-profile-pic {
     border-color: transparent;

--- a/libs/openchallenges/org-profile/src/lib/org-profile-overview/_org-profile-overview-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-overview/_org-profile-overview-theme.scss
@@ -7,10 +7,6 @@
   $accent: map.get($config, 'accent');
   $warn: map.get($config, 'warn');
   $figma: map.get($config, 'figma');
-
-  .link-text {
-    color: map.get($figma, dl-color-default-secondary2);
-  }
 }
 
 @mixin typography($theme) {

--- a/libs/openchallenges/org-profile/src/lib/org-profile-overview/_org-profile-overview-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-overview/_org-profile-overview-theme.scss
@@ -17,7 +17,6 @@
   .section-title {
     font-weight: 400;
     font-size: 21px;
-    text-transform: uppercase;
   }
 }
 

--- a/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.html
@@ -8,13 +8,13 @@
   <div id="contact" class="row">
     <div class="col">
       <p class="section-title">WEBSITE</p>
-      <a class="link-text" href="org.websiteUrl">
+      <a href="org.websiteUrl">
         {{ org.websiteUrl }}
       </a>
     </div>
     <div class="col">
       <p class="section-title">CONTACT EMAIL</p>
-      <a class="link-text">{{ org.email }}</a>
+      <a>{{ org.email }}</a>
     </div>
   </div>
 </main>

--- a/libs/openchallenges/org-profile/src/lib/org-profile-stats/_org-profile-stats-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-stats/_org-profile-stats-theme.scss
@@ -24,7 +24,6 @@
 @mixin typography($theme) {
   .action-btn {
     font-size: 21px;
-    text-transform: uppercase;
   }
   .stat-item > h4 {
     line-height: 0.5;

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.html
@@ -18,7 +18,7 @@
           <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
         </h2>
         <p class="username">@{{ org.login }}</p>
-        <div class="user-tag">Organization</div>
+        <div class="profile-type">Organization</div>
       </div>
       <div id="activity" class="co-4">
         <div class="activity-card">

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.html
@@ -1,12 +1,12 @@
 <main class="base mat-typography">
   <div *ngIf="organization$ | async as org">
     <section id="profile-top" class="row">
-      <div class="link" class="row">
-        <mat-icon aria-hidden="true" class="link-home">home</mat-icon>
-        <mat-icon aria-hidden="true" class="link-home">chevron_right</mat-icon>
+      <div id="breadcrumbs" class="row">
+        <a aria-label="Back to home" href="/home"><mat-icon aria-hidden="true">home</mat-icon></a>
+        <mat-icon aria-hidden="true">chevron_right</mat-icon>
         <a routerLink="/org">Organizations</a>
-        <mat-icon aria-hidden="true" class="link-home">chevron_right</mat-icon>
-        <span>{{ org.login }}</span>
+        <mat-icon aria-hidden="true">chevron_right</mat-icon>
+        <span>{{ org.name }}</span>
       </div>
       <openchallenges-avatar
         class="profile-pic"

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.scss
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.scss
@@ -32,14 +32,6 @@
 #activity {
   max-width: 320px;
 }
-.user-tag {
-  width: 100%;
-  max-width: 118px;
-  margin: 8px 0;
-  padding: 5px;
-  border-radius: 32px;
-  text-align: center;
-}
 .activity-card {
   text-align: right;
 }
@@ -73,7 +65,7 @@
   .activity-card {
     text-align: center;
   }
-  .user-tag {
+  .profile-type {
     align-self: center;
   }
 }

--- a/libs/openchallenges/signup/src/lib/signup.component.html
+++ b/libs/openchallenges/signup/src/lib/signup.component.html
@@ -18,7 +18,7 @@
         <mat-error *ngIf="password?.invalid">{{ getPasswordErrorMessage() }} </mat-error>
       </mat-form-field>
       <mat-error *ngIf="errors.other">{{ errors.other }}</mat-error>
-      <div class="disclaimer">
+      <div class="mat-caption disclaimer">
         <p>
           By creating an account, you agree to the <a href="#">Terms of Use</a> of
           OpenChallenges. Our Privacy Statement can be read <a href="#">here</a>.

--- a/libs/openchallenges/signup/src/lib/signup.component.html
+++ b/libs/openchallenges/signup/src/lib/signup.component.html
@@ -1,7 +1,7 @@
 <main class="base mat-typography">
   <div class="register-container">
     <div class="title">
-      <img src="assets/images/registry_b.png" alt="OpenChallenges" />
+      <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
       <h3>Join Us on OpenChallenges!</h3>
     </div>
     <form class="form-container" [formGroup]="newUserForm" novalidate>
@@ -20,7 +20,7 @@
       <mat-error *ngIf="errors.other">{{ errors.other }}</mat-error>
       <div class="disclaimer">
         <p>
-          By creating an account, you agree to the <a href="#">Terms of Service</a> of
+          By creating an account, you agree to the <a href="#">Terms of Use</a> of
           OpenChallenges. Our Privacy Statement can be read <a href="#">here</a>.
         </p>
       </div>

--- a/libs/openchallenges/signup/src/lib/signup.component.scss
+++ b/libs/openchallenges/signup/src/lib/signup.component.scss
@@ -8,7 +8,7 @@ main {
 }
 .register-container {
   min-width: 320px;
-  max-width: 420px;
+  max-width: 440px;
   width: 100%
 }
 .title {

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -37,6 +37,30 @@ body {
 .text-left {
   text-align: left;
 }
+.text-center {
+  text-align: center;
+}
+
+// LOGO & DESIGN
+.logo-icon {
+  width: 140px;
+  height: 140px;
+}
+.top-design {
+  background: url('/openchallenges-assets/images/about-banner.svg');
+  background-size: cover;
+  background-position: bottom;
+  padding-top: 108px;
+  text-align: center;
+
+  .section-inner {
+    margin-bottom: 40px;
+
+    h2 {
+      margin: 8px 0;
+    }
+  }
+}
 
 // BUTTONS
 .btn {

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -110,7 +110,8 @@ body {
   margin: 0 3px;
 }
 .card-title {
-  margin: 16px 0 !important;
+  margin: 15px 0 !important;
+  font-weight: 700 !important;
   line-height: 24px;
 }
 .card-body {

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -62,6 +62,12 @@ body {
   }
 }
 
+// BREADCRUMBS
+#breadcrumbs {
+  font-size: 15px;
+  line-height: 20px;
+}
+
 // BUTTONS
 .btn {
   padding: 6px 32px !important;

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -61,6 +61,14 @@ body {
     }
   }
 }
+.profile-type {
+  width: 100%;
+  max-width: 148px;
+  margin: 8px 0;
+  padding: 5px;
+  border-radius: 32px;
+  text-align: center;
+}
 
 // BREADCRUMBS
 #breadcrumbs {

--- a/libs/openchallenges/team/src/lib/_team-theme.scss
+++ b/libs/openchallenges/team/src/lib/_team-theme.scss
@@ -19,13 +19,13 @@
 @mixin typography($theme) {
   em {
     font-style: normal;
+    font-weight: 700;
   }
   .card-name {
-    font-weight: 300 !important;
+    font-weight: 700;
   }
   .card-roles {
     font-size: 1.1em;
-    font-style: italic;
   }
 }
 

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -1,21 +1,31 @@
 <main id="team" class="base mat-typography">
-  <img class="team-logo" src="assets/images/registry_b.png" alt="OpenChallenges" />
-  <h2>Meet Our Team</h2>
+  <div class="top-design section-inner">
+    <img class="logo-icon" src="assets/images/openchallenges-icon.svg" alt="OpenChallenges Icon" />
+    <h2>Meet Our Team</h2>
+    <p class="mat-body-strong">
+      We're smart, we're hard-working, and we love a <em>good challenge</em>.
+    </p>
+  </div>
   <div class="member-group">
     <div class="member-card">
       <img class="member-pic" src="assets/images/thomas.png" alt="Thomas Schaffter" />
       <h3 class="card-name">Thomas Schaffter</h3>
-      <p class="card-roles">Project lead, Architect, Lead developer</p>
+      <p class="card-roles">Project lead, Architect, Backend developer</p>
     </div>
     <div class="member-card">
       <img class="member-pic" src="assets/images/rong.png" alt="Rong Chai" />
       <h3 class="card-name">Rong Chai</h3>
-      <p class="card-roles">Developer</p>
+      <p class="card-roles">Frontend developer</p>
     </div>
     <div class="member-card">
       <img class="member-pic" src="assets/images/verena.png" alt="Verena Chung" />
       <h3 class="card-name">Verena Chung</h3>
-      <p class="card-roles">Developer</p>
+      <p class="card-roles">Frontend developer</p>
+    </div>
+    <div class="member-card">
+      <img class="member-pic" src="assets/images/maria.png" alt="Maria Diaz" />
+      <h3 class="card-name">Maria Diaz</h3>
+      <p class="card-roles">Backend developer</p>
     </div>
   </div>
   <div class="member-group">
@@ -29,13 +39,6 @@
       <h3 class="card-name">Amy Heiser</h3>
       <p class="card-roles">Program manager</p>
     </div>
-    <div class="member-card"></div>
-  </div>
-  <div class="description">
-    <h3>
-      We are engineers at <em>Sage Bionetworks</em>, a non-profit organization dedicated to the
-      world of open science and FAIR data.
-    </h3>
   </div>
 </main>
 <openchallenges-footer [version]="appVersion"></openchallenges-footer>

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -18,7 +18,7 @@
   align-items: center;
 }
 .member-pic {
-  max-height: 240px;
+  height: 240px;
   padding: 12px 0 22px;
   -moz-border-radius: 50%;
   -webkit-border-radius: 505;

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -14,7 +14,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: space-evenly;
+  justify-content: center;
 }
 .member-card {
   width: 300px;
@@ -23,8 +23,7 @@
   align-items: center;
 }
 .member-pic {
-  width: 240px;
-  height: 240px;
+  max-height: 240px;
   padding: 12px 0 22px;
   -moz-border-radius: 50%;
   -webkit-border-radius: 505;

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -3,11 +3,6 @@
 #team {
   text-align: center;
 }
-.team-logo {
-  width: 100px;
-  height: 100px;
-  padding: 180px 0 12px;
-}
 .member-group {
   width: 100%;
   padding: 80px 0;

--- a/libs/openchallenges/themes/src/_fonts.scss
+++ b/libs/openchallenges/themes/src/_fonts.scss
@@ -13,7 +13,7 @@ $lato: mat.define-typography-config(
   $subtitle-1: mat.define-typography-level(28px, 38px, 700, "'Lato', sans-serif", -0.1px),
   $subtitle-2: mat.define-typography-level(18px, 30px, 400, "'Lato', sans-serif", -0.1px),
   $body-1: mat.define-typography-level(21px, 32px, 400, "'Lato', sans-serif", -0.1px),
-  $body-2: mat.define-typography-level(15px, 24px, 400, "'Lato', sans-serif"),
-  $caption: mat.define-typography-level(14px, 20px, 400, "'Lato', sans-serif"),
-  $button: mat.define-typography-level(14px, 18px, 400, "'Lato', sans-serif"),
+  $body-2: mat.define-typography-level(18px, 32px, 400, "'Lato', sans-serif"),
+  $caption: mat.define-typography-level(15px, 21px, 400, "'Lato', sans-serif"),
+  $button: mat.define-typography-level(16px, 18px, 400, "'Lato', sans-serif"),
 );

--- a/libs/openchallenges/themes/src/_palettes.scss
+++ b/libs/openchallenges/themes/src/_palettes.scss
@@ -62,56 +62,6 @@ $light-blue-palette: (
   ),
 );
 
-$light-pink-palette: (
-  50: #ffedf1,
-  100: #ffd2da,
-  200: #f3a1a8,
-  300: #ed7c86,
-  400: #fb5c67,
-  500: #ff494f,
-  600: #f4424e,
-  700: #e23847,
-  800: #d53240,
-  900: #c62634,
-  contrast: (
-    50: $dark-primary-text,
-    100: $dark-primary-text,
-    200: $dark-primary-text,
-    300: $dark-primary-text,
-    400: $dark-primary-text,
-    500: $dark-primary-text,
-    600: $dark-primary-text,
-    700: $light-primary-text,
-    800: $light-primary-text,
-    900: $light-primary-text,
-  ),
-);
-
-$light-orange-palette: (
-  50: #faeeed,
-  100: #ffd8cd,
-  200: #ffbeaa,
-  300: #ffa284,
-  400: #ff8c66,
-  500: #ff774b,
-  600: #ff7146,
-  700: #ff6940,
-  800: #f2623c,
-  900: #d85533,
-  contrast: (
-    50: $dark-primary-text,
-    100: $dark-primary-text,
-    200: $dark-primary-text,
-    300: $dark-primary-text,
-    400: $dark-primary-text,
-    500: $dark-primary-text,
-    600: $dark-primary-text,
-    700: $dark-primary-text,
-    800: $dark-primary-text,
-    900: $light-primary-text,
-  ),
-);
-
 $light-green-palette: (
   50: #e8fefb,
   100: #c6fdf3,
@@ -163,27 +113,21 @@ $light-purple-palette: (
 );
 
 // Alias for "accent" usage
-$accent-pink-palette: $light-pink-palette;
-$accent-orange-palette: $light-orange-palette;
 $accent-green-palette: $light-green-palette;
 $accent-purple-palette: $light-purple-palette;
 
 // Figma palettes variables
 $figma-collection: (
   dl-color-default-navbar: map.get($dark-blue-palette, 600),
-  dl-color-default-accent1: map.get($accent-pink-palette, 100),
-  dl-color-default-accent2: map.get($accent-orange-palette, 100),
-  dl-color-default-accent3: map.get($accent-green-palette, 100),
-  dl-color-default-accent4: map.get($accent-purple-palette, 50),
+  dl-color-default-accent1: map.get($accent-green-palette, 100),
+  dl-color-default-accent2: map.get($accent-purple-palette, 50),
   dl-color-default-primary1: map.get($dark-blue-palette, 400),
   dl-color-default-primary2: $dark-focused,
   dl-color-default-navbardark: map.get($dark-blue-palette, 800),
   dl-color-default-secondary1: map.get($light-blue-palette, 300),
   dl-color-default-secondary2: map.get($accent-purple-palette, 300),
-  dl-color-default-darkaccent2: map.get($accent-orange-palette, 300),
-  dl-color-default-darkaccent3: map.get($accent-green-palette, 600),
-  dl-color-default-darkaccent4: map.get($accent-purple-palette, 200),
-  dl-color-default-darkacccent1: map.get($accent-pink-palette, 200),
+  dl-color-default-darkaccent1: map.get($accent-green-palette, 600),
+  dl-color-default-darkaccent2: map.get($accent-purple-palette, 200),
   dl-color-gray-black: #000000,
   dl-color-gray-white: #ffffff,
   dl-color-default-hover1: rgba(249, 249, 249, 1),

--- a/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
@@ -14,7 +14,7 @@
   }
   .card-banner {
     border-color: transparent;
-    background-color: map.get($figma, dl-color-default-accent1);
+    background-color: map.get($figma, dl-color-default-accent2);
   }
   .star-btn {
     border-color: transparent;

--- a/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
@@ -50,12 +50,7 @@
   }
 }
 
-@mixin typography($theme) { 
-  .card-title {
-    font-size: 18px;
-    font-weight: 700;
-  }
-}
+@mixin typography($theme) { }
 
 @mixin theme($theme) {
   $color-config: mat.get-color-config($theme);

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -12,7 +12,7 @@
       <p class="card-subtitle" *ngIf="platform">
         {{ platform.name }}
       </p>
-      <p class="card-desc">{{ challenge.headline }}</p>
+      <p class="mat-caption">{{ challenge.headline }}</p>
     </div>
     <div class="card-footer">
       <div class="difficulty-tag mat-small">

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -16,8 +16,8 @@
     </div>
     <div class="card-footer">
       <div class="difficulty-tag mat-small">
-        <mat-icon aria-hidden="true" class="card-icon">timeline</mat-icon>
-        {{ difficulty }}
+        <mat-icon aria-hidden="true" class="card-icon">auto_awesome</mat-icon>
+        Some incentive
       </div>
       <div class="status-tag mat-small" [ngClass]="statusClass">
         {{ status }}

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -17,7 +17,7 @@
     <div class="card-footer">
       <div class="difficulty-tag mat-small">
         <mat-icon aria-hidden="true" class="card-icon">auto_awesome</mat-icon>
-        Some incentive
+        {{ incentives }}
       </div>
       <div class="status-tag mat-small" [ngClass]="statusClass">
         {{ status }}

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -11,6 +11,10 @@
   border-radius: constants.$dl-radius-radius-radius16;
   cursor: pointer;
 }
+.card-body {
+  min-height: 180px;
+  max-height:180px;
+}
 
 // FOOTER
 .difficulty-tag {

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -5,7 +5,7 @@ import {
   SimpleChallengePlatform,
 } from '@sagebionetworks/openchallenges/api-client-angular';
 import { Challenge as DeprecatedChallenge } from '@sagebionetworks/openchallenges/api-client-angular-deprecated';
-import { startCase } from 'lodash';
+// import { startCase } from 'lodash';
 
 @Component({
   selector: 'openchallenges-challenge-card',
@@ -19,7 +19,7 @@ export class ChallengeCardComponent implements OnInit {
   platform!: SimpleChallengePlatform;
   status!: string | undefined;
   statusClass!: string;
-  difficulty!: string | undefined;
+  // difficulty!: string | undefined;
 
   constructor(private challengePlatformService: ChallengePlatformService) {}
 
@@ -27,9 +27,9 @@ export class ChallengeCardComponent implements OnInit {
     if (this.challenge) {
       this.status = this.challenge.status ? this.challenge.status : 'No Status';
       this.statusClass = this.challenge.status || '';
-      this.difficulty = this.challenge.difficulty
-        ? startCase(this.challenge.difficulty.replace('-', ''))
-        : undefined;
+      // this.difficulty = this.challenge.difficulty
+      //   ? startCase(this.challenge.difficulty.replace('-', ''))
+      //   : undefined;
       this.platform = this.challenge.platform;
     }
   }

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -18,6 +18,7 @@ export class ChallengeCardComponent implements OnInit {
   @Input() deprecatedChallenge!: DeprecatedChallenge;
   platform!: SimpleChallengePlatform;
   status!: string | undefined;
+  incentives!: string;
   statusClass!: string;
   // difficulty!: string | undefined;
 
@@ -31,6 +32,17 @@ export class ChallengeCardComponent implements OnInit {
       //   ? startCase(this.challenge.difficulty.replace('-', ''))
       //   : undefined;
       this.platform = this.challenge.platform;
+      this.incentives =
+        this.challenge.incentives.length === 0
+          ? 'No incentives listed'
+          : this.challenge.incentives
+              .map(function (s) {
+                return (
+                  s[0].toUpperCase() +
+                  s.substring(1).replace('_', ' ').toLowerCase()
+                );
+              })
+              .join(', ');
     }
   }
 }

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -3,8 +3,8 @@
     <div class="col-8">
       <img class="logo" src="assets/images/openchallenges-white.svg" alt="OpenChallenges" />
       <ul class="footer-link-group">
-        <li><a href="/about">ABOUT</a></li>
-        <li><a href="/team">MEET OUR TEAM</a></li>
+        <li><a href="/about">About</a></li>
+        <li><a href="/team">Meet Our Team</a></li>
         <li><a href="#">API</a></li>
       </ul>
     </div>

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -1,6 +1,6 @@
 <footer class="mat-typography">
   <div class="row">
-    <div class="col-8">
+    <div class="col-8 about-oc">
       <img class="logo" src="assets/images/openchallenges-white.svg" alt="OpenChallenges" />
       <ul class="footer-link-group">
         <li><a href="/about">About</a></li>

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -18,8 +18,8 @@
   </div>
   <div class="footer-bottom">
     <span class="footer-links">
-      <a href="#">Terms</a> • <a href="#">Privacy</a> •
-      <a href="https://www.synapse.org">POWERED BY SAGE BIONETWORKS</a>
+      <a href="#">Terms of Use</a> • <a href="#">Privacy Policy</a> •
+      <a href="https://www.sagebionetworks.org">POWERED BY SAGE BIONETWORKS</a>
     </span>
   </div>
 </footer>

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.scss
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.scss
@@ -37,7 +37,7 @@ footer {
   margin: 0;
 }
 .footer-bottom {
-  top: 189px;
+  bottom: 0;
   left: 0px;
   width: 100%;
   height: 70px;
@@ -55,4 +55,17 @@ footer {
 }
 .logo {
   height: 56px;
+}
+
+@media only screen and (max-width: 650px) {
+  footer {
+    height: 330px;
+  }
+  .about-oc,
+  .app-info,
+  .footer-link-group {
+    width: 100%;
+    text-align: center;
+    justify-content: space-around;
+  }
 }

--- a/libs/openchallenges/ui/src/lib/navbar/_navbar-theme.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/_navbar-theme.scss
@@ -19,16 +19,6 @@
 
 @mixin typography($theme) {
   $typography-config: mat.get-typography-config($theme);
-
-  nav .sage-button {
-    font-weight: 400;
-  }
-
-  .home-btn {
-    font-family: mat.font-family($typography-config);
-    font-weight: 400;
-    line-height: normal;
-  }
 }
 
 @mixin theme($theme) {

--- a/libs/openchallenges/ui/src/lib/navbar/_navbar-theme.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/_navbar-theme.scss
@@ -10,9 +10,11 @@
   openchallenges-navbar {
     color: mat.get-color-from-palette($primary, default-contrast);
 
-    .sage-navbar,
-    .sage-navbar-header {
+    .sage-navbar {
       background: mat.get-color-from-palette($primary, 600);
+    }
+    .navbar-item:hover {
+      background-color: mat.get-color-from-palette($primary, 700);
     }
   }
 }

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
@@ -1,12 +1,12 @@
 <!-- TODO: figure out if the <nav> should go inside of a <header> element. -->
-<nav class="sage-navbar-header" aria-label="Top Toolbar">
+<nav class="sage-navbar" aria-label="Top Toolbar">
   <a mat-button routerLink="/" aria-label="Home">
     <img class="logo" src="assets/images/openchallenges-white.svg" alt="OpenChallenges" />
   </a>
 
   <a
     mat-button
-    class="sage-navbar-hide-small sage-button"
+    class="navbar-item"
     *ngFor="let key of sectionsKeys"
     [routerLink]="key"
     >{{ sections[key].name }}
@@ -14,12 +14,13 @@
 
   <div class="flex-spacer"></div>
 
-  <a mat-button class="sage-button" *ngIf="!isLoggedIn" routerLink="/login" aria-label="Log In"
-    >Log In</a
-  >
+  <a mat-button class="navbar-item" *ngIf="!isLoggedIn" routerLink="/login" aria-label="Log In">
+    Log In
+  </a>
 
   <!-- *ngIf="isLoggedIn" -->
   <openchallenges-user-button
+    class="test"
     [avatar]="userAvatar"
     [menuItems]="userMenuItems"
     (menuItemSelected)="selectUserMenuItem($event)"

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <!-- TODO: figure out if the <nav> should go inside of a <header> element. -->
 <nav class="sage-navbar-header" aria-label="Top Toolbar">
-  <a mat-button class="home-btn" routerLink="/" aria-label="Sage Angular">
+  <a mat-button routerLink="/" aria-label="Home">
     <img class="logo" src="assets/images/openchallenges-white.svg" alt="OpenChallenges" />
   </a>
 

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
@@ -20,7 +20,6 @@
 }
 
 .logo {
-  height: 26px;
-  margin: 0 4px 3px 0;
+  height: 36px;
   vertical-align: middle;
 }

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
@@ -1,6 +1,6 @@
 @use 'libs/openchallenges/styles/src/lib/constants';
 
-.sage-navbar-header {
+.sage-navbar {
   height: constants.$navbar-height;
   display: flex;
   flex-wrap: wrap;
@@ -22,4 +22,20 @@
 .logo {
   height: 36px;
   vertical-align: middle;
+}
+
+@media only screen and (max-width: 855px) {
+  .navbar-item {
+    width: 100%;
+    align-self: center;
+  }
+  .sage-navbar {
+    height: 300px;
+  }
+  .flex-spacer {
+    flex-grow: 0;
+  }
+  .test {
+    width: 100%;
+  }
 }

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
@@ -11,6 +11,10 @@
   border-radius: constants.$dl-radius-radius-radius16;
   cursor: pointer;
 }
+.card-body {
+  min-height: 108px;
+  max-height: 108px;
+}
 
 .organization-members {
   margin-top: 18px;

--- a/libs/openchallenges/ui/src/lib/user-button/_user-button-theme.scss
+++ b/libs/openchallenges/ui/src/lib/user-button/_user-button-theme.scss
@@ -28,7 +28,8 @@
 
 @mixin typography($theme) {
   button.mat-menu-item{
-    font-size: 13px;
+    font-size: 15px;
+    font-family: 'Lato';
   }
 }
 

--- a/libs/openchallenges/ui/src/lib/user-button/user-button.component.html
+++ b/libs/openchallenges/ui/src/lib/user-button/user-button.component.html
@@ -1,7 +1,7 @@
 <button mat-button class="user-button" [matMenuTriggerFor]="userMenu">
   <div>
     <openchallenges-avatar [avatar]="avatar"></openchallenges-avatar>
-    {{ avatar.name }}
+    <span>{{ avatar.name }}</span>
     <mat-icon class="app-hide-small" aria-hidden="true">keyboard_arrow_down </mat-icon>
   </div>
 </button>

--- a/libs/openchallenges/ui/src/lib/user-button/user-button.component.scss
+++ b/libs/openchallenges/ui/src/lib/user-button/user-button.component.scss
@@ -12,9 +12,23 @@
     box-sizing: border-box;
     max-height: 100%;
   }
-
+}
+.btn-container {
+  width: 100%
 }
 
 button.mat-menu-item {
   padding-right: 122px;
+}
+
+@media only screen and (max-width: 855px) {
+  .user-button {
+    width:100%;
+    div {
+      justify-content: center;
+      span{
+        padding-left: 8px;
+      }
+    }
+  }
 }

--- a/libs/openchallenges/ui/src/lib/user-button/user-menu-items.ts
+++ b/libs/openchallenges/ui/src/lib/user-button/user-menu-items.ts
@@ -9,14 +9,14 @@ export const USER_MENU_ITEMS: MenuItem[] = [
   },
   {
     name: 'Profile',
-    icon: 'account_circle',
+    // icon: 'account_circle',
   },
   {
     name: 'Settings',
-    icon: 'settings',
+    // icon: 'settings',
   },
   {
     name: 'Log out',
-    icon: 'exit_to_app',
+    // icon: 'exit_to_app',
   },
 ];

--- a/libs/openchallenges/user-profile/src/lib/_user-profile-theme.scss
+++ b/libs/openchallenges/user-profile/src/lib/_user-profile-theme.scss
@@ -22,7 +22,7 @@
   .username {
     color: map.get($figma, dl-color-default-secondary1);
   }
-  .user-tag {
+  .profile-type {
     border-color: map.get($figma, dl-color-default-secondary2);
     background-color: map.get($figma, dl-color-default-accent2);
   }

--- a/libs/openchallenges/user-profile/src/lib/_user-profile-theme.scss
+++ b/libs/openchallenges/user-profile/src/lib/_user-profile-theme.scss
@@ -17,14 +17,14 @@
   }
   .verified {
     border-color: transparent;
-    color: map.get($figma, dl-color-default-darkaccent3);
+    color: map.get($figma, dl-color-default-darkaccent1);
   }
   .username {
     color: map.get($figma, dl-color-default-secondary1);
   }
   .user-tag {
     border-color: map.get($figma, dl-color-default-secondary2);
-    background-color: map.get($figma, dl-color-default-accent4);
+    background-color: map.get($figma, dl-color-default-accent2);
   }
   .base-profile-pic {
     border-color: transparent;

--- a/libs/openchallenges/user-profile/src/lib/user-profile-overview/_user-profile-overview-theme.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-overview/_user-profile-overview-theme.scss
@@ -14,7 +14,6 @@
   .section-title {
     font-weight: 400;
     font-size: 21px;
-    text-transform: uppercase;
   }
 }
 

--- a/libs/openchallenges/user-profile/src/lib/user-profile-overview/_user-profile-overview-theme.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-overview/_user-profile-overview-theme.scss
@@ -11,9 +11,8 @@
 }
 
 @mixin typography($theme) {
-  .section-title {
-    font-weight: 400;
-    font-size: 21px;
+  .tab-item {
+    font-family: 'Lato';
   }
 }
 

--- a/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.html
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.html
@@ -7,7 +7,7 @@
   </div>
   <div id="orgs" class="row">
     <div class="col">
-      <p class="section-title">Organizations</p>
+      <h3>Organizations</h3>
       <div class="card-group">
         <openchallenges-organization-card
           *ngFor="let organization of organizations"

--- a/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-overview/user-profile-overview.component.scss
@@ -1,0 +1,3 @@
+#orgs {
+  margin-top: 28px;
+}

--- a/libs/openchallenges/user-profile/src/lib/user-profile-stats/_user-profile-stats-theme.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-stats/_user-profile-stats-theme.scss
@@ -24,7 +24,6 @@
 @mixin typography($theme) { 
   .action-btn {
     font-size: 21px;
-    text-transform: uppercase;
   }
   .stat-item > h4 {
     line-height: 0.5;

--- a/libs/openchallenges/user-profile/src/lib/user-profile.component.html
+++ b/libs/openchallenges/user-profile/src/lib/user-profile.component.html
@@ -11,7 +11,7 @@
         Awesome User <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
       </h2>
       <p class="username">@awesome-user</p>
-      <div class="user-tag">User</div>
+      <div class="profile-type">User</div>
     </div>
     <div id="activity" class="col-4">
       <div class="activity-card">

--- a/libs/openchallenges/user-profile/src/lib/user-profile.component.html
+++ b/libs/openchallenges/user-profile/src/lib/user-profile.component.html
@@ -1,8 +1,8 @@
 <div class="base mat-typography" *ngIf="user$ | async as user">
   <section id="profile-top" class="row">
-    <div class="link" class="row">
-      <mat-icon aria-hidden="true" class="link-home">home</mat-icon>
-      <mat-icon aria-hidden="true" class="link-home">chevron_right</mat-icon>
+    <div id="breadcrumbs" class="row">
+      <a aria-label="Back to home" href="/home"><mat-icon aria-hidden="true">home</mat-icon></a>
+      <mat-icon aria-hidden="true">chevron_right</mat-icon>
       <span>{{ user.name }}</span>
     </div>
     <openchallenges-avatar class="profile-pic" [avatar]="userAvatar"></openchallenges-avatar>

--- a/libs/openchallenges/user-profile/src/lib/user-profile.component.scss
+++ b/libs/openchallenges/user-profile/src/lib/user-profile.component.scss
@@ -32,14 +32,6 @@
 #activity {
   max-width: 320px;
 }
-.user-tag {
-  width: 100%;
-  max-width: 98px;
-  margin: 8px 0;
-  padding: 5px;
-  border-radius: 32px;
-  text-align: center;
-}
 .activity-card {
   text-align: right;
 }
@@ -72,7 +64,7 @@
   .activity-card {
     text-align: center;
   }
-  .user-tag {
+  .profile-type {
     align-self: center;
   }
 }


### PR DESCRIPTION
Closes #1464 and closes #1450.  Using #1464 as a guide, this PR features UI cleanup for the "Must have" and "Should have".  The "Could have" are dependent on #1360, #1351, #1454, and so will not be implemented now.

![ui-cleanup](https://user-images.githubusercontent.com/9377970/231370858-3704db40-2084-4c49-b825-7128f330e3ea.gif)

> **Note** During this exercise, I noticed we also need to do a cleanup with the SCSS sheets as well (saving that for another PR).