### PR TITLE
feat: Thumbor dev server and container should listen to the same port

### DIFF
--- a/apps/openchallenges/api-gateway/config/application-local.yml
+++ b/apps/openchallenges/api-gateway/config/application-local.yml
@@ -1,0 +1,15 @@
+openchallenges-organization-service:
+  welcome-message: 'Welcome to the OpenChallenges API Gateway (local config).'
+
+# TODO: Remove from here once the config has been updated in the config GitHub repo.
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: openchallenges-thumbor
+          # The port Thumbor listens to inside the container
+          uri: http://openchallenges-thumbor:8889
+          predicates:
+            - Path=/img/**
+          filters:
+            - StripPrefix=1

--- a/apps/openchallenges/thumbor/.env.example
+++ b/apps/openchallenges/thumbor/.env.example
@@ -1,4 +1,5 @@
 LOG_LEVEL=info
+PORT=8889
 
 LOADER=thumbor_aws.loader
 AWS_LOADER_REGION_NAME=local

--- a/apps/openchallenges/thumbor/.env.example.aws
+++ b/apps/openchallenges/thumbor/.env.example.aws
@@ -1,4 +1,5 @@
 LOG_LEVEL=info
+PORT=8889
 
 LOADER=thumbor_aws.loader
 AWS_LOADER_REGION_NAME=us-east-1

--- a/apps/openchallenges/thumbor/README.md
+++ b/apps/openchallenges/thumbor/README.md
@@ -1,5 +1,9 @@
 # OpenChallenges Thumbor
 
+## Overview
+
+This component is based on [Thumbor S3 Docker].
+
 ## Usage
 
 ### Prepare the service
@@ -116,4 +120,5 @@ the values stored in LastPass.
 
 <!-- Links -->
 
+[Thumbor S3 Docker]: https://github.com/beeyev/thumbor-s3-docker
 [Triforce image]: https://static.wikia.nocookie.net/zelda_gamepedia_en/images/7/70/ALBW_Triforce_Artwork.png/revision/latest/scale-to-width-down/1000?cb=20140604184126&format=original

--- a/docker/openchallenges/services/thumbor.yml
+++ b/docker/openchallenges/services/thumbor.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - openchallenges
     ports:
-      - '8889:8888'
+      - '8889:8889'
     volumes:
       - openchallenges-thumbor-data:/data
     # depends_on:


### PR DESCRIPTION
Closes #1632

## Changelog

- Set Thumbor to listen to port 8889 inside its container (previously 8888).
- Overwrites the API gateway config so that it sends requests to Thumbor on port 8889 (dev server only).

## Notes

- 📣 This PR requires developer to add manually the variable `PORT=8889` to the `.env` file of the Thumbor project.
- 📣 This PR requires a change to the remote config of the API gateway stored in another GH repo. This change will break the API gateway container of other feature branches. These feature branches will need to be updated from `main` after this PR has been merged.

## Preview

Thumbor can be reached when deployed with its container and after changing the port mapping.

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/a554031a-92a4-4b61-b1cb-adae23cc22ea)
