### PR TITLE
feat: Add path to get the contributions to a challenge

### DIFF
--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -60,6 +60,26 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /challenges/{challengeId}/contributions:
+    parameters:
+      - $ref: '#/components/parameters/challengeId'
+    get:
+      tags:
+        - ChallengeContribution
+      summary: List challenge contributions
+      description: List challenge contributions
+      operationId: listChallengeContributions
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChallengeContributionsPage'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /challengeInputDataTypes:
     get:
       tags:
@@ -502,6 +522,44 @@ components:
       required:
         - title
         - status
+      x-java-class-annotations:
+        - '@lombok.Builder'
+    ChallengeContributionRole:
+      description: The nature of a challenge contribution.
+      type: string
+      enum:
+        - challenge_organizer
+        - data_contributor
+        - sponsor
+      example: challenge_organizer
+    ChallengeContribution:
+      type: object
+      description: A challenge contribution.
+      properties:
+        challengeId:
+          $ref: '#/components/schemas/ChallengeId'
+        organizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        role:
+          $ref: '#/components/schemas/ChallengeContributionRole'
+      required:
+        - challengeId
+        - organizationId
+        - role
+    ChallengeContributionsPage:
+      type: object
+      description: A page of challenge challenge contributions.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            challengeContributions:
+              description: A list of challenge contributions.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChallengeContribution'
+          required:
+            - challengeContributions
       x-java-class-annotations:
         - '@lombok.Builder'
     ChallengeInputDataTypeSort:

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -66,6 +66,26 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  '/challenges/{challengeId}/contributions':
+    parameters:
+      - $ref: '#/components/parameters/challengeId'
+    get:
+      tags:
+        - ChallengeContribution
+      summary: List challenge contributions
+      description: List challenge contributions
+      operationId: listChallengeContributions
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChallengeContributionsPage'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /challengeInputDataTypes:
     get:
       tags:
@@ -658,6 +678,44 @@ components:
         - status
       x-java-class-annotations:
         - '@lombok.Builder'
+    ChallengeContributionRole:
+      description: The nature of a challenge contribution.
+      type: string
+      enum:
+        - challenge_organizer
+        - data_contributor
+        - sponsor
+      example: challenge_organizer
+    ChallengeContribution:
+      type: object
+      description: A challenge contribution.
+      properties:
+        challengeId:
+          $ref: '#/components/schemas/ChallengeId'
+        organizationId:
+          $ref: '#/components/schemas/OrganizationId'
+        role:
+          $ref: '#/components/schemas/ChallengeContributionRole'
+      required:
+        - challengeId
+        - organizationId
+        - role
+    ChallengeContributionsPage:
+      type: object
+      description: A page of challenge challenge contributions.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            challengeContributions:
+              description: A list of challenge contributions.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChallengeContribution'
+          required:
+            - challengeContributions
+      x-java-class-annotations:
+        - '@lombok.Builder'
     ChallengeInputDataTypeSort:
       description: What to sort results by.
       type: string
@@ -875,14 +933,6 @@ components:
         - url
       x-java-class-annotations:
         - '@lombok.Builder'
-    ChallengeContributorRole:
-      description: The role of a challenge contributor.
-      type: string
-      enum:
-        - challenge_organizer
-        - data_contributor
-        - sponsor
-      example: challenge_organizer
     OrganizationSort:
       description: What to sort results by.
       type: string
@@ -915,11 +965,11 @@ components:
           format: int32
           default: 100
           minimum: 1
-        challengeContributorRoles:
-          description: An array of challenge contributor roles used to filter the results.
+        challengeContributionRoles:
+          description: An array of challenge contribution roles used to filter the results.
           type: array
           items:
-            $ref: '#/components/schemas/ChallengeContributorRole'
+            $ref: '#/components/schemas/ChallengeContributionRole'
         sort:
           $ref: '#/components/schemas/OrganizationSort'
         direction:

--- a/libs/openchallenges/api-description/build/organization.openapi.yaml
+++ b/libs/openchallenges/api-description/build/organization.openapi.yaml
@@ -58,8 +58,8 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
-    ChallengeContributorRole:
-      description: The role of a challenge contributor.
+    ChallengeContributionRole:
+      description: The nature of a challenge contribution.
       type: string
       enum:
         - challenge_organizer
