### PR TITLE
feat(ui): sticky navbar

### DIFF
--- a/libs/openchallenges/styles/src/lib/_constants.scss
+++ b/libs/openchallenges/styles/src/lib/_constants.scss
@@ -35,4 +35,5 @@ $xxl-breakpoint: 1400px;
 
 // Dimensions of component
 $navbar-height: 68px;
+$navbar-height-tall: 240px;
 $footer-height: 259px;

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -1,12 +1,11 @@
 @use 'libs/openchallenges/styles/src/lib/constants';
 
-html
+html {
+  margin-top: constants.$navbar-height;
+}
 body {
   height: 100vh;
   margin: 0;
-}
-html {
-  margin-top: constants.$navbar-height;
 }
 em {
   color: #00b1e5;

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -370,3 +370,8 @@ table {
     max-width: 320px;
   }
 }
+@media only screen and (max-width: constants.$lg-breakpoint) {
+  html {
+    margin-top: constants.$navbar-height-tall;
+  }
+}

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -1,9 +1,12 @@
 @use 'libs/openchallenges/styles/src/lib/constants';
 
-html,
+html
 body {
   height: 100vh;
   margin: 0;
+}
+html {
+  margin-top: constants.$navbar-height;
 }
 em {
   color: #00b1e5;

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
@@ -29,13 +29,13 @@
   vertical-align: middle;
 }
 
-@media only screen and (max-width: 855px) {
+@media only screen and (max-width: constants.$lg-breakpoint) {
   .navbar-item {
     width: 100%;
     align-self: center;
   }
   .sage-navbar {
-    height: 300px;
+    height: constants.$navbar-height-tall;
   }
   .flex-spacer {
     flex-grow: 0;

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
@@ -1,6 +1,11 @@
 @use 'libs/openchallenges/styles/src/lib/constants';
 
 .sage-navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  width: 100%;
   height: constants.$navbar-height;
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Fixes #1652 

## Changelog
* keep navbar on top of viewport.  This will allow users to easily go to a different search page after they've done some scrolling

## Preview

**No scrolling done yet**
![Screen Shot 2023-06-14 at 7 08 45 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/2c4a7d70-7d10-4e74-80d2-9563365010c2)

**After some scrolling**
![Screen Shot 2023-06-14 at 7 08 51 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/f532e379-bb2b-4919-a85a-ea2ec7712b15)

