### PR TITLE
feat(ui): Preserve the content space to make footer sticky at the bottom

### DIFF
--- a/libs/openchallenges/challenge/src/lib/challenge.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.html
@@ -1,88 +1,90 @@
-<main class="base mat-typography" *ngIf="challenge$ | async as challenge">
-  <section id="profile-top" class="row">
-    <openchallenges-avatar
-        class="profile-pic"
-        [avatar]="challengeAvatar"
-      ></openchallenges-avatar>
-    <div id="profile-details" class="col">
-      <h2>
-        {{ challenge.name }}
-        <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
-      </h2>
-      <p class="username">@{{ challenge.slug }}</p>
-      <div class="profile-type"
-        *ngIf="challenge.status"
-        [ngClass]="['status', challenge.status ? challenge.status : '']"
-        >{{ challenge.status }}</div>
-    </div>
-  </section>
-  <section id="profile-stats" class="row">
-    <div class="col fill-empty"></div>
-    <div class="col">
-      <openchallenges-challenge-stats [loggedIn]="loggedIn"></openchallenges-challenge-stats>
-    </div>
-  </section>
-  <section id="profile-bottom" class="content">
-    <div class="profile-sidenav col">
-      <div class="profile-nav-group">
-        <a
-          class="profile-nav-item"
-          routerLink="."
-          [queryParams]="{ tab: 'overview' }"
-          [ngClass]="{ 'active-tab': activeTab === tabs['overview'] }"
+<main class="base mat-typography">
+  <ng-container *ngIf="challenge$ | async as challenge">
+    <section id="profile-top" class="row">
+      <openchallenges-avatar class="profile-pic" [avatar]="challengeAvatar"></openchallenges-avatar>
+      <div id="profile-details" class="col">
+        <h2>
+          {{ challenge.name }}
+          <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
+        </h2>
+        <p class="username">@{{ challenge.slug }}</p>
+        <div
+          class="profile-type"
+          *ngIf="challenge.status"
+          [ngClass]="['status', challenge.status ? challenge.status : '']"
         >
-          Overview
-        </a>
-        <a
-          class="profile-nav-item"
-          routerLink="."
-          [queryParams]="{ tab: 'organizers' }"
-          [ngClass]="{ 'active-tab': activeTab === tabs['organizers'] }"
-        >
-          Organizers
-        </a>
-        <a
-          class="profile-nav-item"
-          routerLink="."
-          [queryParams]="{ tab: 'sponsors' }"
-          [ngClass]="{ 'active-tab': activeTab === tabs['sponsors'] }"
-        >
-          Sponsors
-        </a>
-        <a
-          class="profile-nav-item"
-          routerLink="."
-          [queryParams]="{ tab: 'stargazers' }"
-          [ngClass]="{ 'active-tab': activeTab === tabs['stargazers'] }"
-        >
-          Stargazers
-        </a>
+          {{ challenge.status }}
+        </div>
       </div>
