### PR TITLE
feat: Save Terraform stack state to Terraform Cloud

### DIFF
--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -41,7 +41,7 @@ When using TF cloud backend, the deployment of the stacks will be executed from 
 owned by TF. The AWS credentials must be available to this environment so that it can deploys the
 stack with the AWS provider.
 
-1. Create the TF Cloud workspace (currently `openchallenges-test`)
+1. Create the TF Cloud workspace (currently hard-coded in `main.ts`: `openchallenges-test`)
     ```
     cdktf plan
     ```

--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -47,15 +47,8 @@ stack with the AWS provider.
     ```
 2. Login to your TF Cloud account
 3. Select the workspace
-4. Click on "Variables"
-5. Create the variable `AWS_ACCESS_KEY_ID`
-    - Click on "Add variable"
-    - Category: `Environment variable`
-    - Key: `AWS_ACCESS_KEY_ID`
-    - Value: `YOUR_ACCESS_KEY_ID`
-    - Sensitive: Yes
-    - Click on "Add variable"
-6. Repeat the same process to create the variable `AWS_SECRET_ACCESS_KEY`
+4. [Add a variable] named `AWS_ACCESS_KEY_ID` (sensitive, environment variable).
+5. [Add a variable] named `AWS_SECRET_ACCESS_KEY` (sensitive, environment variable).
 
 ### Generate an SSH key for accessing the EC2 instance
 
@@ -102,3 +95,4 @@ cdktf destroy
 [Terraform CDK]: https://developer.hashicorp.com/terraform/cdktf
 
 [DK for Terraform]: https://developer.hashicorp.com/terraform/cdktf
+[Add a variable]: https://developer.hashicorp.com/terraform/cloud-docs/workspaces/variables/managing-variables#add-a-variable

--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -14,6 +14,16 @@ TODO: Document the roles that this user should have
 
 ### Set AWS configuration
 
+The configuration differs depending on whether the stack is deployed from the local environment or
+from a TF cloud environment.
+
+> **Note** This project is currently configured to deploy the stack using TF cloud backend.
+
+#### When using TF local backend
+
+TF reads the local AWS credentials when deploying the stack with TF local backend. Stack state files
+will be stored locally.
+
 Run this command to quickly set your credentials, Region, and output format. The following example
 shows sample credentials that should be replaced.
 
@@ -24,6 +34,28 @@ AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 Default region name [None]: us-east-1
 Default output format [None]
 ```
+
+#### When using TF cloud backend
+
+When using TF cloud backend, the deployment of the stacks will be executed from a cloud environment
+owned by TF. The AWS credentials must be available to this environment so that it can deploys the
+stack with the AWS provider.
+
+1. Create the TF Cloud workspace (currently `openchallenges-test`)
+    ```
+    cdktf plan
+    ```
+2. Login to your TF Cloud account
+3. Select the workspace
+4. Click on "Variables"
+5. Create the variable `AWS_ACCESS_KEY_ID`
+    - Click on "Add variable"
+    - Category: `Environment variable`
+    - Key: `AWS_ACCESS_KEY_ID`
+    - Value: `YOUR_ACCESS_KEY_ID`
+    - Sensitive: Yes
+    - Click on "Add variable"
+6. Repeat the same process to create the variable `AWS_SECRET_ACCESS_KEY`
 
 ### Generate an SSH key for accessing the EC2 instance
 

--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -41,9 +41,10 @@ When using TF cloud backend, the deployment of the stacks will be executed from 
 owned by TF. The AWS credentials must be available to this environment so that it can deploys the
 stack with the AWS provider.
 
-1. Create the TF Cloud workspace (currently hard-coded in `main.ts`: `openchallenges-test`)
+1. Create the TF Cloud workspace by running the following command (currently hard-coded in
+   `main.ts`: `openchallenges-test`).
     ```
-    cdktf plan
+    cdktf diff
     ```
 2. Login to your TF Cloud account
 3. Select the workspace

--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -18,7 +18,7 @@ Run this command to quickly set your credentials, Region, and output format. The
 shows sample credentials that should be replaced.
 
 ```console
-$ aws configure
+$ aws configure --profile cdktf
 AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
 AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 Default region name [None]: us-east-1

--- a/apps/openchallenges/infra/src/main.ts
+++ b/apps/openchallenges/infra/src/main.ts
@@ -24,7 +24,7 @@ class OpenChallengesStack extends TerraformStack {
 
     new AwsProvider(this, 'AWS', {
       region: 'us-east-1',
-      profile: 'cdktf',
+      // profile: 'cdktf',
     });
 
     const keyPair = new KeyPair(this, 'keypair', {

--- a/apps/openchallenges/infra/src/main.ts
+++ b/apps/openchallenges/infra/src/main.ts
@@ -1,6 +1,12 @@
 /* eslint-disable no-new */
 import { Construct } from 'constructs';
-import { App, TerraformOutput, TerraformStack } from 'cdktf';
+import {
+  App,
+  CloudBackend,
+  NamedCloudWorkspace,
+  TerraformOutput,
+  TerraformStack,
+} from 'cdktf';
 import { logger, Level } from './logger';
 import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
 import { Instance } from '@cdktf/provider-aws/lib/instance';
@@ -18,6 +24,7 @@ class OpenChallengesStack extends TerraformStack {
 
     new AwsProvider(this, 'AWS', {
       region: 'us-east-1',
+      profile: 'cdktf',
     });
 
     const keyPair = new KeyPair(this, 'keypair', {
@@ -41,5 +48,12 @@ logger.setLevel(Level.Debug);
 logger.info('Welcome to the deployment of the OpenChallenges stack.');
 
 const app = new App();
-new OpenChallengesStack(app, 'openchallenges-stack');
+const stack = new OpenChallengesStack(app, 'openchallenges-stack');
+
+new CloudBackend(stack, {
+  hostname: 'app.terraform.io',
+  organization: 'sagebionetworks',
+  workspaces: new NamedCloudWorkspace('openchallenges-test'),
+});
+
 app.synth();


### PR DESCRIPTION
Closes #1497 

## Changelog

- Create the TF Cloud organization `sagebionetworks`
- Configure the project `openchallenges-infra` to store the stack state to Terraform Cloud
- Document how to deploy the stack (see README)