### PR TITLE
fix(ui): UI cleanup, part III

### DIFF
--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -67,8 +67,8 @@
             </div>
             <div class="card-content">
               <ul>
-                <li>Standardize information about Challenges</li>
-                <li>Create a community hub</li>
+                <li class="mat-caption">Standardize information about Challenges</li>
+                <li class="mat-caption">Create a community hub</li>
               </ul>
             </div>
           </div>
@@ -81,8 +81,8 @@
             </div>
             <div class="card-content">
               <ul>
-                <li>Help organizers drive thought, leadership, and awareness</li>
-                <li>Support participants with their professional development journeys</li>
+                <li class="mat-caption">Help organizers drive thought, leadership, and awareness</li>
+                <li class="mat-caption">Support participants with their professional development journeys</li>
               </ul>
             </div>
           </div>
@@ -95,8 +95,8 @@
             </div>
             <div class="card-content">
               <ul>
-                <li>Create OC user profiles to enable challenge intelligence</li>
-                <li>Require registered OC users to go through an onboarding flow</li>
+                <li class="mat-caption">Create OC user profiles to enable challenge intelligence</li>
+                <li class="mat-caption">Require registered OC users to go through an onboarding flow</li>
               </ul>
             </div>
           </div>

--- a/libs/openchallenges/about/src/lib/about.component.scss
+++ b/libs/openchallenges/about/src/lib/about.component.scss
@@ -7,25 +7,21 @@ main {
     margin-bottom: 40px;
   }
 }
-
 .container {
   max-width: 1366px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 16px 60px;
 }
-
 .section-inner {
   position: relative;
   padding-top: 48px;
   padding-bottom: 48px;
 }
-
 h2,
 h3,
 .welcome-msg {
   text-align: center;
 }
-
 .title {
   background: url('/openchallenges-assets/images/about-banner.svg');
   background-size: cover;
@@ -41,18 +37,15 @@ h3,
     }
   }
 }
-
 .welcome-msg {
   margin: 40px 0 0;
 }