-    </div>
-    <div class="main col">
-      <ng-container [ngSwitch]="activeTab">
-        <openchallenges-challenge-overview
-          *ngSwitchCase="tabs['overview']"
-          [challenge]="challenge"
-        >
-        </openchallenges-challenge-overview>
-        <openchallenges-challenge-organizers
-          *ngSwitchCase="tabs['organizers']"
-          [challenge]="challenge"
-        >
-        </openchallenges-challenge-organizers>
-        <openchallenges-challenge-sponsors
-          *ngSwitchCase="tabs['sponsors']"
-          [challenge]="challenge"
-        >
-        </openchallenges-challenge-sponsors>
-        <openchallenges-challenge-stargazers
-          *ngSwitchCase="tabs['stargazers']"
-          [challenge]="challenge"
-        >
-        </openchallenges-challenge-stargazers>
-      </ng-container>
-    </div>
-  </section>
+    </section>
+    <section id="profile-stats" class="row">
+      <div class="col fill-empty"></div>
+      <div class="col">
+        <openchallenges-challenge-stats [loggedIn]="loggedIn"></openchallenges-challenge-stats>
+      </div>
+    </section>
+    <section id="profile-bottom" class="content">
+      <div class="profile-sidenav col">
+        <div class="profile-nav-group">
+          <a
+            class="profile-nav-item"
+            routerLink="."
+            [queryParams]="{ tab: 'overview' }"
+            [ngClass]="{ 'active-tab': activeTab === tabs['overview'] }"
+          >
+            Overview
+          </a>
+          <a
+            class="profile-nav-item"
+            routerLink="."
+            [queryParams]="{ tab: 'organizers' }"
+            [ngClass]="{ 'active-tab': activeTab === tabs['organizers'] }"
+          >
+            Organizers
+          </a>
+          <a
+            class="profile-nav-item"
+            routerLink="."
+            [queryParams]="{ tab: 'sponsors' }"
+            [ngClass]="{ 'active-tab': activeTab === tabs['sponsors'] }"
+          >
+            Sponsors
+          </a>
+          <a
+            class="profile-nav-item"
+            routerLink="."
+            [queryParams]="{ tab: 'stargazers' }"
+            [ngClass]="{ 'active-tab': activeTab === tabs['stargazers'] }"
+          >
+            Stargazers
+          </a>
+        </div>
+      </div>
+      <div class="main col">
+        <ng-container [ngSwitch]="activeTab">
+          <openchallenges-challenge-overview
+            *ngSwitchCase="tabs['overview']"
+            [challenge]="challenge"
+          >
+          </openchallenges-challenge-overview>
+          <openchallenges-challenge-organizers
+            *ngSwitchCase="tabs['organizers']"
+            [challenge]="challenge"
+          >
+          </openchallenges-challenge-organizers>
+          <openchallenges-challenge-sponsors
+            *ngSwitchCase="tabs['sponsors']"
+            [challenge]="challenge"
+          >
+          </openchallenges-challenge-sponsors>
+          <openchallenges-challenge-stargazers
+            *ngSwitchCase="tabs['stargazers']"
+            [challenge]="challenge"
+          >
+          </openchallenges-challenge-stargazers>
+        </ng-container>
+      </div>
+    </section>
+  </ng-container>
 </main>
 <openchallenges-footer [version]="appVersion"></openchallenges-footer>

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.html
@@ -1,70 +1,72 @@
-<main class="base mat-typography" *ngIf="organization$ | async as org">
-  <section id="profile-top" class="row">
-    <openchallenges-avatar
-      *ngIf="organizationAvatar$ | async as organizationAvatar"
-      class="profile-pic"
-      [avatar]="organizationAvatar"
-    ></openchallenges-avatar>
-    <div id="profile-details" class="col">
-      <h2>
-        {{ org.name }}
-        <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
-      </h2>
-      <p class="username">@{{ org.login }}</p>
-      <div class="profile-type">Organization</div>
-    </div>
-  </section>
-  <section id="profile-stats" class="row">
-    <div class="col fill-empty"></div>
-    <div class="col">
-      <openchallenges-org-profile-stats [loggedIn]="loggedIn"></openchallenges-org-profile-stats>
-    </div>
-  </section>
-  <section id="profile-bottom" class="content">
-    <div class="profile-sidenav col">
-      <div class="profile-nav-group">
-        <a
-          class="profile-nav-item"
-          routerLink="."
-          [queryParams]="{ tab: 'overview' }"
-          [ngClass]="{ 'active-tab': activeTab === tabs['overview'] }"
-        >
-          Overview
-        </a>
-        <a
-          class="profile-nav-item"
-          routerLink="."
-          [queryParams]="{ tab: 'challenges' }"
-          [ngClass]="{ 'active-tab': activeTab === tabs['challenges'] }"
-        >
-          Challenges
-        </a>
-        <a
-          class="profile-nav-item"
-          routerLink="."
-          [queryParams]="{ tab: 'members' }"
-          [ngClass]="{ 'active-tab': activeTab === tabs['members'] }"
-        >
-          Members
-        </a>
+<main class="base mat-typography">
+  <ng-container *ngIf="organization$ | async as org">
+    <section id="profile-top" class="row">
+      <openchallenges-avatar
+        *ngIf="organizationAvatar$ | async as organizationAvatar"
+        class="profile-pic"
+        [avatar]="organizationAvatar"
+      ></openchallenges-avatar>
+      <div id="profile-details" class="col">
+        <h2>
+          {{ org.name }}
+          <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
+        </h2>
+        <p class="username">@{{ org.login }}</p>
+        <div class="profile-type">Organization</div>
       </div>
