### PR TITLE
feat: Enable the image service to return images with height 32 px

### DIFF
--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/ImageHeightDto.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/model/dto/ImageHeightDto.java
@@ -11,6 +11,8 @@ import javax.validation.constraints.*;
 public enum ImageHeightDto {
   ORIGINAL("original"),
 
+  _32PX("32px"),
+
   _100PX("100px"),
 
   _140PX("140px"),

--- a/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
+++ b/apps/openchallenges/image-service/src/main/java/org/sagebionetworks/openchallenges/image/service/service/ImageService.java
@@ -56,6 +56,8 @@ public class ImageService {
     // we can't use switch here because height may be null
     if (height == ImageHeightDto.ORIGINAL) {
       return null;
+    } else if (height == ImageHeightDto._32PX) {
+      return 32;
     } else if (height == ImageHeightDto._100PX) {
       return 100;
     } else if (height == ImageHeightDto._140PX) {

--- a/apps/openchallenges/image-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/image-service/src/main/resources/openapi.yaml
@@ -90,6 +90,7 @@ components:
       description: The height of the image.
       enum:
       - original
+      - 32px
       - 100px
       - 140px
       - 250px

--- a/libs/openchallenges/api-client-angular/src/lib/model/imageHeight.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/imageHeight.ts
@@ -14,10 +14,11 @@
 /**
  * The height of the image.
  */
-export type ImageHeight = 'original' | '100px' | '140px' | '250px' | '500px';
+export type ImageHeight = 'original' | '32px' | '100px' | '140px' | '250px' | '500px';
 
 export const ImageHeight = {
     Original: 'original' as ImageHeight,
+    _32px: '32px' as ImageHeight,
     _100px: '100px' as ImageHeight,
     _140px: '140px' as ImageHeight,
     _250px: '250px' as ImageHeight,

--- a/libs/openchallenges/api-description/build/image.openapi.yaml
+++ b/libs/openchallenges/api-description/build/image.openapi.yaml
@@ -49,6 +49,7 @@ components:
       default: original
       enum:
         - original
+        - 32px
         - 100px
         - 140px
         - 250px

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -825,6 +825,7 @@ components:
       default: original
       enum:
         - original
+        - 32px
         - 100px
         - 140px
         - 250px

--- a/libs/openchallenges/api-description/src/components/schemas/ImageHeight.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ImageHeight.yaml
@@ -3,6 +3,7 @@ type: string
 default: original
 enum:
   - original
+  - 32px
   - 100px
   - 140px
   - 250px


### PR DESCRIPTION
Closes #1636

## Changelog

- Update the image service to offer images with their height set to 32 px

## Monorepo Recipe: Update an API Model

> **Note** This development recipe was applied to create this PR. Time: 15 min.

1. Update the API description
    - Update the model in `libs/openchallenges/api-description/src`
    - Build the API description: `nx build openchallenges-api-description`
2. Update the service (here the image service)
    - Run OpenAPI Generator: `nx openapi-generate openchallenges-image-service`
    - Update the business logic (if needed)
3. Update the API clients
    - For Angular: `nx openapi-generate openchallenges-api-client-angular`
4. Update the web app

## Preview

Build the images and start the image service and its dependencies, which include Thumbor:

``` console
openchallenges-build-images
nx serve-detach openchallenges-image-service
```

Getting the URL of an image with height set to 32 px is now available:

```
GET {{basePath}}/images?objectKey=triforce.png&height=32px

HTTP/1.1 200 
{
  "url": "http://localhost:8082/img/4ASTp5fnmUbxyDzqbfA_xvzSfCk=/0x32/triforce.png"
}
```

The URL targets the API gateway (port 8082), which is currently not a dependency of the image service. Let's start it.

```console
nx serve-detach openchallenges-api-gateway
```

Get the image with the URL obtained from the image service (see image height in the layout panel):

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/dd191d14-7971-490a-af08-3309a441aa8e)
