### PR TITLE
chore: Set OpenChallenges VPC CIDR to 10.70.0.0/16

### DIFF
--- a/apps/openchallenges/infra/src/ec2/database.ts
+++ b/apps/openchallenges/infra/src/ec2/database.ts
@@ -28,7 +28,7 @@ export class Database extends Construct {
       instanceType: 't2.micro',
       vpcSecurityGroupIds: [securityGroupId],
       subnetId,
-      privateIp: '10.0.32.253', // TODO replace by config param
+      privateIp: '10.70.32.253', // TODO replace by config param
       // privateIp: vars.databasePrivateIp,
       tags: { Name: `${nameTagPrefix}-database` },
       dependsOn: [natGateway],

--- a/apps/openchallenges/infra/src/ecs/ecs-task-definition-gold.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-task-definition-gold.ts
@@ -42,7 +42,7 @@ export class EcsTaskDefinitionGold extends Construct {
             },
             {
               name: 'UPSTREAM_URIS',
-              value: `http://10.0.32.253:27017`,
+              value: `http://10.70.32.253:27017`,
             },
           ],
         },

--- a/apps/openchallenges/infra/src/ecs/ecs-task-definition-silver.ts
+++ b/apps/openchallenges/infra/src/ecs/ecs-task-definition-silver.ts
@@ -42,7 +42,7 @@ export class EcsTaskDefinitionSilver extends Construct {
             },
             {
               name: 'UPSTREAM_URIS',
-              value: `http://10.0.32.253:27017`,
+              value: `http://10.70.32.253:27017`,
             },
           ],
         },

--- a/apps/openchallenges/infra/src/openchallenges-preview-stack.ts
+++ b/apps/openchallenges/infra/src/openchallenges-preview-stack.ts
@@ -25,7 +25,7 @@ export class OpenChallengesPreviewStack extends SageStack {
     const bastionPublicKey = fs.readFileSync(bastionKeyPath, 'utf-8');
     const bastionKeyName = 'openchallenges-preview-bastion-key';
     const stackOwnerEmail = 'thomas.schaffter@sagebionetworks.org';
-    const bastionPrivateIp = '10.0.2.172';
+    const bastionPrivateIp = '10.70.2.172';
 
     new AwsProvider(this, 'AWS', {
       region: AmazonRegion.US_EAST_1,
@@ -34,7 +34,7 @@ export class OpenChallengesPreviewStack extends SageStack {
     const networkConfig = new NetworkConfig({
       defaultRegion: AmazonRegion.US_EAST_1,
       tagPrefix: 'openchallenges-preview',
-      vpcCirdBlock: '10.0.0.0/16',
+      vpcCirdBlock: '10.70.0.0/16',
     });
 
     const network = new Network(this, 'network', networkConfig);

--- a/apps/openchallenges/infra/src/openchallenges-stack.ts
+++ b/apps/openchallenges/infra/src/openchallenges-stack.ts
@@ -46,7 +46,7 @@ export class OpenChallengesStack extends SageStack {
     const networkConfig = new NetworkConfig({
       defaultRegion: AmazonRegion.US_EAST_1,
       tagPrefix: 'openchallenges',
-      vpcCirdBlock: '10.0.0.0/16',
+      vpcCirdBlock: '10.70.0.0/16',
     });
 
     // The AWS VPC

--- a/apps/openchallenges/infra/src/security-group/security-groups.ts
+++ b/apps/openchallenges/infra/src/security-group/security-groups.ts
@@ -16,7 +16,7 @@ export class SecurityGroups extends Construct {
     super(scope, id);
 
     const nameTagPrefix = 'openchallenges';
-    const bastionPrivateIp = '10.0.2.172'; // TODO Add to config
+    const bastionPrivateIp = '10.70.2.172'; // TODO Add to config
     // const devcontainerPrivateIp = '10.41.30.105'; // TODO Add to config
 
     // reusable ingress 80 rule


### PR DESCRIPTION
Closes #1586

## Changelog

- Set the VPC CIDR of the OC Preview stack to `10.70.0.0/32` as suggested by @jesusaurus 

## Notes

- The project `openchallenges-infra` modified here is still a very early prototype. DRY TODOs will be addressed in future PRs.

## Preview

```console
$ cdktf deploy openchallenges-preview
...
                        Changes to Outputs:
                          + bastion_private_ip          = "10.70.2.172"
                          + bastion_public_ip           = (known after apply)
                          + preview_instance_private_ip = (known after apply)
                          + preview_instance_public_ip  = (known after apply)
                          + private_subnet_0_cidr_block = "10.70.32.0/20"
                          + private_subnet_1_cidr_block = "10.70.48.0/20"
                          + public_subnet_0_cidr_block  = "10.70.0.0/20"
                          + public_subnet_1_cidr_block  = "10.70.16.0/20"
...
```