-    </div>
-    <div class="main col">
-      <ng-container [ngSwitch]="activeTab">
-        <openchallenges-org-profile-overview
-          *ngSwitchCase="tabs['overview']"
-          [organization]="org"
-        >
-        </openchallenges-org-profile-overview>
-        <openchallenges-org-profile-challenges
-          *ngSwitchCase="tabs['challenges']"
-          [organization]="org"
-        >
-        </openchallenges-org-profile-challenges>
-        <openchallenges-org-profile-members *ngSwitchCase="tabs['members']" [organization]="org">
-        </openchallenges-org-profile-members>
-      </ng-container>
-    </div>
-  </section>
+    </section>
+    <section id="profile-stats" class="row">
+      <div class="col fill-empty"></div>
+      <div class="col">
+        <openchallenges-org-profile-stats [loggedIn]="loggedIn"></openchallenges-org-profile-stats>
+      </div>
+    </section>
+    <section id="profile-bottom" class="content">
+      <div class="profile-sidenav col">
+        <div class="profile-nav-group">
+          <a
+            class="profile-nav-item"
+            routerLink="."
+            [queryParams]="{ tab: 'overview' }"
+            [ngClass]="{ 'active-tab': activeTab === tabs['overview'] }"
+          >
+            Overview
+          </a>
+          <a
+            class="profile-nav-item"
+            routerLink="."
+            [queryParams]="{ tab: 'challenges' }"
+            [ngClass]="{ 'active-tab': activeTab === tabs['challenges'] }"
+          >
+            Challenges
+          </a>
+          <a
+            class="profile-nav-item"
+            routerLink="."
+            [queryParams]="{ tab: 'members' }"
+            [ngClass]="{ 'active-tab': activeTab === tabs['members'] }"
+          >
+            Members
+          </a>
+        </div>
+      </div>
+      <div class="main col">
+        <ng-container [ngSwitch]="activeTab">
+          <openchallenges-org-profile-overview
+            *ngSwitchCase="tabs['overview']"
+            [organization]="org"
+          >
+          </openchallenges-org-profile-overview>
+          <openchallenges-org-profile-challenges
+            *ngSwitchCase="tabs['challenges']"
+            [organization]="org"
+          >
+          </openchallenges-org-profile-challenges>
+          <openchallenges-org-profile-members *ngSwitchCase="tabs['members']" [organization]="org">
+          </openchallenges-org-profile-members>
+        </ng-container>
+      </div>
+    </section>
+  </ng-container>
 </main>
 <openchallenges-footer [version]="appVersion"></openchallenges-footer>


### PR DESCRIPTION
- fixes #1687 

Move `ngIf="organization$` to an extra inner `ng-container` to preserve the content space. The footer will always be at the bottom, even if the data is empty initially (due to delays).

>**Note**: 
> If the data is undefined after the requests are complete, the page will still be redirected to "Not Found" page. Although I haven't tested since I still have troubles loading images, I expect no flashes of height difference.

```html
 <!-- original -->
<main class="base mat-typography" *ngIf="organization$ | async as org">
  ...
<main>

 <!-- change to -->
<main class="base mat-typography">
  <ng-container *ngIf="organization$ | async as org">
  ...
  </ng-container>
<main>
```

The changes above are only applied to Challenge Profile and Org Profile pages.