### PR TITLE
chore: Push OpenChallenges images to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,17 +126,17 @@ jobs:
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build-image"
+            && nx run-many --target=build-image --projects=openchallenges-*"
 
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=scan-image"
+            && nx run-many --target=scan-image --projects=openchallenges-*"
 
       - name: Publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=publish-image"
+            && nx run-many --target=publish-image --projects=openchallenges-*"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -264,12 +264,12 @@ jobs:
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build-image"
+            && nx run-many --target=build-image --projects=openchallenges-*"
 
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=scan-image"
+            && nx run-many --target=scan-image --projects=openchallenges-*"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-*"
+            && nx run-many --target=scan-image --projects=openchallenges-* --max-parallel=1"
 
       - name: Publish the images of the affected projects
         run: |
@@ -269,7 +269,7 @@ jobs:
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-*"
+            && nx run-many --target=scan-image --projects=openchallenges-* --max-parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,12 +131,12 @@ jobs:
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
+            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch,openchallenges-rstudio"
 
       - name: Publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
+            && nx run-many --target=publish-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch,openchallenges-rstudio"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -264,14 +264,14 @@ jobs:
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
+            && nx run-many --target=build-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch,openchallenges-rstudio"
 
       - run: df -h
 
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
+            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch,openchallenges-rstudio"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,12 +131,12 @@ jobs:
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-* --max-parallel=1"
+            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
 
       - name: Publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-image --projects=openchallenges-*"
+            && nx run-many --target=publish-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -264,14 +264,14 @@ jobs:
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-image --projects=openchallenges-* --max-parallel=1"
+            && nx run-many --target=build-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
 
       - run: df -h
 
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-* --max-parallel=1"
+            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,9 @@ jobs:
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-image --projects=openchallenges-*"
+            && nx run-many --target=build-image --projects=openchallenges-* --max-parallel=1"
+
+      - run: df -h
 
       - name: Scan the images of the affected projects
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,12 +131,12 @@ jobs:
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
+            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
 
       - name: Publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
+            && nx run-many --target=publish-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -264,14 +264,14 @@ jobs:
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
+            && nx run-many --target=build-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
 
       - run: df -h
 
       - name: Scan the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault"
+            && nx run-many --target=scan-image --projects=openchallenges-* --exclude=openchallenges-zipkin,openchallenges-vault,openchallenges-elasticsearch"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -21,6 +21,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/apex",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-apex"],
           "tags": [

--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -21,9 +21,35 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/apex",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-apex:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-apex"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-apex"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-apex:local --quiet",
+        "color": true
       }
     }
   },

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -64,11 +64,37 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/api-gateway",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-api-gateway:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-api-gateway"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build-image-base"]
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-api-gateway"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-api-gateway:local --quiet",
+        "color": true
+      }
     }
   },
   "tags": ["type:service", "scope:backend"],

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -64,6 +64,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/api-gateway",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-api-gateway"],
           "tags": [

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -139,11 +139,37 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/app",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-app:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-app"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build"]
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-app"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-app:local --quiet",
+        "color": true
+      }
     },
     "server": {
       "executor": "@angular-devkit/build-angular:server",

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -139,6 +139,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/app",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-app"],
           "tags": [

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -73,11 +73,37 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/challenge-service",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-challenge-service:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-challenge-service"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build-image-base"]
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-challenge-service"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-challenge-service:local --quiet",
+        "color": true
+      }
     },
     "openapi-generate": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -73,6 +73,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/challenge-service",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-challenge-service"],
           "tags": [

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -81,6 +81,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/config-server",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-config-server"],
           "tags": [

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -81,11 +81,37 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/config-server",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-config-server:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-config-server"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build-image-base"]
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-config-server"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-config-server:local --quiet",
+        "color": true
+      }
     }
   },
   "tags": ["type:service", "scope:backend"],

--- a/apps/openchallenges/elasticsearch/project.json
+++ b/apps/openchallenges/elasticsearch/project.json
@@ -21,6 +21,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/elasticsearch",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-elasticsearch"],
           "tags": [

--- a/apps/openchallenges/elasticsearch/project.json
+++ b/apps/openchallenges/elasticsearch/project.json
@@ -21,9 +21,35 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/elasticsearch",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-elasticsearch:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-elasticsearch"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-elasticsearch"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-elasticsearch:local --quiet",
+        "color": true
       }
     }
   },

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -24,6 +24,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/grafana",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-grafana"],
           "tags": [

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -24,9 +24,35 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/grafana",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-grafana:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-grafana"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-grafana"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-grafana:local --quiet",
+        "color": true
       }
     },
     "create-api-key": {

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -80,11 +80,37 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/image-service",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-image-service:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-image-service"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build-image-base"]
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-image-service"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-image-service:local --quiet",
+        "color": true
+      }
     },
     "openapi-generate": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -80,6 +80,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/image-service",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-image-service"],
           "tags": [

--- a/apps/openchallenges/mariadb/project.json
+++ b/apps/openchallenges/mariadb/project.json
@@ -20,9 +20,35 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/mariadb",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-mariadb:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-mariadb"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-mariadb"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-mariadb:local --quiet",
+        "color": true
       }
     }
   },

