### PR TITLE
fix: Avatar is not displayed on organization profile

### DIFF
--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -48,7 +48,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "./gradlew build --continuous",
+          "./gradlew build --continuous --exclude-task spotlessCheck",
           "./gradlew bootRun"
         ],
         "cwd": "apps/openchallenges/organization-service",

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
@@ -85,6 +85,13 @@ public class OrganizationService {
                     new OrganizationNotFoundException(
                         String.format(
                             "The organization with ID %s does not exist.", organizationLogin)));
-    return organizationMapper.convertToDto(orgEntity);
+
+    OrganizationDto org = organizationMapper.convertToDto(orgEntity);
+
+    // Convert the image object key to URLs
+    ImageResponse image = imageServiceRestClient.getImage(org.getAvatarUrl());
+    org.setAvatarUrl(image.getUrl());
+
+    return org;
   }
 }

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
@@ -27,8 +27,7 @@ public class OrganizationService {
 
   private final ImageServiceRestClient imageServiceRestClient;
 
-  @Autowired
-  private OrganizationRepository organizationRepository;
+  @Autowired private OrganizationRepository organizationRepository;
 
   private OrganizationMapper organizationMapper = new OrganizationMapper();
 
@@ -45,11 +44,12 @@ public class OrganizationService {
     Pageable pageable = PageRequest.of(query.getPageNumber(), query.getPageSize());
 
     List<String> fieldsToSearchBy = SEARCHABLE_FIELDS;
-    Page<OrganizationEntity> organizationEntitiesPage = organizationRepository.findAll(pageable, query,
-        fieldsToSearchBy.toArray(new String[0]));
+    Page<OrganizationEntity> organizationEntitiesPage =
+        organizationRepository.findAll(pageable, query, fieldsToSearchBy.toArray(new String[0]));
     LOG.info("organizationEntitiesPage {}", organizationEntitiesPage);
 
-    List<OrganizationDto> organizations = organizationMapper.convertToDtoList(organizationEntitiesPage.getContent());
+    List<OrganizationDto> organizations =
+        organizationMapper.convertToDtoList(organizationEntitiesPage.getContent());
 
     // Convert the image object keys to URLs
     organizations.stream()
@@ -77,12 +77,14 @@ public class OrganizationService {
 
   @Transactional(readOnly = true)
   public OrganizationDto getOrganization(String organizationLogin) {
-    OrganizationEntity orgEntity = organizationRepository
-        .findBySimpleNaturalId(organizationLogin)
-        .orElseThrow(
-            () -> new OrganizationNotFoundException(
-                String.format(
-                    "The organization with ID %s does not exist.", organizationLogin)));
+    OrganizationEntity orgEntity =
+        organizationRepository
+            .findBySimpleNaturalId(organizationLogin)
+            .orElseThrow(
+                () ->
+                    new OrganizationNotFoundException(
+                        String.format(
+                            "The organization with ID %s does not exist.", organizationLogin)));
 
     OrganizationDto org = organizationMapper.convertToDto(orgEntity);
 

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
@@ -27,7 +27,8 @@ public class OrganizationService {
 
   private final ImageServiceRestClient imageServiceRestClient;
 
-  @Autowired private OrganizationRepository organizationRepository;
+  @Autowired
+  private OrganizationRepository organizationRepository;
 
   private OrganizationMapper organizationMapper = new OrganizationMapper();
 
@@ -44,14 +45,13 @@ public class OrganizationService {
     Pageable pageable = PageRequest.of(query.getPageNumber(), query.getPageSize());
 
     List<String> fieldsToSearchBy = SEARCHABLE_FIELDS;
-    Page<OrganizationEntity> organizationEntitiesPage =
-        organizationRepository.findAll(pageable, query, fieldsToSearchBy.toArray(new String[0]));
+    Page<OrganizationEntity> organizationEntitiesPage = organizationRepository.findAll(pageable, query,
+        fieldsToSearchBy.toArray(new String[0]));
     LOG.info("organizationEntitiesPage {}", organizationEntitiesPage);
 
-    List<OrganizationDto> organizations =
-        organizationMapper.convertToDtoList(organizationEntitiesPage.getContent());
+    List<OrganizationDto> organizations = organizationMapper.convertToDtoList(organizationEntitiesPage.getContent());
 
-    // Convert the image object key to URLs
+    // Convert the image object keys to URLs
     organizations.stream()
         .parallel()
         .forEach(
@@ -77,18 +77,16 @@ public class OrganizationService {
 
   @Transactional(readOnly = true)
   public OrganizationDto getOrganization(String organizationLogin) {
-    OrganizationEntity orgEntity =
-        organizationRepository
-            .findBySimpleNaturalId(organizationLogin)
-            .orElseThrow(
-                () ->
-                    new OrganizationNotFoundException(
-                        String.format(
-                            "The organization with ID %s does not exist.", organizationLogin)));
+    OrganizationEntity orgEntity = organizationRepository
+        .findBySimpleNaturalId(organizationLogin)
+        .orElseThrow(
+            () -> new OrganizationNotFoundException(
+                String.format(
+                    "The organization with ID %s does not exist.", organizationLogin)));
 
     OrganizationDto org = organizationMapper.convertToDto(orgEntity);
 
-    // Convert the image object key to URLs
+    // Convert the image object key to URL
     ImageResponse image = imageServiceRestClient.getImage(org.getAvatarUrl());
     org.setAvatarUrl(image.getUrl());
 


### PR DESCRIPTION
Fixes #1501

## Changelog

- Build org avatar URL when getting a single org from the organization service 
- The org service can now be served with formatting errors in the code (development mode)

## Preview

The org logo now appears on the org profile page.

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/3056480/236322070-80f8d60f-e3a5-4a14-8867-7a86774ba997.png">
