### PR TITLE
fix: Validate image object key values

### DIFF
--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/BadRequestException.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package org.sagebionetworks.openchallenges.image.service.exception;
+
+public class BadRequestException extends SimpleChallengeGlobalException {
+  public BadRequestException(String detail) {
+    super(
+        ErrorConstants.BAD_REQUEST.getType(),
+        ErrorConstants.BAD_REQUEST.getTitle(),
+        ErrorConstants.BAD_REQUEST.getStatus(),
+        detail);
+  }
+}

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/ControllerAdvisor.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/ControllerAdvisor.java
@@ -1,0 +1,40 @@
+package org.sagebionetworks.openchallenges.image.service.exception;
+
+import org.sagebionetworks.openchallenges.image.service.model.dto.BasicErrorDto;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class ControllerAdvisor extends ResponseEntityExceptionHandler {
+
+  @Override
+  protected ResponseEntity<Object> handleBindException(
+      BindException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+
+    BindingResult result = ex.getBindingResult();
+    FieldError fieldError = result.getFieldErrors().get(0);
+
+    BadRequestException exception =
+        new BadRequestException(
+            String.format(
+                "Invalid value '%s' for for property '%s'",
+                fieldError.getRejectedValue(), fieldError.getField()));
+
+    BasicErrorDto error =
+        BasicErrorDto.builder()
+            .title(exception.getTitle())
+            .status(exception.getStatus().value())
+            .detail(exception.getDetail())
+            .type(exception.getType())
+            .build();
+
+    return new ResponseEntity<Object>(error, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/ErrorConstants.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/ErrorConstants.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorConstants {
   IMAGE_HEIGHT_NOT_SPECIFIED(
       "IMAGE-SERVICE-1000", "Image height not found", HttpStatus.BAD_REQUEST),
-  BAD_REQUEST("IMAGE-SERVICE-1001", "Bad Request", HttpStatus.BAD_REQUEST);
+  BAD_REQUEST("IMAGE-SERVICE-1001", "Bad request", HttpStatus.BAD_REQUEST);
 
   private String type;
   private String title;

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/ErrorConstants.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/exception/ErrorConstants.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorConstants {
   IMAGE_HEIGHT_NOT_SPECIFIED(
-      "IMAGE-SERVICE-1000", "Image height not found", HttpStatus.BAD_REQUEST);
+      "IMAGE-SERVICE-1000", "Image height not found", HttpStatus.BAD_REQUEST),
+  BAD_REQUEST("IMAGE-SERVICE-1001", "Bad Request", HttpStatus.BAD_REQUEST);
 
   private String type;
   private String title;

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/ImageQueryDto.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/ImageQueryDto.java
@@ -31,15 +31,16 @@ public class ImageQueryDto {
   }
 
   /**
-   * The object key of the image.
+   * The unique identifier of the image.
    *
    * @return objectKey
    */
   @NotNull
+  @Pattern(regexp = "^[a-zA-Z0-9/_-]+.[a-zA-Z0-9/_-]+")
   @Schema(
       name = "objectKey",
       example = "logo/dream.png",
-      description = "The object key of the image.",
+      description = "The unique identifier of the image.",
       required = true)
   public String getObjectKey() {
     return objectKey;

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
@@ -39,6 +39,8 @@ public class ImageService {
           "Image height must also be specified when specifying the aspect ratio.");
     }
 
+    LOG.info("Requesting an image url for the objectId: {}", query.getObjectKey());
+
     ThumborUrlBuilder builder = thumbor.buildImage(query.getObjectKey());
     Integer height = getImageHeightInPx(query.getHeight());
 

--- a/apps/openchallenges/image-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/image-service/src/main/resources/openapi.yaml
@@ -80,6 +80,11 @@ components:
             $ref: '#/components/schemas/BasicError'
       description: The request cannot be fulfilled due to an unexpected server error
   schemas:
+    ImageKey:
+      description: The unique identifier of the image.
+      example: logo/dream.png
+      pattern: "^[a-zA-Z0-9\\/_-]+.[a-zA-Z0-9\\/_-]+"
+      type: string
     ImageHeight:
       default: original
       description: The height of the image.
@@ -105,8 +110,9 @@ components:
       description: An image query.
       properties:
         objectKey:
-          description: The object key of the image.
+          description: The unique identifier of the image.
           example: logo/dream.png
+          pattern: "^[a-zA-Z0-9\\/_-]+.[a-zA-Z0-9\\/_-]+"
           type: string
         height:
           $ref: '#/components/schemas/ImageHeight'

--- a/libs/openchallenges/api-description/build/image.openapi.yaml
+++ b/libs/openchallenges/api-description/build/image.openapi.yaml
@@ -38,6 +38,11 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
+    ImageKey:
+      description: The unique identifier of the image.
+      type: string
+      example: logo/dream.png
+      pattern: ^[a-zA-Z0-9\/_-]+.[a-zA-Z0-9\/_-]+
     ImageHeight:
       description: The height of the image.
       type: string
@@ -63,9 +68,7 @@ components:
       description: An image query.
       properties:
         objectKey:
-          description: The object key of the image.
-          type: string
-          example: logo/dream.png
+          $ref: '#/components/schemas/ImageKey'
         height:
           $ref: '#/components/schemas/ImageHeight'
         aspectRatio:

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -812,6 +812,11 @@ components:
             - challengePlatforms
       x-java-class-annotations:
         - '@lombok.Builder'
+    ImageKey:
+      description: The unique identifier of the image.
+      type: string
+      example: logo/dream.png
+      pattern: '^[a-zA-Z0-9\/_-]+.[a-zA-Z0-9\/_-]+'
     ImageHeight:
       description: The height of the image.
       type: string
@@ -839,9 +844,7 @@ components:
       description: An image query.
       properties:
         objectKey:
-          description: The object key of the image.
-          type: string
-          example: logo/dream.png
+          $ref: '#/components/schemas/ImageKey'
         height:
           $ref: '#/components/schemas/ImageHeight'
         aspectRatio:

--- a/libs/openchallenges/api-description/src/components/schemas/ImageKey.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ImageKey.yaml
@@ -1,4 +1,4 @@
 description: The unique identifier of the image.
 type: string
-example: logo/openchallenges.png
+example: logo/dream.png
 pattern: ^[a-zA-Z0-9\/_-]+.[a-zA-Z0-9\/_-]+

--- a/libs/openchallenges/api-description/src/components/schemas/ImageKey.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ImageKey.yaml
@@ -1,3 +1,4 @@
 description: The unique identifier of the image.
 type: string
 example: logo/openchallenges.png
+pattern: ^[a-zA-Z0-9\/_-]+.[a-zA-Z0-9\/_-]+

--- a/libs/openchallenges/api-description/src/components/schemas/ImageQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ImageQuery.yaml
@@ -2,9 +2,7 @@ type: object
 description: An image query.
 properties:
   objectKey:
-    description: The object key of the image.
-    type: string
-    example: logo/dream.png
+    $ref: ImageKey.yaml
   height:
     $ref: ImageHeight.yaml
   aspectRatio:


### PR DESCRIPTION
Fixes #1552

## Changelog

- Validate the API property `ImageQuery.objectKey`

## Note

- We should validate the data at multiple level. One of them should be before and/or when we dump the data to the DB.

## Preview

The image service now shows an error (actually a warning?) in the logs when an invalid object key is specified (validation code automatically generated).

```console
2023-05-16 02:44:50.747  WARN [openchallenges-image-service,fb5b88b51f1090a1,fb5b88b51f1090a1] 18985 --- [nio-8086-exec-8] .m.m.a.ExceptionHandlerExceptionResolver : Resolved [org.springframework.validation.BindException: org.springframework.validation.BeanPropertyBindingResult: 1 errors<EOL>Field error in object 'imageQueryDto' on field 'objectKey': rejected value [logo/texas_biomed_2.png, tx_biomed1.png]; codes [Pattern.imageQueryDto.objectKey,Pattern.objectKey,Pattern.java.lang.String,Pattern]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [imageQueryDto.objectKey,objectKey]; arguments []; default message [objectKey],[Ljavax.validation.constraints.Pattern$Flag;@4a2949b4,^[a-zA-Z0-9/_-]+.[a-zA-Z0-9/_-]+]; default message [must match "^[a-zA-Z0-9/_-]+.[a-zA-Z0-9/_-]+"]]
```

By default, the error returned has a 400 code with not other useful information:

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/14fa687e-0820-452e-9e65-4caff51a1e3f)

The solution found a few sprints ago for the challenge service was to define a `@ControllerAdvice`. The same request now returns the following info:

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/c2fc704c-2bb3-4d54-84da-5ced907ffdaf)