-
 .goals {
   .cards-container {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
   }
-
   .card {
     flex: 0 1 20%;
     display: flex;
@@ -71,9 +64,8 @@ h3,
       text-align: center;
 
     }
-
     li {
-      padding: 0 8px;
+      padding: 0 4px;
 
       &:not(:last-child) {
         margin-bottom: 8px;

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.scss
@@ -9,7 +9,6 @@
 .calendar-group {
   align-items: center;
 }
-
 ::ng-deep .search-field {
   .p-input-icon-left,
   input {
@@ -27,12 +26,10 @@
     cursor: pointer;
   }
 }
-
 ::ng-deep .p-radiobutton.p-component,
 ::ng-deep .p-checkbox.p-component {
   margin-right: 8px;
 }
-
 ::ng-deep .p-panel {
   .p-panel-header,
   .p-panel-content {

--- a/libs/openchallenges/challenge/src/lib/_challenge-theme.scss
+++ b/libs/openchallenges/challenge/src/lib/_challenge-theme.scss
@@ -31,12 +31,14 @@
     border-color: transparent;
     &:focus,
     &:hover {
-      background-color: map.get($figma, dl-color-default-hover2);
+      background-color: map.get($figma, dl-color-default-primary1);
+      color: white;
     }
     color: black;
   }
   .profile-nav-item.active-tab {
-    background-color: map.get($figma, dl-color-default-hover2);
+    background-color: map.get($figma, dl-color-default-navbardark);
+    color: white;
   }
 
   .status {

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
@@ -28,7 +28,7 @@
       </tr> -->
       <tr>
         <td class="text-right">DOI</td>
-        <td><a href="#">{{ mockDoi }}</a></td>
+        <td><a target="_blank" href="#">{{ mockDoi }}</a></td>
       </tr>
       <tr>
         <td class="text-right">Submission Type</td>

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
@@ -26,10 +26,10 @@
         <td class="text-right">Website URL</td>
         <td>{{ challenge.websiteUrl }}</td>
       </tr> -->
-      <!-- <tr>
+      <tr>
         <td class="text-right">DOI</td>
-        <td>{{ mockDoi }}</td>
-      </tr> -->
+        <td><a href="#">{{ mockDoi }}</a></td>
+      </tr>
       <tr>
         <td class="text-right">Submission Type</td>
         <td>

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.ts
@@ -14,7 +14,7 @@ export class ChallengeOverviewComponent {
   @Input() challenge!: Challenge;
   organizations: Organization[] = MOCK_ORGANIZATIONS;
   // mockTopics = ['breast', 'cancer'];
-  // mockDoi = '09.1937/09219137';
+  mockDoi = '09.1937/09219137';
 
   use_default(str: string) {
     return str === '' ? 'Not available' : str;

--- a/libs/openchallenges/challenge/src/lib/challenge-stats/challenge-stats.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-stats/challenge-stats.component.html
@@ -11,7 +11,7 @@
     <mat-icon aria-hidden="true" class="stats-card-icon">edit</mat-icon>
     Edit
   </a>
-  <a href="{{challenge.websiteUrl}}" class="stat-item action-btn" *ngIf="!loggedIn">
+  <a target="_blank" href="{{challenge.websiteUrl}}" class="stat-item action-btn" *ngIf="!loggedIn">
     <mat-icon aria-hidden="true" class="stats-card-icon">open_in_new</mat-icon> 
     Go to Website
   </a>

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
@@ -1,6 +1,6 @@
 <section id="landing" class="mat-typography">
-  <div class="container">
-    <div class="landing-content">
+  <div class="container row">
+    <div class="col-8">
       <h1>
         I want to find challenges related to
         <ngx-typed-js
@@ -13,14 +13,14 @@
           <span class="typing"></span>
         </ngx-typed-js>
       </h1>
-      <p class="mat-body-strong about-rocc">
+      <p class="mat-body-strong">
         OpenChallenges strives to provide a centralized hub of biomedical challenges from various
         hosting organizations. Our goal is to empower both participants with the most up-to-date 
         information about relevant challenges, as well as organizers with standardized challenge
         templates and intelligence.
       </p>
     </div>
-    <div class="img">
+    <div class="col-4">
       <img [src]="(searchOC$ | async)?.url" alt="Search OpenChallenges">
     </div>
   </div>

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
@@ -1,6 +1,5 @@
+@use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 $primary-color: #4950f6;
-$screen-sm: 481px;
-$screen-lg: 641px;
 
 // TAGS
 a, .typing {
@@ -20,7 +19,7 @@ a:active {
   margin: 0 auto;
   padding: 0 16px;
 }
-@media (min-width: $screen-sm) {
+@media (min-width: constants.$sm-breakpoint) {
   .container{
     padding: 0 24px;
   }
@@ -39,17 +38,25 @@ a:active {
 
 // SECTION: landing
 #landing {
-  height: 40vh;
+  height: 100%;
+  
   padding: 140px 64px 72px;
   background-color: #F8F8F8;
+
+  img {
+    max-height: min-content;
+    padding-left: 60px;
+  }
 }
 #search-oc {
   text-align: center;
   padding: 128px 0;
 }
 
-@media (min-width: $screen-sm) {
+@media only screen and (max-width: constants.$lg-breakpoint) {
   #landing {
-    height: 100%;
+    img {
+      display: none;
+    }
   }
 }

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.scss
@@ -40,7 +40,7 @@ a:active {
 // SECTION: landing
 #landing {
   height: 40vh;
-  padding: 210px 64px 72px;
+  padding: 140px 64px 72px;
   background-color: #F8F8F8;
 }
 #search-oc {

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -9,7 +9,7 @@
       </div>
       <div class="col text-center">
         <img class="logo-icon" [src]="(orgs$ | async)?.url" alt="Number of hosts & organizations" />
-        <h2 [countUp]="238">0</h2>
+        <h2 [countUp]="227">0</h2>
         <p>organizations & hosting societies</p>
       </div>
       <div class="col text-center">

--- a/libs/openchallenges/org-profile/src/lib/_org-profile-theme.scss
+++ b/libs/openchallenges/org-profile/src/lib/_org-profile-theme.scss
@@ -35,12 +35,14 @@
     border-color: transparent;
     &:focus,
     &:hover {
-      background-color: map.get($figma, dl-color-default-hover2);
+      background-color: map.get($figma, dl-color-default-primary1);
+      color: white;
     }
     color: black;
   }
   .profile-nav-item.active-tab {
-    background-color: map.get($figma, dl-color-default-hover2);
+    background-color: map.get($figma, dl-color-default-navbardark);
+    color: white;
   }
 
   @media (max-width: 479px) {

--- a/libs/openchallenges/org-profile/src/lib/org-profile-stats/org-profile-stats.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-stats/org-profile-stats.component.html
@@ -10,7 +10,7 @@
   <!-- <div class="stat-item action-btn" *ngIf="loggedIn">
     <mat-icon aria-hidden="true" class="stats-card-icon">edit</mat-icon> Edit Profile
   </div> -->
-  <a href="{{ org.websiteUrl }}" class="stat-item action-btn" *ngIf="loggedIn">
+  <a target="_blank" href="{{ org.websiteUrl }}" class="stat-item action-btn" *ngIf="loggedIn">
       <mat-icon aria-hidden="true" class="stats-card-icon">open_in_new</mat-icon>
       Go to Website
   </a>

--- a/libs/openchallenges/org-search/src/lib/org-search.component.scss
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.scss
@@ -15,6 +15,13 @@
 ::ng-deep .p-dropdown {
   width: 14rem;
 }
+::ng-deep .p-field-checkbox {
+  margin-bottom: 8px;
+
+  label {
+    cursor: pointer;
+  }
+}
 ::ng-deep .p-radiobutton.p-component,
 ::ng-deep .p-checkbox.p-component {
   margin-right: 8px;

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -3,7 +3,7 @@
     <img class="logo-icon" [src]="(logo$ | async)?.url" alt="OpenChallenges Icon" />
     <h2>Meet Our Team</h2>
     <p class="mat-body-strong">
-      We're smart, we're hard-working, and we love a <em>good challenge</em>.
+      We're smart, we're hard-working, and we love <em>a good challenge</em>.
     </p>
   </div>
   <div class="member-group">
@@ -11,6 +11,11 @@
       <img class="member-pic" [src]="(thomas$ | async)?.url" alt="Thomas Schaffter" />
       <h3 class="card-name">Thomas Schaffter</h3>
       <p class="card-roles">Project lead, Architect, Backend developer</p>
+    </div>
+    <div class="member-card">
+      <img class="member-pic" [src]="(maria$ | async)?.url" alt="Maria Diaz" />
+      <h3 class="card-name">Maria Diaz</h3>
+      <p class="card-roles">Backend developer</p>
     </div>
     <div class="member-card">
       <img class="member-pic" [src]="(rong$ | async)?.url" alt="Rong Chai" />
@@ -21,11 +26,6 @@
       <img class="member-pic" [src]="(verena$ | async)?.url" alt="Verena Chung" />
       <h3 class="card-name">Verena Chung</h3>
       <p class="card-roles">Frontend developer</p>
-    </div>
-    <div class="member-card">
-      <img class="member-pic" [src]="(maria$ | async)?.url" alt="Maria Diaz" />
-      <h3 class="card-name">Maria Diaz</h3>
-      <p class="card-roles">Backend developer</p>
     </div>
   </div>
   <div class="member-group">

--- a/libs/openchallenges/team/src/lib/team.component.scss
+++ b/libs/openchallenges/team/src/lib/team.component.scss
@@ -5,7 +5,7 @@
 }
 .member-group {
   width: 100%;
-  padding: 80px 0;
+  padding: 56px 0;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/libs/openchallenges/themes/src/_fonts.scss
+++ b/libs/openchallenges/themes/src/_fonts.scss
@@ -12,8 +12,8 @@ $lato: mat.define-typography-config(
   $headline-6: mat.define-typography-level(40px, 50px, 700, "'Lato', sans-serif"),
   $subtitle-1: mat.define-typography-level(28px, 38px, 700, "'Lato', sans-serif", -0.1px),
   $subtitle-2: mat.define-typography-level(18px, 30px, 400, "'Lato', sans-serif", -0.1px),
-  $body-1: mat.define-typography-level(21px, 32px, 400, "'Lato', sans-serif", -0.1px),
-  $body-2: mat.define-typography-level(18px, 32px, 400, "'Lato', sans-serif"),
-  $caption: mat.define-typography-level(15px, 21px, 400, "'Lato', sans-serif"),
+  $body-1: mat.define-typography-level(21px, 36px, 400, "'Lato', sans-serif", -0.1px),
+  $body-2: mat.define-typography-level(16px, 26px, 400, "'Lato', sans-serif"),
+  $caption: mat.define-typography-level(14px, 21px, 400, "'Lato', sans-serif"),
   $button: mat.define-typography-level(16px, 18px, 400, "'Lato', sans-serif"),
 );


### PR DESCRIPTION
Fixes #1519 
Fixes #1521 
(more to come)

## Changelog

The next iteration on the ongoing effort of cleaning up the UI, including:

* adding DOI as a link to the challenge profile page
* utilizing the primary color for active/hover tabs
* decreasing the body text size (18px looked comically big on a smaller laptop screen)
* ...

## Preview

* Home page
<img width="1235" alt="Screen Shot 2023-05-10 at 1 48 05 AM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/c41f3bd5-6362-4757-91c6-275d760f9b26">

* Profile page
<img width="1150" alt="Screen Shot 2023-05-10 at 1 48 56 AM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/fe63b863-75b2-4044-a8c9-65fec89683a1">
