### PR TITLE
feat(fix): Make paginator highlight the correct selection

### DIFF
--- a/libs/openchallenges/ui/src/lib/paginator/paginator.component.html
+++ b/libs/openchallenges/ui/src/lib/paginator/paginator.component.html
@@ -1,5 +1,5 @@
 <p-paginator
-  [first]="pageNumber"
+  [first]="itemIndex"
   [pageLinkSize]="pageLinkSize"
   [rows]="pageSize"
   [totalRecords]="totalRecords"

--- a/libs/openchallenges/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/openchallenges/ui/src/lib/paginator/paginator.component.ts
@@ -1,17 +1,23 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 
 @Component({
   selector: 'openchallenges-paginator',
   templateUrl: './paginator.component.html',
   styleUrls: ['./paginator.component.scss'],
 })
-export class PaginatorComponent {
-  @Input() pageNumber = 0;
+export class PaginatorComponent implements OnInit {
+  @Input() pageNumber = 0; // index of the new page
   @Input() pageLinkSize = 5;
-  @Input() pageSize = 0;
+  @Input() pageSize = 0; // number of rows to display in new page
   @Input() totalRecords = 0;
   @Input() itemsPerPage!: number[];
   @Output() pageChange = new EventEmitter();
+
+  itemIndex = 0; // index of the first item in the new page
+
+  ngOnInit(): void {
+    this.itemIndex = this.pageNumber * this.pageSize;
+  }
 
   onPageChange(event: any): void {
     this.pageChange.emit(event);


### PR DESCRIPTION
- fixes #1702 

The issue was the `[first]` input of `p-paginator` should use "first" (index of the first item in the new page), instead of "pageNumber" (index of the new page). To fix the bug, manually calculating the "first" using  "pageNumber" and "pageSize".

As a reminder for future, the proporties of paginator states from `onPageChange` are listed below:

```ts
paginate(event) {
    event.first = Index of the first record -> itemIndex
    event.rows = Number of rows to display in new page -> pageSize
    event.page = Index of the new page -> pageNumber
    event.pageCount = Total number of pages
}
```

### Preview
---

https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/f17f38ad-7f7a-49c7-a382-01ef469e3e9e


