### PR TITLE
fix: Update Schematic API base image to Python 3.10.0

### DIFF
--- a/apps/schematic/api/Dockerfile
+++ b/apps/schematic/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0-slim-buster
+FROM python:3.10.0-slim-buster
 
 ENV APP_DIR=/opt/app
 


### PR DESCRIPTION
## Description

A recent Pr from @linglp set the Schematic API project to use Python 3.10.0. The version used for the Docker image should also have been updated. The present PR fixes that.