### PR TITLE
feat: Deploy an EC2 instance with CDKTF that has Docker installed

### DIFF
--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -87,7 +87,7 @@ Connect to the bastion using the private key. The public IP address shown below 
 with the address returned by Terraform at the end of the deployment process.
 
 ```console
-$ ssh -i ~/.ssh/openchallenges-ec2 ubuntu@<bastion public ip>
+ssh -i ~/.ssh/openchallenges-ec2 ubuntu@<bastion public ip>
 ```
 
 ### Connect to the Preview instance
@@ -95,7 +95,7 @@ $ ssh -i ~/.ssh/openchallenges-ec2 ubuntu@<bastion public ip>
 Connect to the preview instance from the bastion:
 
 ```console
-$ ssh -i ~/.ssh/openchallenges-ec2 ubuntu@<preview instance private ip>
+ssh -i ~/.ssh/openchallenges-ec2 ubuntu@<preview instance private ip>
 ```
 
 ### Destroy the stack

--- a/apps/openchallenges/infra/src/resources/scripts/bastion.sh
+++ b/apps/openchallenges/infra/src/resources/scripts/bastion.sh
@@ -1,27 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 apt update
 
 # Set the hostname
 hostnamectl set-hostname openchallenges-bastion
-
-# Install Docker Engine on Ubuntu
-apt-get install -y ca-certificates curl gnupg
-
-install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-chmod a+r /etc/apt/keyrings/docker.gpg
-
-echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-  tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-apt-get update
-apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-# Post-installation steps for Docker Engine
-user="ubuntu"
-
-groupadd --force docker
-usermod -a --groups docker $user

--- a/apps/openchallenges/infra/src/resources/scripts/bastion.sh
+++ b/apps/openchallenges/infra/src/resources/scripts/bastion.sh
@@ -3,5 +3,25 @@
 apt update
 
 # Set the hostname
-# echo "openchallenges-bastion" > /etc/hostname
 hostnamectl set-hostname openchallenges-bastion
+
+# Install Docker Engine on Ubuntu
+apt-get install -y ca-certificates curl gnupg
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Post-installation steps for Docker Engine
+user="ubuntu"
+
+groupadd --force docker
+usermod -a --groups docker $user

--- a/apps/openchallenges/infra/src/resources/scripts/preview-instance.sh
+++ b/apps/openchallenges/infra/src/resources/scripts/preview-instance.sh
@@ -1,7 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 apt update
 
 # Set the hostname
-# echo "openchallenges-preview-instance" > /etc/hostname
 hostnamectl set-hostname openchallenges-preview-instance
+
+# Install Docker Engine on Ubuntu
+apt-get install -y ca-certificates curl gnupg
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Post-installation steps for Docker Engine
+user="ubuntu"
+
+groupadd --force docker
+usermod -a --groups docker $user


### PR DESCRIPTION
Closes #1567

## Changelog

- Install the Docker engine on the preview instance

## Preview

Docker is now available on the preview instance.

```console
ubuntu@openchallenges-preview-instance:~$ docker --version
Docker version 24.0.1, build 6802122

$ docker compose

Usage:  docker compose [OPTIONS] COMMAND

Define and run multi-container applications with Docker.

Options:
      --ansi string                Control when to print ANSI control characters ("never"|"always"|"auto") (default
                                   "auto")
      --compatibility              Run compose in backward compatibility mode
      --dry-run                    Execute command in dry run mode
      --env-file stringArray       Specify an alternate environment file.
  -f, --file stringArray           Compose configuration files
      --parallel int               Control max parallelism, -1 for unlimited (default -1)
      --profile stringArray        Specify a profile to enable
      --project-directory string   Specify an alternate working directory
                                   (default: the path of the, first specified, Compose file)
  -p, --project-name string        Project name

Commands:
  build       Build or rebuild services
  config      Parse, resolve and render compose file in canonical format
  cp          Copy files/folders between a service container and the local filesystem
  create      Creates containers for a service.
  down        Stop and remove containers, networks
  events      Receive real time events from containers.
  exec        Execute a command in a running container.
  images      List images used by the created containers
  kill        Force stop service containers.
  logs        View output from containers
  ls          List running compose projects
  pause       Pause services
  port        Print the public port for a port binding.
  ps          List containers
  pull        Pull service images
  push        Push service images
  restart     Restart service containers
  rm          Removes stopped service containers
  run         Run a one-off command on a service.
  start       Start services
  stop        Stop services
  top         Display the running processes
  unpause     Unpause services
  up          Create and start containers
  version     Show the Docker Compose version information

Run 'docker compose COMMAND --help' for more information on a command.
```

