### PR TITLE
feat: Increase Thumbor container memory to 500M

### DIFF
--- a/docker/openchallenges/services/thumbor.yml
+++ b/docker/openchallenges/services/thumbor.yml
@@ -19,4 +19,4 @@ services:
     deploy:
       resources:
         limits:
-          memory: 200M
+          memory: 500M


### PR DESCRIPTION
Closes  #1655

## Notes

- We observed that Thumbor gets close to 90% of its current max memory, which is why this PR increases this amount.