### PR TITLE
fix: Restore nx serve-detach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,22 +123,22 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
-      - name: Build the images of the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-image --projects=openchallenges-*"
+      # - name: Build the images of the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx run-many --target=build-image --projects=openchallenges-*"
 
-      - run: df -h
+      # - run: df -h
 
       # - name: Scan the images of the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
       #       && nx run-many --target=scan-image --projects=openchallenges-* --parallel=1"
 
-      - name: Publish the images of the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-image --projects=openchallenges-*"
+      # - name: Publish the images of the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx run-many --target=publish-image --projects=openchallenges-*"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -263,12 +263,12 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
-      - name: Build the images of the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-image --projects=openchallenges-*"
+      # - name: Build the images of the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx run-many --target=build-image --projects=openchallenges-*"
 
-      - run: df -h
+      # - run: df -h
 
       # - name: Scan the images of the affected projects
       #   run: |

--- a/apps/schematic/api-docs/project.json
+++ b/apps/schematic/api-docs/project.json
@@ -38,8 +38,15 @@
       "executor": "@nx-tools/nx-container:build",
       "options": {
         "context": "apps/schematic/api-docs",
-        "push": false,
-        "tags": ["sagebionetworks/schematic-api-docs:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/schematic-api-docs"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       },
       "dependsOn": ["build"]
     }

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -41,8 +41,15 @@
       "executor": "@nx-tools/nx-container:build",
       "options": {
         "context": "apps/schematic/api",
-        "push": false,
-        "tags": ["sagebionetworks/schematic-api:latest"]
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/schematic-api"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       }
     },
     "openapi-generate": {

--- a/apps/synapse/rstudio/project.json
+++ b/apps/synapse/rstudio/project.json
@@ -14,7 +14,7 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/synapse/api",
+        "context": "apps/synapse/rstudio",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/synapse-rstudio"],
           "tags": [

--- a/apps/synapse/rstudio/project.json
+++ b/apps/synapse/rstudio/project.json
@@ -14,9 +14,16 @@
     "build-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
-        "context": "apps/synapse/rstudio",
-        "push": false,
-        "tags": ["sagebionetworks/synapse-rstudio:latest"]
+        "context": "apps/synapse/api",
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/synapse-rstudio"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
+        },
+        "push": false
       }
     },
     "serve-detach": {

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -96,6 +96,10 @@ function schematic-build-images {
   nx run-many --target=build-image --projects=schematic-* --parallel=3
 }
 
+function synapse-build-images {
+  nx run-many --target=build-image --projects=synapse-* --parallel=3
+}
+
 # function challenge-seed-db {
 #   node dist/apps/challenge-db-cli/src/index.js seed "$WORKSPACE_DIR/apps/challenge-db-cli/data/seeds/production/"
 # }

--- a/docker/openchallenges/services/apex.yml
+++ b/docker/openchallenges/services/apex.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-apex:
-    image: sagebionetworks/openchallenges-apex:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-apex:local
     container_name: openchallenges-apex
     restart: always
     env_file:

--- a/docker/openchallenges/services/api-gateway.yml
+++ b/docker/openchallenges/services/api-gateway.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-api-gateway:
-    image: sagebionetworks/openchallenges-api-gateway:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-api-gateway:local
     container_name: openchallenges-api-gateway
     restart: always
     env_file:

--- a/docker/openchallenges/services/app.yml
+++ b/docker/openchallenges/services/app.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-app:
-    image: sagebionetworks/openchallenges-app:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-app:local
     container_name: openchallenges-app
     restart: always
     networks:

--- a/docker/openchallenges/services/challenge-service.yml
+++ b/docker/openchallenges/services/challenge-service.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-challenge-service:
-    image: sagebionetworks/openchallenges-challenge-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-challenge-service:local
     container_name: openchallenges-challenge-service
     restart: always
     env_file:

--- a/docker/openchallenges/services/config-server.yml
+++ b/docker/openchallenges/services/config-server.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-config-server:
-    image: sagebionetworks/openchallenges-config-server:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-config-server:local
     container_name: openchallenges-config-server
     restart: always
     env_file:

--- a/docker/openchallenges/services/elasticsearch.yml
+++ b/docker/openchallenges/services/elasticsearch.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-elasticsearch:
-    image: sagebionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-latest}
+    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-local}
     container_name: openchallenges-elasticsearch
     restart: always
     environment:
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
 
   openchallenges-elasticsearch-node-2:
-    image: sagebionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-latest}
+    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-local}
     container_name: openchallenges-elasticsearch-node-2
     restart: always
     environment:
@@ -53,7 +53,7 @@ services:
           memory: 2G
 
   openchallenges-elasticsearch-node-3:
-    image: sagebionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-latest}
+    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-local}
     container_name: openchallenges-elasticsearch-node-3
     restart: always
     environment:

