### PR TITLE
feat: Connect to the bastion with AWS SSM

### DIFF
--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -83,6 +83,41 @@ cdktf deploy
 
 ### Connect to the Bastion
 
+#### With AWS SSM
+
+Add the following profile to `~/.aws/config`.
+
+```ini
+[profile cnb-dev]
+region = us-east-1
+sso_start_url = https://d-906769aa66.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 384625883722
+sso_role_name = Administrator
+output = json
+```
+
+Login to AWS SSO.
+
+```console
+aws --profile cnb-dev sso login
+```
+
+A browser window will pop up, asking for access from an application. Click `Allow`. You are now
+authenticated for remote access for the next 8-10 hours. Re-login as necessary.
+
+Connect to the instance as `ubuntu`, passing the `Instance ID` to `--target`.
+
+```console
+aws ssm start-session \
+  --profile cnb-dev \
+  --document-name AWS-StartInteractiveCommand \
+  --parameters command="sudo su - ubuntu" \
+  --target <instance id>
+```
+
+#### With SSH (deprecated)
+
 Connect to the bastion using the private key. The public IP address shown below should be replaced
 with the address returned by Terraform at the end of the deployment process.
 

--- a/apps/openchallenges/infra/README.md
+++ b/apps/openchallenges/infra/README.md
@@ -81,9 +81,7 @@ cdktf synth
 cdktf deploy
 ```
 
-### Connect to the Bastion
-
-#### With AWS SSM
+### Connect to the Bastion with AWS SSM
 
 Add the following profile to `~/.aws/config`.
 
@@ -116,13 +114,20 @@ aws ssm start-session \
   --target <instance id>
 ```
 
-#### With SSH (deprecated)
+Add a new profile to the `~/.ssh/config`. Replace `<instance id>` with the ID of the instance.
 
-Connect to the bastion using the private key. The public IP address shown below should be replaced
-with the address returned by Terraform at the end of the deployment process.
+```
+Host oc-bastion
+  HostName <instance id>
+  User ubuntu
+  IdentityFile ~/.ssh/openchallenges-ec2
+  ProxyCommand sh -c "AWS_PROFILE=cnb-dev aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+```
+
+Connect to the bastion with SSM:
 
 ```console
-ssh -i ~/.ssh/openchallenges-ec2 ubuntu@<bastion public ip>
+ssh oc-bastion
 ```
 
 ### Connect to the Preview instance

