### PR TITLE
feat: Format Java files on Save

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,5 @@
 yarn nx affected --uncommitted --target=format
 yarn nx affected --uncommitted --target=lint
 
-# Re-index the staged files
+# Re-index the staged files after they have been formatted
 git diff --name-only --cached | xargs -l git add

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,4 @@
 
 yarn nx affected --uncommitted --target=format
 yarn nx affected --uncommitted --target=lint
+git add -u

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,6 @@
 
 yarn nx affected --uncommitted --target=format
 yarn nx affected --uncommitted --target=lint
-git add -u
+
+# Re-index the staged files
+git diff --name-only --cached | xargs -l git add

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,9 +28,9 @@
   //   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   //   "editor.formatOnSave": true
   // },
-  "java.format.enabled": false,
+  "java.format.enabled": true,
   "[java]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": true
   },
   "[html]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -22,6 +22,7 @@
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {
         "root": "apps/openchallenges/image-service"
+        // "args": ["--exclude-task spotlessCheck"]
       },
       "outputs": ["apps/openchallenges/image-service"],
       "dependsOn": ["^install"]
@@ -48,7 +49,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "./gradlew build --continuous",
+          "./gradlew build --continuous --exclude-task spotlessCheck",
           "./gradlew bootRun"
         ],
         "cwd": "apps/openchallenges/image-service",

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -22,7 +22,6 @@
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {
         "root": "apps/openchallenges/image-service"
-        // "args": ["--exclude-task spotlessCheck"]
       },
       "outputs": ["apps/openchallenges/image-service"],
       "dependsOn": ["^install"]

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/ImageServiceApplication.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/ImageServiceApplication.java
@@ -22,9 +22,9 @@ public class ImageServiceApplication implements CommandLineRunner {
     this.imageServiceConfigData = imageServiceConfigData;
   }
 
-  public static void main(String[] args) {
-    SpringApplication.run(ImageServiceApplication.class, args);
-  }
+      public static void main(String[] args) {
+        SpringApplication.run(ImageServiceApplication.class, args);
+      }
 
   @Override
   public void run(String... args) throws Exception {

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/ImageServiceApplication.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/ImageServiceApplication.java
@@ -22,9 +22,9 @@ public class ImageServiceApplication implements CommandLineRunner {
     this.imageServiceConfigData = imageServiceConfigData;
   }
 
-      public static void main(String[] args) {
-        SpringApplication.run(ImageServiceApplication.class, args);
-      }
+  public static void main(String[] args) {
+    SpringApplication.run(ImageServiceApplication.class, args);
+  }
 
   @Override
   public void run(String... args) throws Exception {


### PR DESCRIPTION
Closes #1488

## Changelog

- Update the task `serve` of the image service to disable formatting check.
  - The motivation is to streamline development by removing the need to run manually the task `format`.
- Update the pre-commit hook to automatically format the files AND re-index the staged files after they have been formatted.
- Enable Format on Save for Java files.
  - One limitation is that the environment is now using two different tools to format Java files:
    - Spotless that powers the task `format`
    - The VS Code extension "Language Support for Java" that is run when saving Java files.
    - While Spotless is the tool used to valid the formatting of the Java files, the motivation for formatting files on save with Language Support for Java is to make the writing of Java code smoother. In the case where Java Language Support for Java "disagrees" with Spotless, the format of the Java files will be automatically fixed by Spotless during the pre-commit process. This behavior should be transparent to the developers.

## Preview

### Format Java files on Save

![Recording 2023-05-01 at 12 05 34](https://user-images.githubusercontent.com/3056480/235512497-9ec98ccc-c194-4003-9d4e-e21b9fb68324.gif)