### PR TITLE
docs: Show Sage Monorepo README when new dev container starts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,11 @@
   },
 
   "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "README.md"
+      ]
+    },
     "vscode": {
       "extensions": [
         "1000ch.svgo",
@@ -36,7 +41,9 @@
         "vscjava.vscode-java-pack",
         "webhint.vscode-webhint"
       ],
-      "settings": {}
+      "settings": {
+        "workbench.startupEditor": "readme"
+      }
     }
   },
 


### PR DESCRIPTION
Closes #1700

## Notes

- It looks like only GitHub Codespace offers this feature. I tried VS Code settings `"workbench.startupEditor": "readme"` but couldn't manage to get it to display the README when opening the folder. I'm also worried that using this option would open the README instead of the last files opened. I also have this concern for GH Codespace, but that's less critical since I don't see us developing on Codespace actively, but instead showing the README would be a plus in Codespace for demo. 
- The change made by this PR can be revert anytime if needed.

## References

- VS Code: https://code.visualstudio.com/docs/getstarted/settings#_settingsjson
- Codespace: [Automatically opening files in the codespaces for a repository](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/configuring-dev-containers/automatically-opening-files-in-the-codespaces-for-a-repository)