### PR TITLE
feat: Add R to the monorepo devcontainer

### DIFF
--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -17,6 +17,8 @@ ARG yarnVersion="3.3.0"
 ARG devcontainerCliVersion="0.25.2"
 # https://pypi.org/project/poetry
 ARG poetryVersion="1.3.1"
+# https://docs.posit.co/resources/install-r/#specify-r-version
+ARG rVersion="4.2.3"
 
 # Create the docker group so that we can assign it to the user.
 # This is to enable the non-root user to use the command `docker`.
@@ -27,7 +29,7 @@ RUN groupadd docker \
     ca-certificates curl git bash-completion gnupg2 lsb-release ssh sudo \
     python3-pip python3-dev python-is-python3 openjdk-17-jdk \
     htop unzip vim wget lsof iproute2 build-essential \
-    kafkacat jq \
+    kafkacat jq ca-certificates-java gdebi-core \
     # Required by AWS CLI
     mandoc \
     # Required for setting up locales

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -97,6 +97,11 @@ RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
   && locale-gen
 ENV LANG=en_US.UTF-8
 
+## Install the R environment
+RUN curl "https://cdn.rstudio.com/r/debian-11/pkgs/r-${rVersion}_1_amd64.deb" -o /tmp/r_amd64.deb \
+  && gdebi --non-interactive /tmp/r_amd64.deb \
+  && rm -fr /tmp/r_amd64.deb
+
 ARG user=vscode
 RUN useradd -m $user \
   && echo "$user:$user" | chpasswd \

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -83,7 +83,7 @@ RUN groupadd docker \
   # Install Poetry
   && curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version "${poetryVersion}" \
   && ln -s /etc/poetry/bin/poetry /usr/local/bin/. \
-  # Install the R environment
+  # Install R
   && curl "https://cdn.rstudio.com/r/debian-11/pkgs/r-${rVersion}_1_amd64.deb" -o /tmp/r_amd64.deb \
     && gdebi --non-interactive /tmp/r_amd64.deb \
     && rm -fr /tmp/r_amd64.deb \

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -83,6 +83,12 @@ RUN groupadd docker \
   # Install Poetry
   && curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version "${poetryVersion}" \
   && ln -s /etc/poetry/bin/poetry /usr/local/bin/. \
+  # Install the R environment
+  && curl "https://cdn.rstudio.com/r/debian-11/pkgs/r-${rVersion}_1_amd64.deb" -o /tmp/r_amd64.deb \
+    && gdebi --non-interactive /tmp/r_amd64.deb \
+    && rm -fr /tmp/r_amd64.deb \
+    && ln -s /opt/R/${rVersion}/bin/R /usr/local/bin/R \
+    && ln -s /opt/R/${rVersion}/bin/Rscript /usr/local/bin/Rscript \
   # Increase the max number of file watchers
   # See https://github.com/Sage-Bionetworks/sage-monorepo/issues/856
   && echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf \
@@ -96,11 +102,6 @@ RUN groupadd docker \
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
   && locale-gen
 ENV LANG=en_US.UTF-8
-
-## Install the R environment
-RUN curl "https://cdn.rstudio.com/r/debian-11/pkgs/r-${rVersion}_1_amd64.deb" -o /tmp/r_amd64.deb \
-  && gdebi --non-interactive /tmp/r_amd64.deb \
-  && rm -fr /tmp/r_amd64.deb
 
 ARG user=vscode
 RUN useradd -m $user \

--- a/tools/devcontainers/sage/.devcontainer/devcontainer.json
+++ b/tools/devcontainers/sage/.devcontainer/devcontainer.json
@@ -1,8 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/main/containers/docker-existing-dockerfile
 {
   "name": "Sage Dev Container",
-
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
@@ -10,43 +7,7 @@
       "devcontainerVersion": "${localEnv:DEVCONTAINER_VERSION}"
 		}
 	},
-
-  // Install tools and languages from a pre-defined set of scripts or even your
-  // own.
-  "features": {
-    // docker features must be specified in the developer facing
-    // devcontainer.json for VS Code to properly mount the docker sockets.
-  },
-
-  // The reference properties listed below are not used during the devcontainer
-  // image building process (`devcontainer build [OPTIONS]`).
-
-  // Set *default* container specific settings.json values on container create.
-  "settings": {},
-
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [],
-
-  // Use 'forwardPorts' to make a list of ports inside the container available
-	// locally.
-  "forwardPorts": [],
-
-    // Object that maps a port number, "host:port" value, range, or regular
-  // expression to a set of default options.
-  "portsAttributes": {},
-
-  // Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
-  // Comment out to connect as root instead. More info:
-  // https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
-
-  // Indicates whether VS Code and other devcontainer.json supporting tools
-  // should stop the containers when the related tool window is closed / shut
-  // down.
   "shutdownAction": "stopContainer",
-
-  // An array of Docker CLI arguments
   "runArgs": ["--name", "sage_devcontainer"]
 }


### PR DESCRIPTION
Closes #1620

## Description

This PR adds R with a pinned version to the monorepo dev container image. R will then be available to all the developers of the monorepo once it's part of the official dev container, which will be built and published to Docker Hub by a CI/CD workflow when this PR is merged.

## Changelog

- Add R version 4.2.3 to the dev container image
- Remove comments and unused properties from `tools/devcontainers/sage/.devcontainer/devcontainer.json`

## Preview

> **Note** I used the steps below to build the dev container image locally and check that R is properly added to the dev container image. As any contribution made to this monorepo, this work was done inside the monorepo dev container (#inception). :-)

Build the test dev container image (`sagebionetworks/sage-devcontainer:test`):

```console
cd tools/devcontainers
./build-image.sh
```

Start a container for this image and step into it:

```console
docker run -it --rm sagebionetworks/sage-devcontainer:test bash
```

Show the version of R:

```console
vscode@3853e9bf1a40:/$ R --version
R version 4.2.3 (2023-03-15) -- "Shortstop Beagle"
Copyright (C) 2023 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under the terms of the
GNU General Public License versions 2 or 3.
For more information about these matters see
https://www.gnu.org/licenses/.
```