### PR TITLE
chore: Update `docker-in-docker`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Sage",
-  "image": "sagebionetworks/sage-devcontainer:7f9d3e3",
+  "image": "sagebionetworks/sage-devcontainer:e045b26",
 
   "containerEnv": {
     "NX_BASE": "${localEnv:NX_BASE}",
@@ -13,8 +13,8 @@
   },
 
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2.0.0": {
-      "version": "20.10.21"
+    "ghcr.io/devcontainers/features/docker-in-docker:2.2.0": {
+      "version": "20.10.24"
     }
   },
 


### PR DESCRIPTION
Closes #1727

## Changelog

- Update `docker-in-docker` to v2.2.0
- Update Docker to v20.10.24

## Notes

- It looks like the latest version of `docker-in-docker` (v2.2.0) can not install versions of Docker above 20.10.x.
  - I opened a ticket in the feature repo: https://github.com/devcontainers/features/issues/607