### PR TITLE
feat: Add Python 3.11.0 to the devcontainer (take 2)

### DIFF
--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -99,8 +99,8 @@ RUN useradd -m $user \
   && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
   && printf "%s\n" \
     "" \
-    "export PYENV_ROOT=\"\$HOME/.pyenv\"" \
-    "export PATH=\"\$PYENV_ROOT/bin:\$PATH\"" \
+    "#export PYENV_ROOT=\"\$HOME/.pyenv\"" \
+    "#export PATH=\"\$PYENV_ROOT/bin:\$PATH\"" \
     "eval \"\$(pyenv init --path)\"" \
     "eval \"\$(pyenv virtualenv-init -)\"" \
     "" \
@@ -115,5 +115,10 @@ USER $user
 
 # Install pyenv as the user
 RUN curl https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash -
+
+## Install Python environments
+ENV PYENV_ROOT /home/${user}/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+RUN pyenv install 3.11.0
 
 CMD ["bash"]


### PR DESCRIPTION
Installing a Python environment may take more than 1 min (depends on compute resources and internet bandwidth). The time required to perform this action is larger than the time required to download a slightly larger devcontainer image that is preloaded with the environment. For this reason, the Sage devcontainer now accepts multiple Python environment to be included in its image (up to a limit). 

```console
$ time pyenv install 3.11.0
...
real    1m31.234s
```