### PR TITLE
feat: Preload devcontainer with Python 3.11.0

### DIFF
--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -101,8 +101,8 @@ RUN useradd -m $user \
     "" \
     "export PYENV_ROOT=\"\$HOME/.pyenv\"" \
     "export PATH=\"\$PYENV_ROOT/bin:\$PATH\"" \
-    "eval \"$(pyenv init --path)\"" \
-    "eval \"$(pyenv virtualenv-init -)\"" \
+    "eval \"\$(pyenv init --path)\"" \
+    "eval \"\$(pyenv virtualenv-init -)\"" \
     "" \
     "# source dev-env.sh if found in the current directory" \
     "if [ -f dev-env.sh ]; then" \


### PR DESCRIPTION
Installing a Python environment may take more than 1 min (depends on compute resources and internet bandwidth). The time required to perform this action is larger than the time required to download a slightly larger devcontainer image that is preloaded with the environment. For this reason, the Sage devcontainer now accepts multiple Python environment to be included in its image (up to a limit). 

```console
$ time pyenv install 3.11.0
...
real    1m31.234s
```