### PR TITLE
feat: Add static analysis tool to prevent bugs and improve DX #1612 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,33 +8,37 @@
     }
   },
 
-  "settings": {},
-
-  "extensions": [
-    "1000ch.svgo",
-    "Angular.ng-template",
-    "dbaeumer.vscode-eslint",
-    "emeraldwalk.RunOnSave",
-    "esbenp.prettier-vscode",
-    "firsttris.vscode-jest-runner",
-    "GitHub.vscode-pull-request-github",
-    "Gruntfuggly.todo-tree",
-    "humao.rest-client",
-    "mhutchie.git-graph",
-    "mongodb.mongodb-vscode",
-    "ms-python.python",
-    "mtxr.sqltools-driver-mysql",
-    "mtxr.sqltools-driver-pg",
-    "mtxr.sqltools",
-    "nrwl.angular-console",
-    "ritwickdey.LiveServer",
-    "shengchen.vscode-checkstyle",
-    "stkb.rewrap",
-    "vmware.vscode-boot-dev-pack",
-    "vscjava.vscode-gradle",
-    "vscjava.vscode-java-pack",
-    "webhint.vscode-webhint"
-  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "1000ch.svgo",
+        "Angular.ng-template",
+        "dbaeumer.vscode-eslint",
+        "emeraldwalk.RunOnSave",
+        "esbenp.prettier-vscode",
+        "firsttris.vscode-jest-runner",
+        "GitHub.vscode-pull-request-github",
+        "Gruntfuggly.todo-tree",
+        "humao.rest-client",
+        "mhutchie.git-graph",
+        "mongodb.mongodb-vscode",
+        "ms-python.python",
+        "mtxr.sqltools-driver-mysql",
+        "mtxr.sqltools-driver-pg",
+        "mtxr.sqltools",
+        "nrwl.angular-console",
+        "ritwickdey.LiveServer",
+        "shengchen.vscode-checkstyle",
+        "SonarSource.sonarlint-vscode",
+        "stkb.rewrap",
+        "vmware.vscode-boot-dev-pack",
+        "vscjava.vscode-gradle",
+        "vscjava.vscode-java-pack",
+        "webhint.vscode-webhint"
+      ],
+      "settings": {}
+    }
+  },
 
   "forwardPorts": [
     3000,


### PR DESCRIPTION
Closes #1610

## Changelog

- Add the VS Code extension SonarLint for static analysis of Python, Java and TypeScript (among many other languages).
- Move the VS Code settings and extensions to `customizations/vscode/extensions` and `customizations/vscode/settings` (recent change in the devcontainer standard)

## Preview

TODO