### PR TITLE
feat: Explore Trivy to scan docker images

### DIFF
--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -25,6 +25,12 @@
         "push": false,
         "tags": ["sagebionetworks/openchallenges-zipkin:latest"]
       }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image sagebionetworks/openchallenges-zipkin:latest --quiet"
+      }
     }
   },
   "tags": ["type:service", "scope:backend"],

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -29,7 +29,8 @@
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "trivy image sagebionetworks/openchallenges-zipkin:latest --quiet"
+        "command": "trivy image sagebionetworks/openchallenges-zipkin:latest --quiet",
+        "color": true
       }
     }
   },


### PR DESCRIPTION
Closes #1730

## Description

Scan the Docker image of a project with Trivy:

```console
nx build-image <project>
nx scan-image <project>
```

## TODO

- [x] Check how to conserve the output colors from Trivy when running the command with Nx
    - https://github.com/nrwl/nx/issues/8051
    - Updating Nx may help (future ticket)

## Changelog

- Add the task `scan-image` to the project `openchallenges-zipkin`

## Preview

```console
vscode@3d8deaace953:/workspaces/sage-monorepo$ nx scan-image openchallenges-zipkin

> nx run openchallenges-zipkin:scan-image

sagebionetworks/openchallenges-zipkin:latest (alpine 3.16.3)
============================================================
Total: 26 (UNKNOWN: 0, LOW: 0, MEDIUM: 8, HIGH: 18, CRITICAL: 0)
┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2022-3996 │ HIGH     │ 3.0.7-r0          │ 3.0.7-r2      │ openssl: double locking leads to denial of service         │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-3996                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4450 │          │                   │ 3.0.8-r0      │ double free after calling PEM_read_bio_ex                  │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0215 │          │                   │               │ use-after-free following BIO_new_NDEF                      │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0216 │          │                   │               │ invalid pointer dereference in d2i_PKCS7 functions         │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0216                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0217 │          │                   │               │ NULL dereference validating DSA public key                 │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0217                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0286 │          │                   │               │ X.400 address type confusion in X.509 GeneralName          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0401 │          │                   │               │ NULL dereference during PKCS7 data verification            │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0401                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0464 │          │                   │ 3.1.0-r1      │ Denial of service by excessive resource usage in verifying │
│            │               │          │                   │               │ X509 policy constraints...                                 │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-2650 │          │                   │ 3.1.1-r0      │ Possible DoS translating ASN.1 object identifiers          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                  │
│            ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4203 │ MEDIUM   │                   │ 3.0.8-r0      │ read buffer overflow in X.509 certificate verification     │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4203                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4304 │          │                   │               │ timing attack in RSA Decryption implementation             │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0465 │          │                   │ 3.1.0-r2      │ Invalid certificate policies in leaf certificates are      │
│            │               │          │                   │               │ silently ignored                                           │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-1255 │          │                   │ 3.1.0-r4      │ Input buffer over-read in AES-XTS implementation on 64 bit │
│            │               │          │                   │               │ ARM                                                        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-1255                  │
├────────────┼───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2022-3996 │ HIGH     │                   │ 3.0.7-r2      │ openssl: double locking leads to denial of service         │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-3996                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4450 │          │                   │ 3.0.8-r0      │ double free after calling PEM_read_bio_ex                  │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0215 │          │                   │               │ use-after-free following BIO_new_NDEF                      │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0216 │          │                   │               │ invalid pointer dereference in d2i_PKCS7 functions         │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0216                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0217 │          │                   │               │ NULL dereference validating DSA public key                 │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0217                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0286 │          │                   │               │ X.400 address type confusion in X.509 GeneralName          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0401 │          │                   │               │ NULL dereference during PKCS7 data verification            │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0401                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0464 │          │                   │ 3.1.0-r1      │ Denial of service by excessive resource usage in verifying │
│            │               │          │                   │               │ X509 policy constraints...                                 │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-2650 │          │                   │ 3.1.1-r0      │ Possible DoS translating ASN.1 object identifiers          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                  │
│            ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4203 │ MEDIUM   │                   │ 3.0.8-r0      │ read buffer overflow in X.509 certificate verification     │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4203                  │
│            ├───────────────┤          │                   │               ├────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4304 │          │                   │               │ timing attack in RSA Decryption implementation             │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0465 │          │                   │ 3.1.0-r2      │ Invalid certificate policies in leaf certificates are      │
│            │               │          │                   │               │ silently ignored                                           │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-1255 │          │                   │ 3.1.0-r4      │ Input buffer over-read in AES-XTS implementation on 64 bit │
│            │               │          │                   │               │ ARM                                                        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-1255                  │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
Java (jar)
==========
Total: 10 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 3, CRITICAL: 2)
┌─────────────────────────────────────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────────────────────┬────────────────────────────────────────────────────────────┐
│                           Library                           │ Vulnerability  │ Severity │ Installed Version │         Fixed Version         │                           Title                            │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────────────────────┼────────────────────────────────────────────────────────────┤
│ io.netty:netty-codec-haproxy                                │ CVE-2022-41881 │ HIGH     │ 4.1.78.Final      │ 4.1.86.Final                  │ HAProxyMessageDecoder Stack Exhaustion DoS                 │
│ (netty-codec-haproxy-4.1.78.Final.jar)                      │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2022-41881                 │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┤                   ├───────────────────────────────┼────────────────────────────────────────────────────────────┤
│ io.netty:netty-handler (netty-handler-4.1.78.Final.jar)     │ CVE-2023-34462 │ MEDIUM   │                   │ 4.1.94.Final                  │ Netty is an asynchronous event-driven network application  │
│                                                             │                │          │                   │                               │ framework fo ...                                           │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-34462                 │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────────────────────┼────────────────────────────────────────────────────────────┤
│ org.springframework.boot:spring-boot-actuator-autoconfigure │ CVE-2023-20873 │ CRITICAL │ 2.5.14            │ 2.7.11, 3.0.6                 │ Spring Boot Security Bypass with Wildcard Pattern Matching │
│ (spring-boot-actuator-autoconfigure-2.5.14.jar)             │                │          │                   │                               │ on Cloud Foundry                                           │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-20873                 │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┤                   ├───────────────────────────────┼────────────────────────────────────────────────────────────┤
│ org.springframework.boot:spring-boot-autoconfigure          │ CVE-2023-20883 │ HIGH     │                   │ 2.7.12, 3.0.7, 2.5.15, 2.6.15 │ Spring Boot Welcome Page DoS Vulnerability                 │
│ (spring-boot-autoconfigure-2.5.14.jar)                      │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-20883                 │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────────────────────┼────────────────────────────────────────────────────────────┤
│ org.springframework:spring-core (spring-core-5.3.20.jar)    │ CVE-2023-20861 │ MEDIUM   │ 5.3.20            │ 5.3.26, 6.0.7, 5.2.23.RELEASE │ Spring Expression DoS Vulnerability                        │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-20861                 │
│                                                             ├────────────────┤          │                   ├───────────────────────────────┼────────────────────────────────────────────────────────────┤
│                                                             │ CVE-2023-20863 │          │                   │ 5.3.27, 6.0.8, 5.2.24.RELEASE │ Spring Expression DoS Vulnerability                        │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-20863                 │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────────────────────┼────────────────────────────────────────────────────────────┤
│ org.xerial.snappy:snappy-java (snappy-java-1.1.8.1.jar)     │ CVE-2023-34455 │ HIGH     │ 1.1.8.1           │ 1.1.10.1                      │ snappy-java's unchecked chunk length leads to DoS          │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-34455                 │
│                                                             ├────────────────┼──────────┤                   │                               ├────────────────────────────────────────────────────────────┤
│                                                             │ CVE-2023-34453 │ MEDIUM   │                   │                               │ snappy-java's Integer Overflow vulnerability in shuffle    │
│                                                             │                │          │                   │                               │ leads to DoS                                               │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-34453                 │
│                                                             ├────────────────┤          │                   │                               ├────────────────────────────────────────────────────────────┤
│                                                             │ CVE-2023-34454 │          │                   │                               │ snappy-java's Integer Overflow vulnerability in compress   │
│                                                             │                │          │                   │                               │ leads to DoS                                               │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2023-34454                 │
├─────────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────────────────────┼────────────────────────────────────────────────────────────┤
│ org.yaml:snakeyaml (snakeyaml-1.33.jar)                     │ CVE-2022-1471  │ CRITICAL │ 1.33              │ 2.0                           │ Constructor Deserialization Remote Code Execution          │
│                                                             │                │          │                   │                               │ https://avd.aquasec.com/nvd/cve-2022-1471                  │
└─────────────────────────────────────────────────────────────┴────────────────┴──────────┴───────────────────┴───────────────────────────────┴────────────────────────────────────────────────────────────┘
```