### PR TITLE
feat: Get challenge and org counts from the backend

### DIFF
--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -3,17 +3,21 @@
     <h3 class="section-title">Current Landscape</h3>
     <div class="row">
       <div class="col text-center">
-        <img class="logo-icon" [src]="(challenges$ | async)?.url" alt="Number of challenges" />
-        <h2 [countUp]="166">0</h2>
+        <img class="logo-icon" [src]="(challengeImg$ | async)?.url" alt="Number of challenges" />
+        <h2 *ngIf="challengeCount$ | async as challengeCount" [countUp]="challengeCount">0</h2>
         <p>annotated challenges</p>
       </div>
       <div class="col text-center">
-        <img class="logo-icon" [src]="(orgs$ | async)?.url" alt="Number of hosts & organizations" />
-        <h2 [countUp]="227">0</h2>
+        <img
+          class="logo-icon"
+          [src]="(orgImg$ | async)?.url"
+          alt="Number of organizations & hosting societies"
+        />
+        <h2 *ngIf="orgCount$ | async as orgCount" [countUp]="orgCount">0</h2>
         <p>organizations & hosting societies</p>
       </div>
       <div class="col text-center">
-        <img class="logo-icon" [src]="(users$ | async)?.url" alt="Number of users" />
+        <img class="logo-icon" [src]="(userImg$ | async)?.url" alt="Number of users" />
         <h2 [countUp]="3">0</h2>
         <p>registered users</p>
       </div>

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import {
+  ChallengeSearchQuery,
+  ChallengeService,
   Image,
+  ImageHeight,
   ImageService,
+  OrganizationSearchQuery,
+  OrganizationService,
 } from '@sagebionetworks/openchallenges/api-client-angular';
-import {
-  Registry,
-  RegistryService,
-} from '@sagebionetworks/openchallenges/api-client-angular-deprecated';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-statistics-viewer',
@@ -15,27 +16,47 @@ import { Observable } from 'rxjs';
   styleUrls: ['./statistics-viewer.component.scss'],
 })
 export class StatisticsViewerComponent implements OnInit {
-  public challenges$: Observable<Image> | undefined;
-  public orgs$: Observable<Image> | undefined;
-  public users$: Observable<Image> | undefined;
-  registry$!: Observable<Registry>;
+  challengeImg$: Observable<Image> | undefined;
+  orgImg$: Observable<Image> | undefined;
+  userImg$: Observable<Image> | undefined;
+
+  private imgHeight = ImageHeight._140px;
+
+  challengeCount$: Observable<number> | undefined;
+  orgCount$: Observable<number> | undefined;
 
   constructor(
-    private registryService: RegistryService,
-    private imageService: ImageService
-  ) {
-    this.registry$ = this.registryService.getRegistry();
-  }
+    private imageService: ImageService,
+    private challengeService: ChallengeService,
+    private organizationService: OrganizationService
+  ) {}
 
   ngOnInit() {
-    this.challenges$ = this.imageService.getImage({
+    this.challengeImg$ = this.imageService.getImage({
       objectKey: 'home-challenges.svg',
+      height: this.imgHeight,
     });
-    this.orgs$ = this.imageService.getImage({
+    this.orgImg$ = this.imageService.getImage({
       objectKey: 'home-hosts.svg',
+      height: this.imgHeight,
     });
-    this.users$ = this.imageService.getImage({
+    this.userImg$ = this.imageService.getImage({
       objectKey: 'home-users.svg',
+      height: this.imgHeight,
     });
+
+    this.challengeCount$ = this.challengeService
+      .listChallenges({
+        pageNumber: 1,
+        pageSize: 1,
+      } as ChallengeSearchQuery)
+      .pipe(map((page) => page.totalElements));
+
+    this.orgCount$ = this.organizationService
+      .listOrganizations({
+        pageNumber: 1,
+        pageSize: 1,
+      } as OrganizationSearchQuery)
+      .pipe(map((page) => page.totalElements));
   }
 }


### PR DESCRIPTION
Closes #1468

## Changelog

- Home page: fetch challenge and org counts from the backend
- Download the images that illustrate the counts at the size they are used

## Notes

- The user count remains hardcoded as the user service will not be available for the preview.

## Preview

<img width="1150" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/cf1e1c15-779c-43d1-a4c9-bd2f46f8aacd">