@@ -98,11 +98,11 @@ components:
           format: int32
           default: 100
           minimum: 1
-        challengeContributorRoles:
-          description: An array of challenge contributor roles used to filter the results.
+        challengeContributionRoles:
+          description: An array of challenge contribution roles used to filter the results.
           type: array
           items:
-            $ref: '#/components/schemas/ChallengeContributorRole'
+            $ref: '#/components/schemas/ChallengeContributionRole'
         sort:
           $ref: '#/components/schemas/OrganizationSort'
         direction:

--- a/libs/openchallenges/api-description/src/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/src/challenge.openapi.yaml
@@ -24,6 +24,8 @@ paths:
     $ref: paths/challenges.yaml
   /challenges/{challengeId}:
     $ref: paths/challenges/@{challengeId}.yaml
+  /challenges/{challengeId}/contributions:
+    $ref: paths/challenges/@{challengeId}/contributions.yaml
   /challengeInputDataTypes:
     $ref: paths/challengeInputDataTypes.yaml
   /challengePlatforms:

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeContribution.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeContribution.yaml
@@ -1,0 +1,13 @@
+type: object
+description: A challenge contribution.
+properties:
+  challengeId:
+    $ref: ChallengeId.yaml
+  organizationId:
+    $ref: OrganizationId.yaml
+  role:
+    $ref: ChallengeContributionRole.yaml
+required:
+  - challengeId
+  - organizationId
+  - role

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeContributionRole.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeContributionRole.yaml
@@ -1,4 +1,4 @@
-description: The role of a challenge contributor.
+description: The nature of a challenge contribution.
 type: string
 enum:
   - challenge_organizer

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeContributionsPage.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeContributionsPage.yaml
@@ -1,0 +1,15 @@
+type: object
+description: A page of challenge challenge contributions.
+allOf:
+  - $ref: PageMetadata.yaml
+  - type: object
+    properties:
+      challengeContributions:
+        description: A list of challenge contributions.
+        type: array
+        items:
+          $ref: ChallengeContribution.yaml
+    required:
+      - challengeContributions
+x-java-class-annotations:
+  - '@lombok.Builder'

--- a/libs/openchallenges/api-description/src/components/schemas/OrganizationSearchQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/OrganizationSearchQuery.yaml
@@ -13,11 +13,11 @@ properties:
     format: int32
     default: 100
     minimum: 1
-  challengeContributorRoles:
-    description: An array of challenge contributor roles used to filter the results.
+  challengeContributionRoles:
+    description: An array of challenge contribution roles used to filter the results.
     type: array
     items:
-      $ref: ChallengeContributorRole.yaml
+      $ref: ChallengeContributionRole.yaml
   sort:
     $ref: OrganizationSort.yaml
   direction:

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions.yaml
@@ -1,0 +1,19 @@
+parameters:
+  - $ref: ../../../components/parameters/path/challengeId.yaml
+get:
+  tags:
+    - ChallengeContribution
+  summary: List challenge contributions
+  description: List challenge contributions
+  operationId: listChallengeContributions
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: ../../../components/schemas/ChallengeContributionsPage.yaml
+      description: Success
+    '400':
+      $ref: ../../../components/responses/BadRequest.yaml
+    '500':
+      $ref: ../../../components/responses/InternalServerError.yaml


### PR DESCRIPTION
Related to #1537

## Description

This PR updates the OC API description to enable users to access contributions made to a challenge. The implementation of this change to the API description will be made in other PRs that target the upstream branch `challenge-contributions`.

## Changelog

- Add the path `/challenges/{challengeId}/contributions`
- Rename the org search query param `ChallengeContributorRole` to `ChallengeContributionRole`

## Notes

- I've been thinking about whether we should name the object `contribution` or `contributor`. The reason I prefer the former is that we could add more information about the contribution that are not directly about the contributor such as a start and end date for the contribution.
  - A source of inspiration could be [CD2H contribution data model](https://contributor-attribution-model.readthedocs.io/en/latest/info_model/classes/contribution.html).