### PR TITLE
feat: Build OC images from outside the dev container

### DIFF
--- a/tools/switch-devcontainer-to-docker-outside-of-docker.sh
+++ b/tools/switch-devcontainer-to-docker-outside-of-docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Update the definition of the dev container to replace the feature "docker-in-docker" by
+# "docker-outside-of-docker". The first purpose of this script is to build the Docker images of the
+# stacks developed in this monorepo so that these images are available on the host (i.e. outside of
+# the dev container).
+#
+# Usage: ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
+#
+# References:
+# - https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker
+
+DEV_CONTAINER_DEFINITION_FILE="$WORKSPACE_DIR/.devcontainer/devcontainer.json"
+
+# Remove the feature "docker-in-docker" from the devcontainer definition
+cat <<< $(jq 'delpaths([paths | select(.[0] == "features" and 
+    (.[1] | tostring | startswith("ghcr.io/devcontainers/features/docker-in-docker")))])' \
+  $DEV_CONTAINER_DEFINITION_FILE) \
+  > $DEV_CONTAINER_DEFINITION_FILE
+
+# Add the feature "docker-outside-of-docker" to the new devcontainer definition
+cat <<< $(jq '.features."ghcr.io/devcontainers/features/docker-outside-of-docker:1" = {}' \
+  $DEV_CONTAINER_DEFINITION_FILE) \
+  > $DEV_CONTAINER_DEFINITION_FILE


### PR DESCRIPTION
Closes #1675

## Description

The OpenChallenges team has always been using the Sage Monorepo dev container with VS Code (GUI). This PR illustrates how a dev container can be managed with a CLI and used to run a process *inside* the dev container from the host (i.e. outside of the dev container).

This PR demonstrates how to use this approach to build the Docker images for all the components of the OC stack so that these images are then available on the host. The dev container feature "docker-outside-of-docker" is used to share the Docker engine of the host with the dev container (while the feature "docker-in-docker" isolates the host and dev container Docker engines), so that the images build image the dev container are available to the host too. In an upcoming PR, the OC stack will be started on the host with Docker Compose using these images.

> **Note** In production, the Docker images will be pushed to a Docker registry instead of being built from source. I haven't figured out yet how to manage the version of the different components/images yet, which is why I decided to explore deploying the stack from its source.

## Changelog

- Provide instructions on how to build the Docker images of the OC stack from outside the devcontainer

## Preview (Ubuntu 22.04 LTS)

Install git, jq and Node.js:

```console
curl -sL https://deb.nodesource.com/setup_18.x | bash -
apt install -y git jq nodejs gcc g++ make
```

Install the devcontainer CLI:

```console
npm install -g @devcontainers/cli@0.25.2
```

Clone Sage Monorepo:

```console
git clone --filter=blob:none --no-checkout https://github.com/Sage-Bionetworks/sage-monorepo.git
cd sage-monorepo
git checkout <commit_sha>
```

Update the definition of the monorepo dev container to use the feature `docker-outside-of-docker` instead of `docker-in-docker`.

```console
./tools/switch-devcontainer-to-docker-outside-of-docker.sh
```

Step outside of the repository:

```console
cd ..
```

Start the dev container:

```console
devcontainer up --workspace-folder sage-monorepo
```

Check that the dev container is running:

```console
$ docker ps
CONTAINER ID   IMAGE                                                             COMMAND                  CREATED          STATUS          PORTS     NAMES
142dbc55bf40   vsc-sage-monorepo-a5347526fc0521fb7b12bdaace8a5958-features-uid   "/bin/sh -c 'echo Co…"   34 seconds ago   Up 33 seconds             sage_devcontainer
```

Build the images:

```console
$ devcontainer exec --workspace-folder sage-monorepo bash -c   ". ./dev-env.sh \
  && workspace-install \
  && ./tools/switch-devcontainer-to-docker-outside-of-docker.sh \
  && openchallenges-build-images"
...
    ✔  nx run openchallenges-apex:build-image (2s)
    ✔  nx run openchallenges-app:build-image (2s)
    ✔  nx run openchallenges-auth-service:build-image (21s)
    ✔  nx run openchallenges-core-service:build-image (44s)
    ✔  nx run openchallenges-user-service:build-image (44s)
    ✔  nx run openchallenges-organization-service:build-image (2s)
    ✔  nx run openchallenges-challenge-service:build-image (2s)
    ✔  nx run openchallenges-image-service:build-image (4s)
    ✔  nx run openchallenges-challenge-to-elasticsearch-service:build-image (32s)
    ✔  nx run openchallenges-config-server:build-image (1s)
    ✔  nx run openchallenges-kaggle-to-kafka-service:build-image (22s)
{"outcome":"success"}
```

