### PR TITLE
feat: Configure the OC stack during deployment

### DIFF
--- a/apps/openchallenges/infra/src/preview-instance-alb/preview-instance-alb.ts
+++ b/apps/openchallenges/infra/src/preview-instance-alb/preview-instance-alb.ts
@@ -35,7 +35,7 @@ export class PreviewInstanceAlb extends Construct {
 
     this.targetGroup = new LbTargetGroup(this, 'preview_instance_alb_targets', {
       namePrefix: 'pi-',
-      port: 8080,
+      port: 8000,
       protocol: 'HTTP',
       vpcId,
       deregistrationDelay: '30',

--- a/apps/openchallenges/infra/src/security-group/security-groups.ts
+++ b/apps/openchallenges/infra/src/security-group/security-groups.ts
@@ -136,14 +136,14 @@ export class SecurityGroups extends Construct {
       vpcId,
     });
 
-    new SecurityGroupRule(this, 'preview_instance_allow_alb_8080', {
+    new SecurityGroupRule(this, 'preview_instance_allow_alb_8000', {
       securityGroupId: this.previewInstanceSg.id,
       type: 'ingress',
       protocol: 'tcp',
-      fromPort: 8080,
-      toPort: 8080,
+      fromPort: 8000,
+      toPort: 8000,
       sourceSecurityGroupId: this.previewInstanceAlbSg.id,
-      description: 'Allow HTTP traffic on 8080 from the Preview Instance ALB',
+      description: 'Allow HTTP traffic on 8000 from the Preview Instance ALB',
     });
     allowInboundSelf(
       this.previewInstanceSg.id,


### PR DESCRIPTION
Closes #1678

## Changelog

- Configure the preview instance to listen to the port 8000
- Configure the ALB to forward traffic to the port 8000 of the preview instance
- Document in the `openchallenges-infra` README how to configure and start the stack