### PR TITLE
feat:  Deploy mock microservices with CDKTF and AWS Fargate

### DIFF
--- a/apps/openchallenges/infra/src/ecs/ecs-service-client.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-service-client.ts
@@ -1,0 +1,43 @@
+import { EcsService } from '@cdktf/provider-aws/lib/ecs-service';
+import { Subnet } from '@cdktf/provider-aws/lib/subnet';
+import { Construct } from 'constructs';
+
+export class EcsServiceClient extends Construct {
+  service: EcsService;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    clusterArn: string,
+    taskDefinitionArn: string,
+    targetGroupArn: string,
+    subnets: Subnet[],
+    clientSecurityGroupId: string
+  ) {
+    super(scope, id);
+
+    const nameTagPrefix = 'openchallenges';
+
+    this.service = new EcsService(this, id, {
+      name: `${nameTagPrefix}-client`,
+      cluster: clusterArn,
+      taskDefinition: taskDefinitionArn,
+      desiredCount: 1,
+      launchType: 'FARGATE',
+
+      loadBalancer: [
+        {
+          targetGroupArn,
+          containerName: 'client',
+          containerPort: 9090,
+        },
+      ],
+
+      networkConfiguration: {
+        subnets: subnets.map((subnet) => subnet.id),
+        assignPublicIp: false,
+        securityGroups: [clientSecurityGroupId],
+      },
+    });
+  }
+}

--- a/apps/openchallenges/infra/src/ecs/ecs-service-upstream.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-service-upstream.ts
@@ -1,0 +1,43 @@
+import { EcsService } from '@cdktf/provider-aws/lib/ecs-service';
+import { Subnet } from '@cdktf/provider-aws/lib/subnet';
+import { Construct } from 'constructs';
+
+export class EcsServiceUpstream extends Construct {
+  service: EcsService;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    clusterArn: string,
+    taskDefinitionArn: string,
+    targetGroupArn: string,
+    subnets: Subnet[],
+    securityGroupId: string
+  ) {
+    super(scope, id);
+
+    const nameTagPrefix = 'openchallenges';
+
+    this.service = new EcsService(this, id, {
+      name: `${nameTagPrefix}-${id}`,
+      cluster: clusterArn,
+      taskDefinition: taskDefinitionArn,
+      desiredCount: 1,
+      launchType: 'FARGATE',
+
+      loadBalancer: [
+        {
+          targetGroupArn,
+          containerName: id,
+          containerPort: 9090,
+        },
+      ],
+
+      networkConfiguration: {
+        subnets: subnets.map((subnet) => subnet.id),
+        assignPublicIp: false,
+        securityGroups: [securityGroupId],
+      },
+    });
+  }
+}

--- a/apps/openchallenges/infra/src/ecs/ecs-task-definition-client.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-task-definition-client.ts
@@ -1,0 +1,66 @@
+import { Construct } from 'constructs';
+import { EcsTaskDefinition } from '@cdktf/provider-aws/lib/ecs-task-definition';
+import { Fn } from 'cdktf';
+
+export class EcsTaskDefinitionClient extends Construct {
+  definition: EcsTaskDefinition;
+
+  constructor(scope: Construct, id: string, upstreamUriString: string) {
+    super(scope, id);
+
+    const nameTagPrefix = 'openchallenges';
+
+    this.definition = new EcsTaskDefinition(this, 'task_definition', {
+      family: `${nameTagPrefix}-client`,
+      memory: '512',
+      cpu: '256',
+      networkMode: 'awsvpc',
+
+      containerDefinitions: Fn.jsonencode([
+        {
+          name: 'client',
+          image: 'nicholasjackson/fake-service:v0.23.1',
+          cpu: 0,
+          essential: true,
+
+          portMappings: [
+            {
+              containerPort: 9090,
+              hostPort: 9090,
+              protocol: 'tcp',
+            },
+          ],
+
+          environment: [
+            {
+              name: 'NAME',
+              value: 'client',
+            },
+            {
+              name: 'MESSAGE',
+              value: 'Hello World from the client!',
+            },
+            {
+              name: 'UPSTREAM_URIS',
+              value: upstreamUriString,
+            },
+          ],
+        },
+        // {
+        //   name: 'datadog-agent',
+        //   image: 'public.ecr.aws/datadog/agent:latest',
+        //   environment: [
+        //     {
+        //       name: 'DD_API_KEY',
+        //       value: `${process.env.DD_API_KEY}`,
+        //     },
+        //     {
+        //       name: 'ECS_FARGATE',
+        //       value: 'true', // https://github.com/aws/amazon-ecs-agent/issues/2571, seems that unmarshal in Go doesn't allow for straight booleans
+        //     },
+        //   ],
+        // },
+      ]),
+    });
+  }
+}