Check that the images are available on the host 🤩:

```console
$ docker images
REPOSITORY                                                          TAG        IMAGE ID       CREATED          SIZE
vsc-sage-monorepo-a5347526fc0521fb7b12bdaace8a5958-features-uid     latest     e298128435d2   57 minutes ago   2.9GB
vsc-sage-monorepo-a5347526fc0521fb7b12bdaace8a5958-features         latest     8752c00c2169   57 minutes ago   2.9GB
sagebionetworks/openchallenges-app                                  latest     3ecdde89e802   22 hours ago     27MB
sagebionetworks/openchallenges-organization-service                 latest     df09d9393b2f   22 hours ago     356MB
sagebionetworks/openchallenges-challenge-service                    latest     6079b52666d4   25 hours ago     358MB
sagebionetworks/openchallenges-apex                                 latest     d98e43fc0623   2 days ago       143MB
sagebionetworks/openchallenges-api-gateway                          latest     e268805baf19   2 days ago       323MB
sagebionetworks/openchallenges-config-server                        latest     e288d3a38ced   5 days ago       308MB
sagebionetworks/openchallenges-image-service                        latest     8c61ec066757   5 days ago       323MB
sagebionetworks/openchallenges-vault                                latest     df4efc8be92c   5 days ago       226MB
sagebionetworks/openchallenges-elasticsearch                        latest     fff50841d9d8   5 days ago       622MB
sagebionetworks/openchallenges-mariadb                              latest     493948368af1   5 days ago       384MB
sagebionetworks/openchallenges-service-registry                     latest     f13f8582e478   5 days ago       322MB
paketobuildpacks/run                                                base-cnb   1c8659977d9c   2 weeks ago      87.1MB
sagebionetworks/openchallenges-thumbor                              latest     dc7a8926b3bf   7 weeks ago      606MB
sagebionetworks/openchallenges-grafana                              latest     cb89d764be4a   3 months ago     329MB
sagebionetworks/openchallenges-prometheus                           latest     89c908248b08   4 months ago     232MB
sagebionetworks/openchallenges-zipkin                               latest     ad5bf93e3f50   6 months ago     165MB
sagebionetworks/openchallenges-mongo                                latest     6bd422e35f78   6 months ago     700MB
sagebionetworks/openchallenges-keycloak                             latest     7e056640ba34   7 months ago     546MB
sagebionetworks/openchallenges-postgres                             latest     f80233e85a39   8 months ago     216MB
sagebionetworks/openchallenges-api-docs                             latest     d526ff253f89   9 months ago     33.4MB
sagebionetworks/openchallenges-mysqld-exporter                      latest     19c65f9e7851   15 months ago    17.8MB
sagebionetworks/openchallenges-api-gateway-base                     latest     c4b6153e4df0   43 years ago     313MB
sagebionetworks/openchallenges-auth-service                         latest     015a76661ea2   43 years ago     304MB
sagebionetworks/openchallenges-user-service                         latest     b812f562952e   43 years ago     339MB
sagebionetworks/openchallenges-service-registry-base                latest     e82fdab93fe6   43 years ago     312MB
sagebionetworks/openchallenges-config-server-base                   latest     e70657479b7c   43 years ago     299MB
paketobuildpacks/builder                                            base       d37640437760   43 years ago     1.29GB
sagebionetworks/openchallenges-core-service                         latest     1a018c2bc5cd   43 years ago     323MB
sagebionetworks/openchallenges-organization-service-base            latest     0bfe382cba9c   43 years ago     346MB
sagebionetworks/openchallenges-challenge-to-elasticsearch-service   latest     524cdd493de2   43 years ago     319MB
sagebionetworks/openchallenges-challenge-service-base               latest     cc0e56e7dadd   43 years ago     348MB
sagebionetworks/openchallenges-kaggle-to-kafka-service              latest     f832503ab2bb   43 years ago     317MB
sagebionetworks/openchallenges-image-service-base                   latest     083c1f7bf2d2   43 years ago     313MB
sagebionetworks/openchallenges-minio                                latest     0a43e4ca196e   N/A              215MB
```

Remove the dev container:

```console
docker rm -f sage_devcontainer
```

## Future Work

- Document how to create the configuration for deploying the OC stack with Docker Compose