### PR TITLE
docs: Attempt to push image to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,12 +219,6 @@ jobs:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - run: compgen -A command docker
-
-      - run: cat ~/.docker/config.json
-
-      - run: echo $HOME
-
       - name: Install devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-single-buildx
 
       - name: Install devcontainer CLI
-        run: npm install -g @devcontainers/cli@0.25.2
+        run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container
         run: |
@@ -206,8 +206,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - run: compgen -A command docker
+
+      - run: cat ~/.docker/config.json
+
+      - run: echo $HOME
+
       - name: Install devcontainer CLI
-        run: npm install -g @devcontainers/cli@0.25.2
+        run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container
         run: |
@@ -216,7 +235,8 @@ jobs:
           # host (i.e. outside the dev container).
           ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-          devcontainer up --workspace-folder ../sage-monorepo
+          devcontainer up --workspace-folder ../sage-monorepo \
+            --mount type="bind,source=$HOME/.docker,target=/home/vscode/.docker"
 
       - name: Prepare the workspace in the dev container
         run: |
@@ -247,6 +267,11 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=build-image"
+
+      - name: Publish the images of the projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=publish-image"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/apps/openchallenges/zipkin/Dockerfile
+++ b/apps/openchallenges/zipkin/Dockerfile
@@ -1,1 +1,1 @@
-FROM openzipkin/zipkin:2.24.0
+FROM openzipkin/zipkin:2.24.2

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -23,7 +23,15 @@
       "options": {
         "context": "apps/openchallenges/zipkin",
         "push": false,
-        "tags": ["sagebionetworks/openchallenges-zipkin:latest"]
+        "tags": ["ghcr.io/sage-bionetworks/openchallenges-zipkin:latest"]
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "context": "apps/openchallenges/zipkin",
+        "push": true,
+        "tags": ["ghcr.io/sage-bionetworks/openchallenges-zipkin:latest"]
       }
     }
   },


### PR DESCRIPTION
## Description

The goal of this PR/ticket is to explore how to push images to GitHub Container Registry instead of Docker Hub.

## Notes

- The Docker credentials for GHCR are fully stored in `$HOME/.docker/config.json`
- I deleted the Docker Hub token that has been exposed.

## Conclusion

I was able to push the image for the project `openchallenges-zipkin` to GHCR. See the image repository [here](https://github.com/Sage-Bionetworks/sage-monorepo/pkgs/container/openchallenges-zipkin).