### PR TITLE
feat: Add sorters by relevance and name for challenge platforms 

### DIFF
--- a/apps/openchallenges/challenge-service/requests.http
+++ b/apps/openchallenges/challenge-service/requests.http
@@ -72,6 +72,10 @@ GET {{basePath}}/challenges?sort=recently_ended
 
 GET {{basePath}}/challengePlatforms
 
+### List the challenge platforms sorted by name.
+
+GET {{basePath}}/challengePlatforms?sort=name
+
 ### List the challenges platforms for the search terms 'synapse'.
 
 GET {{basePath}}/challengePlatforms?searchTerms=synapse

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSortDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformSortDto.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.*;
 /** What to sort results by. */
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum ChallengePlatformSortDto {
-  CREATED("created"),
+  NAME("name"),
 
   RELEVANCE("relevance");
 

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengePlatformEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengePlatformEntity.java
@@ -11,8 +11,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.sagebionetworks.openchallenges.challenge.service.model.search.ChallengePlatformNameValueBridge;
 
 @Entity
 @Table(name = "challenge_platform")
@@ -33,6 +37,10 @@ public class ChallengePlatformEntity {
 
   @Column(nullable = false)
   @FullTextField()
+  @GenericField(
+      name = "name_sort",
+      valueBridge = @ValueBridgeRef(type = ChallengePlatformNameValueBridge.class),
+      sortable = Sortable.YES)
   private String name;
 
   @Column(name = "avatar_url", nullable = false)

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/search/ChallengePlatformNameValueBridge.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/search/ChallengePlatformNameValueBridge.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.search;
+
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+
+public class ChallengePlatformNameValueBridge implements ValueBridge<String, String> {
+
+  @Override
+  public String toIndexedValue(String value, ValueBridgeToIndexedValueContext context) {
+    // This will replace all the characters except alphanumeric ones
+    return value == null ? null : value.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
+  }
+}

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -823,7 +823,7 @@ components:
       default: relevance
       description: What to sort results by.
       enum:
-      - created
+      - name
       - relevance
       type: string
     ChallengePlatformDirection:

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -575,7 +575,7 @@ components:
       type: string
       default: relevance
       enum:
-        - created
+        - name
         - relevance
     ChallengePlatformDirection:
       description: The direction to sort the results by.

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -729,7 +729,7 @@ components:
       type: string
       default: relevance
       enum:
-        - created
+        - name
         - relevance
     ChallengePlatformDirection:
       description: The direction to sort the results by.

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformSort.yaml
@@ -2,5 +2,5 @@ description: What to sort results by.
 type: string
 default: relevance
 enum:
-  - created
+  - name
   - relevance


### PR DESCRIPTION
Closes #1476 

## Changelog

- Sort challenge platforms by name (default when no search terms are provided)
- Sort challenge platforms by relevance (default when search terms are provided)

## Preview

List the challenge platforms sorted by name.

```
GET {{basePath}}/challengePlatforms?sort=name

HTTP/1.1 200
{
  "number": 0,
  "size": 100,
  "totalElements": 12,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "challengePlatforms": [
    {
      "id": 2,
      "slug": "cagi",
      "name": "CAGI",
      "avatarUrl": "https://via.placeholder.com/300.png",
      "websiteUrl": "https://genomeinterpretation.org/challenges.html",
      "createdAt": "2023-04-29T21:43:23Z",
      "updatedAt": "2023-04-29T21:43:23Z"
    },
    {
      "id": 3,
      "slug": "cami",
      "name": "CAMI",
      "avatarUrl": "https://via.placeholder.com/300.png",
      "websiteUrl": "https://data.cami-challenge.org/",
      "createdAt": "2023-04-29T21:43:23Z",
      "updatedAt": "2023-04-29T21:43:23Z"
    },
    {
      "id": 4,
      "slug": "casp",
      "name": "CASP",
      "avatarUrl": "https://via.placeholder.com/300.png",
      "websiteUrl": "https://predictioncenter.org/",
      "createdAt": "2023-04-29T21:43:23Z",
      "updatedAt": "2023-04-29T21:43:23Z"
    },
    {
      "id": 10,
      "slug": "codabench",
      "name": "CodaBench",
      "avatarUrl": "https://via.placeholder.com/300.png",
      "websiteUrl": "https://www.codabench.org/",
      "createdAt": "2023-04-29T21:43:23Z",
      "updatedAt": "2023-04-29T21:43:23Z"
    },
```