--- a/apps/openchallenges/infra/src/ecs/ecs-task-definition-gold.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-task-definition-gold.ts
@@ -5,7 +5,7 @@ import { Fn } from 'cdktf';
 export class EcsTaskDefinitionGold extends Construct {
   definition: EcsTaskDefinition;
 
-  constructor(scope: Construct, id: string, executionRoleArn: string) {
+  constructor(scope: Construct, id: string) {
     super(scope, id);
 
     const nameTagPrefix = 'openchallenges';
@@ -15,7 +15,6 @@ export class EcsTaskDefinitionGold extends Construct {
       memory: '512',
       cpu: '256',
       networkMode: 'awsvpc',
-      executionRoleArn,
 
       containerDefinitions: Fn.jsonencode([
         {

--- a/apps/openchallenges/infra/src/ecs/ecs-task-definition-gold.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-task-definition-gold.ts
@@ -1,0 +1,67 @@
+import { Construct } from 'constructs';
+import { EcsTaskDefinition } from '@cdktf/provider-aws/lib/ecs-task-definition';
+import { Fn } from 'cdktf';
+
+export class EcsTaskDefinitionGold extends Construct {
+  definition: EcsTaskDefinition;
+
+  constructor(scope: Construct, id: string, executionRoleArn: string) {
+    super(scope, id);
+
+    const nameTagPrefix = 'openchallenges';
+
+    this.definition = new EcsTaskDefinition(this, 'task_definition', {
+      family: `${nameTagPrefix}-gold`,
+      memory: '512',
+      cpu: '256',
+      networkMode: 'awsvpc',
+      executionRoleArn,
+
+      containerDefinitions: Fn.jsonencode([
+        {
+          name: 'gold',
+          image: 'nicholasjackson/fake-service:v0.23.1',
+          cpu: 0,
+          essential: true,
+
+          portMappings: [
+            {
+              containerPort: 9090,
+              hostPort: 9090,
+              protocol: 'tcp',
+            },
+          ],
+
+          environment: [
+            {
+              name: 'NAME',
+              value: 'gold',
+            },
+            {
+              name: 'MESSAGE',
+              value: 'Hello World from the gold service!',
+            },
+            {
+              name: 'UPSTREAM_URIS',
+              value: `http://10.0.32.253:27017`,
+            },
+          ],
+        },
+        // {
+        //   name: 'datadog-agent',
+        //   image: 'public.ecr.aws/datadog/agent:latest',
+        //   environment: [
+        //     {
+        //       name: 'DD_API_KEY',
+        //       value: `${process.env.DD_API_KEY}`,
+        //     },
+        //     {
+        //       name: 'ECS_FARGATE',
+        //       value: 'true', // https://github.com/aws/amazon-ecs-agent/issues/2571, seems that unmarshal in Go doesn't allow for straight booleans
+        //     },
+        //   ],
+        // },
+      ]),
+    });
+  }
+}

--- a/apps/openchallenges/infra/src/ecs/ecs-task-definition-silver.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-task-definition-silver.ts
@@ -1,0 +1,67 @@
+import { Construct } from 'constructs';
+import { EcsTaskDefinition } from '@cdktf/provider-aws/lib/ecs-task-definition';
+import { Fn } from 'cdktf';
+
+export class EcsTaskDefinitionGold extends Construct {
+  definition: EcsTaskDefinition;
+
+  constructor(scope: Construct, id: string, executionRoleArn: string) {
+    super(scope, id);
+
+    const nameTagPrefix = 'openchallenges';
+
+    this.definition = new EcsTaskDefinition(this, 'task_definition', {
+      family: `${nameTagPrefix}-silver`,
+      memory: '512',
+      cpu: '256',
+      networkMode: 'awsvpc',
+      executionRoleArn,
+
+      containerDefinitions: Fn.jsonencode([
+        {
+          name: 'silver',
+          image: 'nicholasjackson/fake-service:v0.23.1',
+          cpu: 0,
+          essential: true,
+
+          portMappings: [
+            {
+              containerPort: 9090,
+              hostPort: 9090,
+              protocol: 'tcp',
+            },
+          ],
+
+          environment: [
+            {
+              name: 'NAME',
+              value: 'silver',
+            },
+            {
+              name: 'MESSAGE',
+              value: 'Hello World from the silver service!',
+            },
+            {
+              name: 'UPSTREAM_URIS',
+              value: `http://10.0.32.253:27017`,
+            },
+          ],
+        },
+        // {
+        //   name: 'datadog-agent',
+        //   image: 'public.ecr.aws/datadog/agent:latest',
+        //   environment: [
+        //     {
+        //       name: 'DD_API_KEY',
+        //       value: `${process.env.DD_API_KEY}`,
+        //     },
+        //     {
+        //       name: 'ECS_FARGATE',
+        //       value: 'true', // https://github.com/aws/amazon-ecs-agent/issues/2571, seems that unmarshal in Go doesn't allow for straight booleans
+        //     },
+        //   ],
+        // },
+      ]),
+    });
+  }
+}

--- a/apps/openchallenges/infra/src/ecs/ecs-task-definition-silver.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-task-definition-silver.ts
@@ -2,10 +2,10 @@ import { Construct } from 'constructs';
 import { EcsTaskDefinition } from '@cdktf/provider-aws/lib/ecs-task-definition';
 import { Fn } from 'cdktf';
 
-export class EcsTaskDefinitionGold extends Construct {
+export class EcsTaskDefinitionSilver extends Construct {
   definition: EcsTaskDefinition;
 
-  constructor(scope: Construct, id: string, executionRoleArn: string) {
+  constructor(scope: Construct, id: string) {
     super(scope, id);
 
     const nameTagPrefix = 'openchallenges';
@@ -15,7 +15,6 @@ export class EcsTaskDefinitionGold extends Construct {
       memory: '512',
       cpu: '256',
       networkMode: 'awsvpc',
-      executionRoleArn,
 
       containerDefinitions: Fn.jsonencode([
         {

--- a/apps/openchallenges/infra/src/main.ts
+++ b/apps/openchallenges/infra/src/main.ts
@@ -31,6 +31,10 @@ import { SecurityGroups } from './security-groups';
 import { EcsClientAlb, EcsCluster, EcsUpstreamServiceAlb } from './ecs';
 import { Database } from './ec2/database';
 import { EcsTaskDefinitionClient } from './ecs/ecs-task-definition-client';
+import { EcsServiceClient } from './ecs/ecs-service-client';
+import { EcsTaskDefinitionGold } from './ecs/ecs-task-definition-gold';
+import { EcsServiceUpstream } from './ecs/ecs-service-upstream';
+import { EcsTaskDefinitionSilver } from './ecs/ecs-task-definition-silver';
 
 class OpenChallengesStack extends SageStack {
   constructor(scope: Construct, id: string) {
@@ -111,16 +115,53 @@ class OpenChallengesStack extends SageStack {
       `http://${goldAlb.lb.dnsName},http://${silverAlb.lb.dnsName}`
     );
 
-    // new EcsServiceClient(
-    //   this,
-    //   'client',
-    //   vars,
-    //   cluster.arn,
-    //   clientTaskDefinition.def.arn,
-    //   clientAlb.targetGroup.arn,
-    //   vpc.privateSubnets,
-    //   securityGroups.clientService.id
-    // );
+    new EcsServiceClient(
+      this,
+      'client',
+      cluster.cluster.arn,
+      clientTaskDefinition.definition.arn,
+      clientAlb.targetGroup.arn,
+      network.privateSubnets,
+      securityGroups.clientServiceSg.id
+    );
+
+    // Gold Service Resources
+    const goldTaskDefinition = new EcsTaskDefinitionGold(
+      this,
+      'gold_task_definition'
+    );
+
+    new EcsServiceUpstream(
+      this,
+      'gold',
+      cluster.cluster.arn,
+      goldTaskDefinition.definition.arn,
+      goldAlb.targetGroup.arn,
+      network.privateSubnets,
+      securityGroups.upstreamServiceSg.id
+    );
+
+    // Silver Service Resources
+    const silverTaskDefinition = new EcsTaskDefinitionSilver(
+      this,
+      'silver_task_definition'
+    );
+
+    new EcsServiceUpstream(
+      this,
+      'silver',
+      cluster.cluster.arn,
+      silverTaskDefinition.definition.arn,
+      silverAlb.targetGroup.arn,
+      network.privateSubnets,
+      securityGroups.upstreamServiceSg.id
+    );
+
+    // Outputs
+    new TerraformOutput(this, 'client_service_endpoint', {
+      value: clientAlb.lb.dnsName,
+      description: 'DNS name (endpoint) of the AWS ALB for Client service',
+    });
 
     // new TerraformOutput(this, 'vpc_id', {
     //   value: network.vpc.id,

--- a/apps/openchallenges/infra/src/main.ts
+++ b/apps/openchallenges/infra/src/main.ts
@@ -30,6 +30,7 @@ import { Network } from './network/network';
 import { SecurityGroups } from './security-groups';
 import { EcsClientAlb, EcsCluster, EcsUpstreamServiceAlb } from './ecs';
 import { Database } from './ec2/database';
+import { EcsTaskDefinitionClient } from './ecs/ecs-task-definition-client';
 
 class OpenChallengesStack extends SageStack {
   constructor(scope: Construct, id: string) {
@@ -102,6 +103,24 @@ class OpenChallengesStack extends SageStack {
       securityGroups.databaseSg.id,
       network.natGateway
     );
+
+    // Client Service Resources
+    const clientTaskDefinition = new EcsTaskDefinitionClient(
+      this,
+      'client_task_definition',
+      `http://${goldAlb.lb.dnsName},http://${silverAlb.lb.dnsName}`
+    );
+
+    // new EcsServiceClient(
+    //   this,
+    //   'client',
+    //   vars,
+    //   cluster.arn,
+    //   clientTaskDefinition.def.arn,
+    //   clientAlb.targetGroup.arn,
+    //   vpc.privateSubnets,
+    //   securityGroups.clientService.id
+    // );
 
     // new TerraformOutput(this, 'vpc_id', {
     //   value: network.vpc.id,


### PR DESCRIPTION
Closes #1565 

## Changelog

- Deploy an ECS task for the client
- Deploy two ECS tasks for the gold and silver mock microservices

## Preview

```console
vscode@2d058f0500d9:/workspaces/sage-monorepo/apps/openchallenges/infra$ cdktf deploy
...

openchallenges-stack  aws_instance.database_7CF902CB (database/database): Still creating... [2m0s elapsed]
openchallenges-stack  aws_instance.database_7CF902CB (database/database): Still creating... [2m10s elapsed]
openchallenges-stack  aws_instance.database_7CF902CB (database/database): Still creating... [2m20s elapsed]
openchallenges-stack  aws_instance.database_7CF902CB (database/database): Creation complete after 2m22s [id=i-0357ca67cfd1653a2]
openchallenges-stack  Apply complete! Resources: 52 added, 0 changed, 0 destroyed.

                      Outputs:
                      client_service_endpoint = "cl-2023051704230436150000000f-750152857.us-east-1.elb.amazonaws.com"

  openchallenges-stack
  client_service_endpoint = cl-2023051704230436150000000f-750152857.us-east-1.elb.amazonaws.com
```

Navigating to the client endpoint:

```json
{
  "name": "client",
  "uri": "/",
  "type": "HTTP",
  "ip_addresses": [
    "169.254.172.2",
    "10.0.32.146"
  ],
  "start_time": "2023-05-17T04:31:46.023237",
  "end_time": "2023-05-17T04:31:46.034531",
  "duration": "11.294132ms",
  "body": "Hello World from the client!",
  "upstream_calls": {
    "http://internal-s-2023051704224472770000000a-1897987137.us-east-1.elb.amazonaws.com": {
      "name": "gold",
      "uri": "http://internal-s-2023051704224472770000000a-1897987137.us-east-1.elb.amazonaws.com",
      "type": "HTTP",
      "ip_addresses": [
        "169.254.172.2",
        "10.0.51.56"
      ],
      "start_time": "2023-05-17T04:31:46.027160",
      "end_time": "2023-05-17T04:31:46.030246",
      "duration": "3.085722ms",
      "headers": {
        "Content-Length": "861",
        "Content-Type": "text/plain; charset=utf-8",
        "Date": "Wed, 17 May 2023 04:31:46 GMT"
      },
      "body": "Hello World from the gold service!",
      "upstream_calls": {
        "http://10.0.32.253:27017": {
          "name": "database",
          "uri": "http://10.0.32.253:27017",
          "type": "HTTP",
          "ip_addresses": [
            "10.0.32.253"
          ],
          "start_time": "2023-05-17T04:31:46.037075",
          "end_time": "2023-05-17T04:31:46.037183",
          "duration": "107.816µs",
          "headers": {
            "Content-Length": "272",
            "Content-Type": "text/plain; charset=utf-8",
            "Date": "Wed, 17 May 2023 04:31:46 GMT"
          },
          "body": "'Hello from the Database'",
          "code": 200
        }
      },
      "code": 200
    },
    "http://internal-s-2023051704224498280000000b-307292449.us-east-1.elb.amazonaws.com": {
      "name": "silver",
      "uri": "http://internal-s-2023051704224498280000000b-307292449.us-east-1.elb.amazonaws.com",
      "type": "HTTP",
      "ip_addresses": [
        "169.254.172.2",
        "10.0.36.241"
      ],
      "start_time": "2023-05-17T04:31:46.032715",
      "end_time": "2023-05-17T04:31:46.034064",
      "duration": "1.34958ms",
      "headers": {
        "Content-Length": "864",
        "Content-Type": "text/plain; charset=utf-8",
        "Date": "Wed, 17 May 2023 04:31:46 GMT"
      },
      "body": "Hello World from the silver service!",
      "upstream_calls": {
        "http://10.0.32.253:27017": {
          "name": "database",
          "uri": "http://10.0.32.253:27017",
          "type": "HTTP",
          "ip_addresses": [
            "10.0.32.253"
          ],
          "start_time": "2023-05-17T04:31:46.041483",
          "end_time": "2023-05-17T04:31:46.041533",
          "duration": "49.922µs",
          "headers": {
            "Content-Length": "271",
            "Content-Type": "text/plain; charset=utf-8",
            "Date": "Wed, 17 May 2023 04:31:46 GMT"
          },
          "body": "'Hello from the Database'",
          "code": 200
        }
      },
      "code": 200
    }
  },
  "code": 200
}

```

> **Note** At first the client response indicated that it couldn't connect to the database. A few minutes later, I got the above successful output.