### PR TITLE
fix: Fix challenge input data type full-text search and sorters

### DIFF
--- a/apps/openchallenges/challenge-service/requests.http
+++ b/apps/openchallenges/challenge-service/requests.http
@@ -84,6 +84,14 @@ GET {{basePath}}/challengePlatforms/synapse
 
 GET {{basePath}}/challengeInputDataTypes
 
+### List the challenge input data types sorted by name.
+
+GET {{basePath}}/challengeInputDataTypes?sort=name
+
+### List the challenge input data types for the search terms "genomic".
+
+GET {{basePath}}/challengeInputDataTypes?searchTerms=genomic
+
 ### Get the challenge with ID 1.
 
 GET {{basePath}}/challenges/1

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeInputDataTypeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeInputDataTypeEntity.java
@@ -11,8 +11,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.sagebionetworks.openchallenges.challenge.service.model.search.ChallengeInputDataTypeNameValueBridge;
 
 @Entity
 @Table(name = "challenge_input_data_type")
@@ -33,6 +37,10 @@ public class ChallengeInputDataTypeEntity {
 
   @Column(nullable = false)
   @FullTextField()
+  @GenericField(
+      name = "name_sort",
+      valueBridge = @ValueBridgeRef(type = ChallengeInputDataTypeNameValueBridge.class),
+      sortable = Sortable.YES)
   private String name;
 
   @Column(name = "created_at")

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/ChallengeInputDataTypeRepository.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/ChallengeInputDataTypeRepository.java
@@ -5,7 +5,8 @@ import org.sagebionetworks.openchallenges.challenge.service.model.entity.Challen
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChallengeInputDataTypeRepository
-    extends JpaRepository<ChallengeInputDataTypeEntity, Long> {
+    extends JpaRepository<ChallengeInputDataTypeEntity, Long>,
+        CustomChallengeInputDataTypeRepository {
 
   Optional<ChallengeInputDataTypeEntity> findByName(String name);
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeInputDataTypeRepository.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeInputDataTypeRepository.java
@@ -1,0 +1,12 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.repository;
+
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSearchQueryDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengeInputDataTypeEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomChallengeInputDataTypeRepository {
+
+  Page<ChallengeInputDataTypeEntity> findAll(
+      Pageable pageable, ChallengeInputDataTypeSearchQueryDto query, String... fields);
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeInputDataTypeRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeInputDataTypeRepositoryImpl.java
@@ -1,0 +1,125 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.hibernate.search.engine.search.common.BooleanOperator;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.search.sort.SearchSort;
+import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
+import org.hibernate.search.engine.search.sort.dsl.SortOrder;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.sagebionetworks.openchallenges.challenge.service.exception.BadRequestException;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeDirectionDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeSearchQueryDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengeInputDataTypeEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CustomChallengeInputDataTypeRepositoryImpl
+    implements CustomChallengeInputDataTypeRepository {
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @Override
+  public Page<ChallengeInputDataTypeEntity> findAll(
+      Pageable pageable, ChallengeInputDataTypeSearchQueryDto query, String... fields) {
+    SearchResult<ChallengeInputDataTypeEntity> result = getSearchResult(pageable, query, fields);
+    return new PageImpl<>(result.hits(), pageable, result.total().hitCount());
+  }
+
+  private SearchResult<ChallengeInputDataTypeEntity> getSearchResult(
+      Pageable pageable, ChallengeInputDataTypeSearchQueryDto query, String[] fields) {
+    SearchSession searchSession = Search.session(entityManager);
+    SearchPredicateFactory pf = searchSession.scope(ChallengeInputDataTypeEntity.class).predicate();
+    SearchSortFactory sf = searchSession.scope(ChallengeInputDataTypeEntity.class).sort();
+    List<SearchPredicate> predicates = new ArrayList<>();
+
+    if (query.getSearchTerms() != null && !query.getSearchTerms().isBlank()) {
+      predicates.add(getSearchTermsPredicate(pf, query, fields));
+    }
+
+    SearchSort sort = getSearchSort(sf, query);
+    SearchPredicate sortPredicate = getSearchSortPredicate(pf, query);
+    if (sortPredicate != null) {
+      predicates.add(sortPredicate);
+    }
+
+    SearchPredicate topLevelPredicate = buildTopLevelPredicate(pf, predicates);
+
+    SearchResult<ChallengeInputDataTypeEntity> result =
+        searchSession
+            .search(ChallengeInputDataTypeEntity.class)
+            .where(topLevelPredicate)
+            .sort(sort)
+            .fetch((int) pageable.getOffset(), pageable.getPageSize());
+    return result;
+  }
+
+  private SearchPredicate getSearchTermsPredicate(
+      SearchPredicateFactory pf, ChallengeInputDataTypeSearchQueryDto query, String[] fields) {
+    return pf.simpleQueryString()
+        .fields(fields)
+        .matching(query.getSearchTerms())
+        .defaultOperator(BooleanOperator.AND)
+        .toPredicate();
+  }
+
+  private SearchPredicate buildTopLevelPredicate(
+      SearchPredicateFactory pf, List<SearchPredicate> predicates) {
+    return pf.bool(
+            b -> {
+              b.must(f -> f.matchAll());
+              for (SearchPredicate predicate : predicates) {
+                b.must(predicate);
+              }
+            })
+        .toPredicate();
+  }
+
+  private SearchSort getSearchSort(
+      SearchSortFactory sf, ChallengeInputDataTypeSearchQueryDto query) {
+    SortOrder orderWithDefaultAsc =
+        query.getDirection() == ChallengeInputDataTypeDirectionDto.DESC
+            ? SortOrder.DESC
+            : SortOrder.ASC;
+    SortOrder orderWithDefaultDesc =
+        query.getDirection() == ChallengeInputDataTypeDirectionDto.ASC
+            ? SortOrder.ASC
+            : SortOrder.DESC;
+
+    SearchSort nameSort = sf.field("name_sort").order(orderWithDefaultAsc).toSort();
+    SearchSort scoreSort = sf.score().order(orderWithDefaultDesc).toSort();
+    SearchSort relevanceSort =
+        (query.getSearchTerms() == null || query.getSearchTerms().isBlank()) ? nameSort : scoreSort;
+
+    switch (query.getSort()) {
+      case NAME -> {
+        return nameSort;
+      }
+      case RELEVANCE -> {
+        return relevanceSort;
+      }
+      default -> {
+        throw new BadRequestException(
+            String.format("Unhandled sorting strategy '%s'", query.getSort()));
+      }
+    }
+  }
+
+  private SearchPredicate getSearchSortPredicate(
+      SearchPredicateFactory pf, ChallengeInputDataTypeSearchQueryDto query) {
+    switch (query.getSort()) {
+      default -> {
+        return null;
+      }
+    }
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/search/ChallengeInputDataTypeNameValueBridge.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/search/ChallengeInputDataTypeNameValueBridge.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.search;
+
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+
+public class ChallengeInputDataTypeNameValueBridge implements ValueBridge<String, String> {
+
+  @Override
+  public String toIndexedValue(String value, ValueBridgeToIndexedValueContext context) {
+    // This will replace all the characters except alphanumeric ones
+    return value == null ? null : value.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeInputDataTypeService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeInputDataTypeService.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.openchallenges.challenge.service.service;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengeInputDataTypeDto;
@@ -24,6 +25,8 @@ public class ChallengeInputDataTypeService {
   private ChallengeInputDataTypeMapper challengeInputDataTypeMapper =
       new ChallengeInputDataTypeMapper();
 
+  private static final List<String> SEARCHABLE_FIELDS = Arrays.asList("name");
+
   @Transactional(readOnly = true)
   public ChallengeInputDataTypesPageDto listChallengeInputDataTypes(
       ChallengeInputDataTypeSearchQueryDto query) {
@@ -32,8 +35,10 @@ public class ChallengeInputDataTypeService {
 
     Pageable pageable = PageRequest.of(query.getPageNumber(), query.getPageSize());
 
+    List<String> fieldsToSearchBy = SEARCHABLE_FIELDS;
     Page<ChallengeInputDataTypeEntity> entitiesPage =
-        challengeInputDataTypeRepository.findAll(pageable);
+        challengeInputDataTypeRepository.findAll(
+            pageable, query, fieldsToSearchBy.toArray(new String[0]));
 
     List<ChallengeInputDataTypeDto> challengeInputDataTypes =
         challengeInputDataTypeMapper.convertToDtoList(entitiesPage.getContent());


### PR DESCRIPTION
Fixes #1463

## Note

The content of this PR should have been included with #1451. I may have forgotten to push my last changes.

## Preview

List the challenge input data types sorted by name.

```
GET {{basePath}}/challengeInputDataTypes?sort=name

HTTP/1.1 200
{
  "number": 0,
  "size": 100,
  "totalElements": 4,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challengeInputDataTypes": [
    {
      "id": 3,
      "slug": "gene-expression",
      "name": "gene expression",
      "createdAt": "2023-04-29T15:43:21Z",
      "updatedAt": "2023-04-29T15:43:21Z"
    },
    {
      "id": 1,
      "slug": "genomic",
      "name": "genomic",
      "createdAt": "2023-04-29T15:43:21Z",
      "updatedAt": "2023-04-29T15:43:21Z"
    },
    {
      "id": 4,
      "slug": "metabolomic",
      "name": "metabolomic",
      "createdAt": "2023-04-29T15:43:21Z",
      "updatedAt": "2023-04-29T15:43:21Z"
    },
    {
      "id": 2,
      "slug": "proteomic",
      "name": "proteomic",
      "createdAt": "2023-04-29T15:43:21Z",
      "updatedAt": "2023-04-29T15:43:21Z"
    }
  ]
}
```

List the challenge input data types for the search terms "genomic".

```
GET {{basePath}}/challengeInputDataTypes?searchTerms=genomic

HTTP/1.1 200
{
  "number": 0,
  "size": 100,
  "totalElements": 1,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challengeInputDataTypes": [
    {
      "id": 1,
      "slug": "genomic",
      "name": "genomic",
      "createdAt": "2023-04-29T15:37:09Z",
      "updatedAt": "2023-04-29T15:37:09Z"
    }
  ]
}
```