### PR TITLE
feat(angular):  Capture the active search parameters for Organization Search page

### DIFF
--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -336,7 +336,7 @@ export class ChallengeSearchComponent
 
     this.query
       .pipe(
-        tap((query) => console.log('List challenges', query)),
+        tap((query) => console.log('List challenges query', query)),
         switchMap((query) => this.challengeService.listChallenges(query)),
         tap((page) => console.log('List of challenges: ', page.challenges)),
         catchError((err) => {

--- a/libs/openchallenges/org-search/src/lib/org-search-filters-values.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search-filters-values.ts
@@ -1,6 +1,6 @@
 import { FilterValue } from '@sagebionetworks/openchallenges/ui';
 
-export const contributionRolesFilterValues: FilterValue[] = [
+export const challengeContributionRolesFilterValues: FilterValue[] = [
   {
     value: 'challenge_organizer',
     label: 'Challenge Organizer',

--- a/libs/openchallenges/org-search/src/lib/org-search-filters.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search-filters.ts
@@ -1,9 +1,9 @@
 import { Filter } from '@sagebionetworks/openchallenges/ui';
-import { contributionRolesFilterValues } from './org-search-filters-values';
+import { challengeContributionRolesFilterValues } from './org-search-filters-values';
 
-export const contributionRolesFilter: Filter = {
+export const challengeContributionRolesFilter: Filter = {
   query: 'challengeContributionRoles',
   label: 'Contribution Role',
-  values: contributionRolesFilterValues,
+  values: challengeContributionRolesFilterValues,
   collapsed: false,
 };

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -33,16 +33,18 @@
   </section>
   <section id="bottom" class="content">
     <div class="facets">
-      <ng-container *ngFor="let checkbox of checkboxFilters">
-        <p-panel header="{{ checkbox.label }}" [toggleable]="true" [collapsed]="checkbox.collapsed">
-          <openchallenges-checkbox-filter
-            [values]="checkbox.values"
-            (selectionChange)="onCheckboxSelectionChange($event, checkbox.query)"
-            inputId="{{ checkbox.query }}"
-          ></openchallenges-checkbox-filter>
-        </p-panel>
-        <!-- <p-divider></p-divider> -->
-      </ng-container>
+      <p-panel
+        header="{{ contributionRolesFilter.label }}"
+        [toggleable]="true"
+        [collapsed]="contributionRolesFilter.collapsed"
+      >
+        <openchallenges-checkbox-filter
+          [values]="contributionRolesFilter.values"
+          [selectedValues]="selectedContributionRoles"
+          (selectionChange)="onContributionRolesChange($event)"
+          inputId="{{ contributionRolesFilter.query }}"
+        ></openchallenges-checkbox-filter>
+      </p-panel>
     </div>
     <div class="main col">
       <h3>Results ({{ searchResultsCount }})</h3>
@@ -54,8 +56,8 @@
         </openchallenges-organization-card>
       </div>
       <openchallenges-paginator
-        [pageNumber]="pageNumber"
-        [pageSize]="pageSize"
+        [pageNumber]="selectedPageNumber || defaultPageNumber"
+        [pageSize]="selectedPageSize || defaultPageSize"
         [totalRecords]="searchResultsCount"
         [itemsPerPage]="[12, 24, 36, 48]"
         (pageChange)="onPageChange($event)"

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -12,7 +12,7 @@
           <input
             type="text"
             pInputText
-            [(ngModel)]="searchTermValue"
+            [(ngModel)]="searchedTerms"
             (input)="onSearchChange()"
             placeholder="Search organizations"
           />

--- a/libs/openchallenges/org-search/src/lib/org-search.component.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.ts
@@ -55,7 +55,6 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
   );
 
   private destroy = new Subject<void>();
-  searchTermValue = '';
 
   searchResultsCount = 0;
   totalOrgCount = 0;
@@ -192,7 +191,7 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
 
   onSearchChange(): void {
     // update searchTerms to trigger the query' searchTerm
-    this.searchTerms.next(this.searchTermValue);
+    this.searchTerms.next(this.searchedTerms);
   }
 
   onContributionRolesChange(selected: string[]): void {

--- a/libs/openchallenges/org-search/src/lib/org-search.component.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.ts
@@ -25,6 +25,7 @@ import {
   of,
   Observable,
   forkJoin,
+  tap,
 } from 'rxjs';
 import {
   catchError,
@@ -131,7 +132,9 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
       });
 
     const orgPage$ = this.query.pipe(
+      tap((query) => console.log('List organization query: ', query)),
       switchMap((query) => this.organizationService.listOrganizations(query)),
+      tap((page) => console.log('List of organizations: ', page.organizations)),
       catchError((err) => {
         if (err.message) {
           this.openSnackBar(


### PR DESCRIPTION
- resolves #1705 

### Preview
---
#### Capture the filter values in the URL

https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/cd669d55-1236-4b7c-8913-f19e6a5dc125

- The pagination and sort filters are also captured (not showing in the recording above)

#### Go to Org Search page with a shareable link

https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/3ca20289-ebe8-43ea-a84f-9895d844b92b

