### PR TITLE
chore: Identify Docker credential storage strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - run: compgen -A command docker
+
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-single-buildx
 
       - name: Install devcontainer CLI
-        run: npm install -g @devcontainers/cli@0.25.2
+        run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container
         run: |
@@ -206,8 +206,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
 
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v2
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Install devcontainer CLI
-        run: npm install -g @devcontainers/cli@0.25.2
+        run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container
         run: |
@@ -247,6 +260,11 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=build-image"
+
+      - name: Publish the images of the projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=publish-image"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,8 @@ jobs:
           # host (i.e. outside the dev container).
           ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-          devcontainer up --workspace-folder ../sage-monorepo
+          devcontainer up --workspace-folder ../sage-monorepo \
+            --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker
 
       - name: Prepare the workspace in the dev container
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
           ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
           devcontainer up --workspace-folder ../sage-monorepo \
-            --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker
+            --mount type="bind,source=$HOME/.docker,target=/home/vscode/.docker"
 
       - name: Prepare the workspace in the dev container
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,8 @@ jobs:
 
       - run: cat ~/.docker/config.json
 
+      - run: echo $HOME
+
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,8 @@ jobs:
 
       - run: compgen -A command docker
 
+      - run: cat ~/.docker/config.json
+
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 

--- a/apps/openchallenges/zipkin/Dockerfile
+++ b/apps/openchallenges/zipkin/Dockerfile
@@ -1,1 +1,1 @@
-FROM openzipkin/zipkin:2.24.0
+FROM openzipkin/zipkin:2.24.2

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -30,7 +30,7 @@
       "executor": "@nx-tools/nx-container:build",
       "options": {
         "context": "apps/openchallenges/zipkin",
-        "push": false,
+        "push": true,
         "tags": ["sagemonorepo/openchallenges-zipkin:latest"]
       }
     }

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -23,7 +23,15 @@
       "options": {
         "context": "apps/openchallenges/zipkin",
         "push": false,
-        "tags": ["sagebionetworks/openchallenges-zipkin:latest"]
+        "tags": ["sagemonorepo/openchallenges-zipkin:latest"]
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "context": "apps/openchallenges/zipkin",
+        "push": false,
+        "tags": ["sagemonorepo/openchallenges-zipkin:latest"]
       }
     }
   },


### PR DESCRIPTION
The base branch of this PR has been created on the upstream GH repo so that the CI/CD workflow can access the secrets of this repository.

The goal of this PR is to identify how to share the Docker credentials with the dev container.

## Conclusion

The GitHub runner stores the Docker credentials when logging into Docker Hub entirely in `$HOME/.docker/config.json`. Mounting `$HOME/.docker` to the dev container enables us to push images to Docker Hub from inside the dev container.

```console
          devcontainer up --workspace-folder ../sage-monorepo \
            --mount type="bind,source=$HOME/.docker,target=/home/vscode/.docker"
```