--- a/apps/openchallenges/infra/src/bastion/bastion-instance-profile.ts
+++ b/apps/openchallenges/infra/src/bastion/bastion-instance-profile.ts
@@ -1,0 +1,49 @@
+import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
+import { IamInstanceProfile } from '@cdktf/provider-aws/lib/iam-instance-profile';
+import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
+import { Construct } from 'constructs';
+
+export class BastionInstanceProfile extends Construct {
+  iamRole: IamRole;
+  iamInstanceProfile: IamInstanceProfile;
+
+  constructor(scope: Construct, id: string, nameTagPrefix: string) {
+    super(scope, id);
+
+    const iamPolicy = new DataAwsIamPolicyDocument(
+      this,
+      'bastion_assume_role',
+      {
+        statement: [
+          {
+            actions: ['sts:AssumeRole'],
+            effect: 'Allow',
+            principals: [
+              {
+                identifiers: ['ec2.amazonaws.com'],
+                type: 'Service',
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    this.iamRole = new IamRole(this, 'bastion_role', {
+      name: `${nameTagPrefix}-bastion-role`,
+      assumeRolePolicy: iamPolicy.json,
+      managedPolicyArns: [
+        'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore',
+      ],
+    });
+
+    this.iamInstanceProfile = new IamInstanceProfile(
+      this,
+      'bastion_instance_profile',
+      {
+        name: `${nameTagPrefix}-bastion-instance-profile`,
+        role: this.iamRole.name,
+      }
+    );
+  }
+}

--- a/apps/openchallenges/infra/src/bastion/bastion.ts
+++ b/apps/openchallenges/infra/src/bastion/bastion.ts
@@ -1,13 +1,53 @@
+/* eslint-disable no-unused-vars */
 import { Instance } from '@cdktf/provider-aws/lib/instance';
 import { Construct } from 'constructs';
 import { readFileSync } from 'fs';
 import { BastionConfig } from './bastion-config';
+import { IamInstanceProfile } from '@cdktf/provider-aws/lib/iam-instance-profile';
+import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
+import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
 
 export class Bastion extends Construct {
   instance: Instance;
 
   constructor(scope: Construct, id: string, config: BastionConfig) {
     super(scope, id);
+
+    const policyDocument = new DataAwsIamPolicyDocument(
+      this,
+      'bastion_assume_role',
+      {
+        statement: [
+          {
+            actions: ['sts:AssumeRole'],
+            effect: 'Allow',
+            principals: [
+              {
+                identifiers: ['ec2.amazonaws.com'],
+                type: 'Service',
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    const ssmInstanceRole = new IamRole(this, 'bastion_iam_role', {
+      name: `${config.tagPrefix}-ec2-role`,
+      assumeRolePolicy: policyDocument.json,
+      managedPolicyArns: [
+        'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore',
+      ],
+    });
+
+    const ssmInstanceProfile = new IamInstanceProfile(
+      this,
+      'ssm_instance_profile',
+      {
+        name: `${config.tagPrefix}-ssm-instance-profile`,
+        role: ssmInstanceRole.name,
+      }
+    );
 
     this.instance = new Instance(this, id, {
       ami: config.ami,
@@ -18,6 +58,7 @@ export class Bastion extends Construct {
       tags: { Name: `${config.tagPrefix}-bastion` },
       userData: readFileSync('./src/resources/scripts/bastion.sh', 'utf8'),
       vpcSecurityGroupIds: [config.securityGroupId],
+      iamInstanceProfile: ssmInstanceProfile.name,
     });
   }
 }

--- a/apps/openchallenges/infra/src/openchallenges-preview-stack.ts
+++ b/apps/openchallenges/infra/src/openchallenges-preview-stack.ts
@@ -103,11 +103,8 @@ export class OpenChallengesPreviewStack extends SageStack {
     new TerraformOutput(this, 'private_subnet_1_cidr_block', {
       value: network.privateSubnets[1].cidrBlock,
     });
-    new TerraformOutput(this, 'bastion_public_ip', {
-      value: bastion.instance.publicIp,
-    });
-    new TerraformOutput(this, 'bastion_private_ip', {
-      value: bastion.instance.privateIp,
+    new TerraformOutput(this, 'bastion_id', {
+      value: bastion.instance.id,
     });
     new TerraformOutput(this, 'preview_instance_public_ip', {
       value: previewInstance.instance.publicIp,

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -74,6 +74,10 @@ RUN groupadd docker \
   && unzip awscliv2.zip \
   && ./aws/install \
   && rm -fr awscliv2.zip ./aws \
+  # Add AWS Session Manager plugin
+  && curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/session-manager-plugin.deb \
+  && dpkg -i /tmp/session-manager-plugin.deb \
+  && rm -fr /tmp/session-manager-plugin.deb \
   # Install Poetry
   && curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version "${poetryVersion}" \
   && ln -s /etc/poetry/bin/poetry /usr/local/bin/. \


### PR DESCRIPTION
Closes #1591

## Changelog

- Add an IAM instance profile to the Bastion
- Document how to connect to the Bastion with SSM
- Add the AWS Session Manager plugin to the devcontainer

## Preview

The ID of the bastion is now shown after its deployment. This ID will be used to access the bastion with SSM.

```console
  openchallenges-preview
  bastion_id = i-05b07d2ace58137e8
```

Connect to the bastion with SSM:

```console
vscode@eee29c9f9d7c:/workspaces/sage-monorepo$ ssh oc-bastion
Welcome to Ubuntu 22.04.2 LTS (GNU/Linux 5.19.0-1024-aws x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Sat May 27 00:08:00 UTC 2023

  System load:           0.060546875
  Usage of /:            23.1% of 7.57GB
  Memory usage:          26%
  Swap usage:            0%
  Processes:             101
  Users logged in:       0
  IPv4 address for eth0: 10.70.2.172
  IPv6 address for eth0: 2600:1f18:4978:0:89c3:f27:7e4:71fd

Expanded Security Maintenance for Applications is not enabled.

34 updates can be applied immediately.
23 of these updates are standard security updates.
To see these additional updates run: apt list --upgradable

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status



The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

ubuntu@openchallenges-bastion:~$
```