--- a/apps/openchallenges/mariadb/project.json
+++ b/apps/openchallenges/mariadb/project.json
@@ -20,6 +20,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/mariadb",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-mariadb"],
           "tags": [

--- a/apps/openchallenges/mysqld-exporter/project.json
+++ b/apps/openchallenges/mysqld-exporter/project.json
@@ -21,9 +21,35 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/mysqld-exporter",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-mysqld-exporter:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:local --quiet",
+        "color": true
       }
     }
   },

--- a/apps/openchallenges/mysqld-exporter/project.json
+++ b/apps/openchallenges/mysqld-exporter/project.json
@@ -21,6 +21,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/mysqld-exporter",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter"],
           "tags": [

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -73,11 +73,37 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/organization-service",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-organization-service:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-organization-service"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build-image-base"]
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-organization-service"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-organization-service:local --quiet",
+        "color": true
+      }
     },
     "openapi-generate": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -73,6 +73,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/organization-service",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-organization-service"],
           "tags": [

--- a/apps/openchallenges/prometheus/project.json
+++ b/apps/openchallenges/prometheus/project.json
@@ -21,9 +21,35 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/prometheus",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-prometheus:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-prometheus"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-prometheus"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-prometheus:local --quiet",
+        "color": true
       }
     }
   },

--- a/apps/openchallenges/prometheus/project.json
+++ b/apps/openchallenges/prometheus/project.json
@@ -21,6 +21,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/prometheus",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-prometheus"],
           "tags": [

--- a/apps/openchallenges/rstudio/project.json
+++ b/apps/openchallenges/rstudio/project.json
@@ -11,20 +11,46 @@
         "cwd": "apps/openchallenges/rstudio"
       }
     },
-    "build-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": "apps/openchallenges/rstudio",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-rstudio:latest"]
-      }
-    },
     "serve-detach": {
       "executor": "nx:run-commands",
       "options": {
         "command": "docker/openchallenges/serve-detach.sh openchallenges-rstudio"
       },
       "dependsOn": []
+    },
+    "build-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-rstudio"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-rstudio"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-rstudio:local --quiet",
+        "color": true
+      }
     }
   },
   "tags": ["type:app", "scope:client"],

--- a/apps/openchallenges/rstudio/project.json
+++ b/apps/openchallenges/rstudio/project.json
@@ -21,6 +21,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/rstudio",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-rstudio"],
           "tags": [

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -69,6 +69,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/service-registry",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-service-registry"],
           "tags": [

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -69,11 +69,37 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/service-registry",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-service-registry:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-service-registry"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build-image-base"]
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-service-registry"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-service-registry:local --quiet",
+        "color": true
+      }
     }
   },
   "tags": ["type:service", "scope:backend"],

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -15,8 +15,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "docker/openchallenges/serve-detach.sh openchallenges-thumbor"
-      },
-      "dependsOn": []
+      }
     },
     "build-image": {
       "executor": "@nx-tools/nx-container:build",

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -21,9 +21,35 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/openchallenges/thumbor",
-        "push": false,
-        "tags": ["sagebionetworks/openchallenges-thumbor:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-thumbor"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
+      }
+    },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/openchallenges-thumbor"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-thumbor:local --quiet",
+        "color": true
       }
     }
   },

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -20,6 +20,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/thumbor",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-thumbor"],
           "tags": [

--- a/apps/openchallenges/vault/project.json
+++ b/apps/openchallenges/vault/project.json
@@ -20,6 +20,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/vault",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-vault"],
           "tags": [

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -20,6 +20,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/zipkin",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-zipkin"],
           "tags": [


### PR DESCRIPTION
Closes #1708

## Changelog

- Update all the OpenChallenges projects that can be deployed with `docker/openchallenges/serve-detach.sh` to build, scan and publish their images to GHCR, except a few images (see Nx option `--exclude`).
- Temporarily build, scan and publish all OC images, which will be reverted to `affected` once all the images have been published once.

## Notes

- The GH runner has 84 GB of storage, which is not enough to build all the OC images. I bumped into this issue here because I use `run-many` but ultimately building the images only for the `affected` projects will make things work. For now I work around this issue with `run-many` using the option `--exclude=A,B`.