### PR TITLE
feat: Create a second deployment stack withing openchallenges-infra

### DIFF
--- a/apps/openchallenges/infra/src/ec2/single-stack-instance.ts
+++ b/apps/openchallenges/infra/src/ec2/single-stack-instance.ts
@@ -1,0 +1,36 @@
+import { Instance } from '@cdktf/provider-aws/lib/instance';
+import { Construct } from 'constructs';
+import { Ami } from '../constants';
+import { NatGateway } from '@cdktf/provider-aws/lib/nat-gateway';
+import { readFileSync } from 'fs';
+
+export class SingleStackInstance extends Construct {
+  instance: Instance;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    subnetId: string,
+    securityGroupId: string,
+    natGateway: NatGateway
+  ) {
+    super(scope, id);
+
+    const nameTagPrefix = 'openchallenges';
+
+    this.instance = new Instance(this, id, {
+      ami: Ami.UBUNTU_22_04_LTS,
+      instanceType: 't3.xlarge',
+      vpcSecurityGroupIds: [securityGroupId],
+      subnetId,
+      privateIp: '10.0.32.253', // TODO replace by config param
+      // privateIp: vars.databasePrivateIp,
+      tags: { Name: `${nameTagPrefix}-single-stack-instance` },
+      dependsOn: [natGateway],
+      userData: readFileSync(
+        './src/resources/scripts/single-stack-instance.sh',
+        'utf8'
+      ),
+    });
+  }
+}

--- a/apps/openchallenges/infra/src/ec2/single-stack-instance.ts
+++ b/apps/openchallenges/infra/src/ec2/single-stack-instance.ts
@@ -1,8 +1,10 @@
 import { Instance } from '@cdktf/provider-aws/lib/instance';
 import { Construct } from 'constructs';
-import { Ami } from '../constants';
+import { Ami, SageCostCenter } from '../constants';
 import { NatGateway } from '@cdktf/provider-aws/lib/nat-gateway';
 import { readFileSync } from 'fs';
+import { Aspects } from 'cdktf/lib/aspect';
+import { TagsAddingAspect } from '../tag/tags-adding-aspect';
 
 export class SingleStackInstance extends Construct {
   instance: Instance;
@@ -17,6 +19,7 @@ export class SingleStackInstance extends Construct {
     super(scope, id);
 
     const nameTagPrefix = 'openchallenges';
+    const stackOwnerEmail = 'thomas.schaffter@sagebionetworks.org';
 
     this.instance = new Instance(this, id, {
       ami: Ami.UBUNTU_22_04_LTS,
@@ -32,5 +35,13 @@ export class SingleStackInstance extends Construct {
         'utf8'
       ),
     });
+
+    // Add tags to every resource defined within this stack.
+    Aspects.of(this).add(
+      new TagsAddingAspect({
+        OwnerEmail: stackOwnerEmail,
+        CostCenter: SageCostCenter.ITCR,
+      })
+    );
   }
 }

--- a/apps/openchallenges/infra/src/main.ts
+++ b/apps/openchallenges/infra/src/main.ts
@@ -35,6 +35,7 @@ import { EcsServiceClient } from './ecs/ecs-service-client';
 import { EcsTaskDefinitionGold } from './ecs/ecs-task-definition-gold';
 import { EcsServiceUpstream } from './ecs/ecs-service-upstream';
 import { EcsTaskDefinitionSilver } from './ecs/ecs-task-definition-silver';
+import { OpenChallengesPreviewStack } from './stack/openchallenges-preview-stack';
 
 class OpenChallengesStack extends SageStack {
   constructor(scope: Construct, id: string) {
@@ -220,11 +221,21 @@ logger.info('Welcome to the deployment of the OpenChallenges stack.');
 
 const app = new App();
 const stack = new OpenChallengesStack(app, 'openchallenges-stack');
+const openchallengesPreviewStack = new OpenChallengesPreviewStack(
+  app,
+  'openchallenges-preview'
+);
 
 new CloudBackend(stack, {
   hostname: 'app.terraform.io',
   organization: 'sagebionetworks',
   workspaces: new NamedCloudWorkspace('openchallenges-test'),
+});
+
+new CloudBackend(openchallengesPreviewStack, {
+  hostname: 'app.terraform.io',
+  organization: 'sagebionetworks',
+  workspaces: new NamedCloudWorkspace('openchallenges-preview'),
 });
 
 app.synth();

--- a/apps/openchallenges/infra/src/resources/scripts/single-stack-instance.sh
+++ b/apps/openchallenges/infra/src/resources/scripts/single-stack-instance.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+apt update && apt install -y unzip
+
+# # Install Fake Service
+# curl -LO https://github.com/nicholasjackson/fake-service/releases/download/v0.23.1/fake_service_linux_amd64.zip
+# unzip fake_service_linux_amd64.zip
+# mv fake-service /usr/local/bin
+# chmod +x /usr/local/bin/fake-service
+
+# # Fake Service Systemd Unit File
+# cat > /etc/systemd/system/database.service <<- EOF
+# [Unit]
+# Description=Database
+# After=syslog.target network.target
+# [Service]
+# Environment="MESSAGE='Hello from the Database'"
+# Environment="NAME=database"
+# Environment="LISTEN_ADDR=0.0.0.0:27017"
+# ExecStart=/usr/local/bin/fake-service
+# ExecStop=/bin/sleep 5
+# Restart=always
+# [Install]
+# WantedBy=multi-user.target
+# EOF
+
+# # Reload unit files and start the database service
+# systemctl daemon-reload
+# systemctl start database

--- a/apps/openchallenges/infra/src/stack/openchallenges-preview-stack.ts
+++ b/apps/openchallenges/infra/src/stack/openchallenges-preview-stack.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-new */
+import { Construct } from 'constructs';
+import { SageStack } from './sage-stack';
+import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
+import { AmazonRegion } from '../constants';
+import { NetworkConfig } from '../network/network-config';
+import { Network } from '../network/network';
+import { SingleStackInstance } from '../ec2/single-stack-instance';
+
+export class OpenChallengesPreviewStack extends SageStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // const keyPath = `${os.homedir()}/.ssh/openchallenges-ec2.pub`;
+    // const publicKey = fs.readFileSync(keyPath, 'utf-8');
+    // const keyName = 'openchallenges-ec2-key';
+    // const stackOwnerEmail = 'thomas.schaffter@sagebionetworks.org';
+
+    new AwsProvider(this, 'AWS', {
+      region: AmazonRegion.US_EAST_1,
+    });
+
+    const networkConfig = new NetworkConfig({
+      defaultRegion: AmazonRegion.US_EAST_1,
+      tagPrefix: 'openchallenges',
+      vpcCirdBlock: '10.0.0.0/16',
+    });
+
+    const network = new Network(this, 'network', networkConfig);
+
+    // const securityGroups = new SecurityGroups(
+    //   this,
+    //   'security_groups',
+    //   network.vpc.id
+    // );
+
+    // new SingleStackInstance(
+    //   this,
+    //   'single_stack_instance',
+    //   // vars,
+    //   network.privateSubnets[0].id,
+    //   securityGroups.databaseSg.id,
+    //   network.natGateway
+    // );
+  }
+}


### PR DESCRIPTION
Closes #1578

## Changelog

- Add a second CDKTF stack to separate the long-term stack from the preview stack

## Preview

Build the Terraform configuration files for all stacks:

```console
cdktf synth
```

Deploy the new stack:

```console
cdktf deploy openchallenges-preview
```