### PR TITLE
Private preview prep

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.1__insert_temp_data.sql
+++ b/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.1__insert_temp_data.sql
@@ -2445,7 +2445,7 @@ VALUES (
     '',
     'The International Brain Tumor Segmentation (BraTS) challenge. BraTS, since 2012, has focused on the generation of a benchmarking environment and dataset for the delineation of adult brain gliomas. The focus of this year’s challenge remains the generation of a common benchmarking environment, but its dataset is substantially expanded to ~4,500 cases towards addressing additional i) populations (e.g., sub-Saharan Africa patients), ii) tumors (e.g., meningioma), iii) clinical concerns (e.g., missing data), and iv) technical considerations (e.g., augmentations). Specifically, the focus of BraTS 2023 is to identify the current state-of-the-art algorithms for addressing (Task 1) the same adult glioma population as in the RSNA-ANSR-MICCAI BraTS challenge, as well as (Task 2) the underserved sub-Saharan African brain glioma patient population, (Task 3) intracranial meningioma, (Task 4) brain metastasis, (Task 5) pediatric brain tumor patients, (Task 6) global & local missing data, (Task 7...',
     'https://www.synapse.org/brats',
-    'upcoming',
+    'active',
     'advanced',
     '1',
     '',

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search-filters-values.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search-filters-values.ts
@@ -18,10 +18,10 @@ export const challengeStartYearRangeFilterValues: FilterValue[] = [
     value: undefined,
     label: 'All',
   },
-  {
-    value: updateYear(thisYear, 1, 1),
-    label: (thisYear + 1).toString(),
-  },
+  // {
+  //   value: updateYear(thisYear, 1, 1),
+  //   label: (thisYear + 1).toString(),
+  // },
   {
     value: updateYear(thisYear, 0, 0),
     label: thisYear.toString(),

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -9,7 +9,7 @@
       <ul class="footer-link-group">
         <li><a href="/about">About</a></li>
         <li><a href="/team">Meet Our Team</a></li>
-        <li><a href="#">API</a></li>
+        <!-- <li><a href="#">API</a></li> -->
         <li>
           <a
             href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose"


### PR DESCRIPTION
## Changelog
* "Hide" API link in the footer - currently doesn't redirect anywhere
* "Hide" upcoming year in the Challenge Year facet - there are currently no challenges listed for 2024 so may be misleading to have
   > **Note**: I am not marking this PR as a fix for #1594, as the acceptance criteria is to update the "algorithm"
* Update challenge status for BraTS 2023 which is now active

## Preview

**Footer**
![Screen Shot 2023-06-12 at 4 41 33 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/67dea33c-f901-4702-856b-7abd85c7c374)

**Challenge Search**
![Screen Shot 2023-06-12 at 4 41 39 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/481b4e13-22ec-4bad-a2dd-0fb77212cd81)