--- a/docker/openchallenges/services/grafana.yml
+++ b/docker/openchallenges/services/grafana.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-grafana:
-    image: sagebionetworks/openchallenges-grafana:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-grafana:local
     container_name: openchallenges-grafana
     restart: always
     env_file:

--- a/docker/openchallenges/services/image-service.yml
+++ b/docker/openchallenges/services/image-service.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-image-service:
-    image: sagebionetworks/openchallenges-image-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-image-service:local
     container_name: openchallenges-image-service
     restart: always
     env_file:

--- a/docker/openchallenges/services/mariadb.yml
+++ b/docker/openchallenges/services/mariadb.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-mariadb:
-    image: sagebionetworks/openchallenges-mariadb:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-mariadb:local
     container_name: openchallenges-mariadb
     restart: always
     env_file:

--- a/docker/openchallenges/services/minio.yml
+++ b/docker/openchallenges/services/minio.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-minio:
-    image: sagebionetworks/openchallenges-minio:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-minio:local
     container_name: openchallenges-minio
     restart: always
     env_file:

--- a/docker/openchallenges/services/mysqld-exporter.yml
+++ b/docker/openchallenges/services/mysqld-exporter.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-mysqld-exporter:
-    image: sagebionetworks/openchallenges-mysqld-exporter:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:local
     container_name: openchallenges-mysqld-exporter
     restart: always
     env_file:

--- a/docker/openchallenges/services/organization-service.yml
+++ b/docker/openchallenges/services/organization-service.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-organization-service:
-    image: sagebionetworks/openchallenges-organization-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-organization-service:local
     container_name: openchallenges-organization-service
     restart: always
     env_file:

--- a/docker/openchallenges/services/prometheus.yml
+++ b/docker/openchallenges/services/prometheus.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-prometheus:
-    image: sagebionetworks/openchallenges-prometheus:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-prometheus:local
     container_name: openchallenges-prometheus
     restart: always
     env_file:

--- a/docker/openchallenges/services/rstudio.yml
+++ b/docker/openchallenges/services/rstudio.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-rstudio:
-    image: sagebionetworks/openchallenges-rstudio:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-rstudio:local
     container_name: openchallenges-rstudio
     restart: always
     env_file:

--- a/docker/openchallenges/services/service-registry.yml
+++ b/docker/openchallenges/services/service-registry.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-service-registry:
-    image: sagebionetworks/openchallenges-service-registry:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-service-registry:local
     container_name: openchallenges-service-registry
     restart: always
     env_file:

--- a/docker/openchallenges/services/thumbor.yml
+++ b/docker/openchallenges/services/thumbor.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-thumbor:
-    image: sagebionetworks/openchallenges-thumbor:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-thumbor:local
     container_name: openchallenges-thumbor
     restart: always
     env_file:

--- a/docker/openchallenges/services/vault.yml
+++ b/docker/openchallenges/services/vault.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-vault:
-    image: sagebionetworks/openchallenges-vault:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-vault:local
     container_name: openchallenges-vault
     restart: always
     env_file:

--- a/docker/openchallenges/services/zipkin.yml
+++ b/docker/openchallenges/services/zipkin.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-zipkin:
-    image: sagebionetworks/openchallenges-zipkin:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-zipkin:local
     container_name: openchallenges-zipkin
     restart: always
     env_file:

--- a/docker/schematic/services/api.yml
+++ b/docker/schematic/services/api.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   schematic-api:
-    image: sagebionetworks/schematic-api:latest
+    image: ghcr.io/sage-bionetworks/schematic-api:local
     container_name: schematic-api
     restart: always
     env_file:

--- a/docker/synapse/services/rstudio.yml
+++ b/docker/synapse/services/rstudio.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   synapse-rstudio:
-    image: sagebionetworks/synapse-rstudio:latest
+    image: ghcr.io/sage-bionetworks/synapse-rstudio:local
     container_name: synapse-rstudio
     restart: always
     env_file:


### PR DESCRIPTION
Closes #1745

## Changelog

- Rename all the images generated by this monorepo so that they use the GHCR names
- Add the command `synapse-build-images`
- Disable image push, scan and publish in the CI workflow (to be fixed in another PR)

## Preview

### OpenChallenges

```console
openchallenges-build-images
nx serve-detach openchallenges-apex
```

<img width="925" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/df9de249-6599-4eb5-8896-78f34d295307">

### Schematic

```console
schematic-build-images
nx serve-detach schematic-api
```

<img width="692" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/98196b8e-64d8-495e-9fc1-4d5466343d55">

### Synapse

```console
synapse-build-images
nx serve-detach synapse-rstudio
```

<img width="712" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/d7edf373-b7c0-40df-931b-56efab783f98">
