### PR TITLE
chore: Publish images without rebuilding them in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,15 +251,10 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
-      - run: df -h
-      - run: docker system df
-
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx run-many --target=build-and-remove-image --parallel=1"
-
-      - run: docker system df
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-and-remove-image --parallel=1"
+            && nx run-many --target=build-and-remove-image --parallel=1"
 
       - run: docker system df
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image --parallel=1"
+            && nx run-many --target=publish-and-remove-image --parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -257,7 +257,7 @@ jobs:
       - name: Publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image --parallel=1"
+            && nx run-many --target=publish-and-remove-image --parallel=1"
 
       - run: docker system df
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install devcontainer CLI
+      - name: Install the devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container
@@ -214,7 +214,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
 
-      - name: Install devcontainer CLI
+      - name: Install the devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
       - run: df -h
       - run: docker system df
 
-      - name: Publish the images of the affected projects
+      - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx run-many --target=build-and-remove-image --parallel=1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,22 +123,10 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
-      # - name: Build the images of the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=build-image --projects=openchallenges-*"
-
-      # - run: df -h
-
-      # - name: Scan the images of the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=scan-image --projects=openchallenges-* --parallel=1"
-
-      # - name: Publish the images of the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=publish-image --projects=openchallenges-*"
+      - name: Publish the images of the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=build-and-remove-image --parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -263,17 +251,15 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
-      # - name: Build the images of the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=build-image --projects=openchallenges-*"
+      - run: df -h
+      - run: docker system df
 
-      # - run: df -h
+      - name: Publish the images of the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=build-and-remove-image --parallel=1"
 
-      # - name: Scan the images of the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=scan-image --projects=openchallenges-* --parallel=1"
+      - run: docker system df
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -36,6 +36,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/apex",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-apex"],
           "tags": [
@@ -45,6 +46,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-apex:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -54,6 +54,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-apex:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -80,6 +80,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/api-gateway",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-api-gateway"],
           "tags": [
@@ -89,6 +90,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-api-gateway:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -98,6 +98,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-api-gateway:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -155,6 +155,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/app",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-app"],
           "tags": [
@@ -164,6 +165,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-app:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -173,6 +173,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-app:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -107,6 +107,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-challenge-service:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -88,6 +88,7 @@
     },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
+      "context": "apps/openchallenges/challenge-service",
       "options": {
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-challenge-service"],
@@ -98,6 +99,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-challenge-service:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -97,6 +97,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/config-server",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-config-server"],
           "tags": [
@@ -106,6 +107,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-config-server:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -115,6 +115,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-config-server:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/elasticsearch/project.json
+++ b/apps/openchallenges/elasticsearch/project.json
@@ -54,6 +54,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-elasticsearch:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/elasticsearch/project.json
+++ b/apps/openchallenges/elasticsearch/project.json
@@ -36,6 +36,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/elasticsearch",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-elasticsearch"],
           "tags": [
@@ -45,6 +46,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-elasticsearch:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -39,6 +39,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/grafana",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-grafana"],
           "tags": [
@@ -48,6 +49,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-grafana:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -57,6 +57,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-grafana:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -114,6 +114,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-image-service:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -96,6 +96,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/image-service",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-image-service"],
           "tags": [
@@ -105,6 +106,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-image-service:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/mariadb/project.json
+++ b/apps/openchallenges/mariadb/project.json
@@ -35,6 +35,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/mariadb",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-mariadb"],
           "tags": [
@@ -44,6 +45,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-mariadb:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/mariadb/project.json
+++ b/apps/openchallenges/mariadb/project.json
@@ -53,6 +53,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-mariadb:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/mysqld-exporter/project.json
+++ b/apps/openchallenges/mysqld-exporter/project.json
@@ -36,6 +36,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/mysqld-exporter",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter"],
           "tags": [
@@ -45,6 +46,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/mysqld-exporter/project.json
+++ b/apps/openchallenges/mysqld-exporter/project.json
@@ -54,6 +54,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -89,6 +89,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/organization-service",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-organization-service"],
           "tags": [
@@ -98,6 +99,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-organization-service:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -107,6 +107,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-organization-service:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/prometheus/project.json
+++ b/apps/openchallenges/prometheus/project.json
@@ -54,6 +54,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-prometheus:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/prometheus/project.json
+++ b/apps/openchallenges/prometheus/project.json
@@ -36,6 +36,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/prometheus",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-prometheus"],
           "tags": [
@@ -45,6 +46,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-prometheus:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/rstudio/project.json
+++ b/apps/openchallenges/rstudio/project.json
@@ -36,6 +36,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/rstudio",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-rstudio"],
           "tags": [
@@ -45,6 +46,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-rstudio:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/rstudio/project.json
+++ b/apps/openchallenges/rstudio/project.json
@@ -54,6 +54,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-rstudio:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -103,6 +103,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-service-registry:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -85,6 +85,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/service-registry",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-service-registry"],
           "tags": [
@@ -94,6 +95,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-service-registry:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -53,6 +53,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-thumbor:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -35,6 +35,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/thumbor",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-thumbor"],
           "tags": [
@@ -44,6 +45,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-thumbor:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/vault/project.json
+++ b/apps/openchallenges/vault/project.json
@@ -35,6 +35,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/vault",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-vault"],
           "tags": [
@@ -44,6 +45,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-vault:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/vault/project.json
+++ b/apps/openchallenges/vault/project.json
@@ -53,6 +53,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-vault:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -53,6 +53,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-zipkin:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -35,6 +35,7 @@
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
+        "context": "apps/openchallenges/zipkin",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/openchallenges-zipkin"],
           "tags": [
@@ -44,6 +45,13 @@
         },
         "push": true
       }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/openchallenges-zipkin:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -52,6 +52,34 @@
         "push": false
       }
     },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "context": "apps/schematic/api",
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/schematic-api"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/schematic-api:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/schematic-api:local --quiet",
+        "color": true
+      }
+    },
     "openapi-generate": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -73,6 +73,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/schematic-api:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/synapse/rstudio/project.json
+++ b/apps/synapse/rstudio/project.json
@@ -26,6 +26,34 @@
         "push": false
       }
     },
+    "publish-image": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "context": "apps/synapse/rstudio",
+        "metadata": {
+          "images": ["ghcr.io/sage-bionetworks/synapse-rstudio"],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
+        },
+        "push": true
+      }
+    },
+    "publish-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/synapse-rstudio:*\" --quiet) --force"
+      },
+      "dependsOn": ["publish-image"]
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/synapse-rstudio:local --quiet",
+        "color": true
+      }
+    },
     "serve-detach": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/synapse/rstudio/project.json
+++ b/apps/synapse/rstudio/project.json
@@ -47,6 +47,13 @@
       },
       "dependsOn": ["publish-image"]
     },
+    "build-and-remove-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker rmi $(docker images --filter=reference=\"ghcr.io/sage-bionetworks/synapse-rstudio:*\" --quiet) --force"
+      },
+      "dependsOn": ["build-image"]
+    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Closes #1744

## Changelog

- Create the task `publish-and-remove-image`
- Update CI to run the task `publish-and-remove-image` for all project one at a time

## Notes

- The step `publish-and-remove-image` is applied to one project at a time so that the removal of images does not affect concurrent tasks.
- Ultimately the CI step `publish-and-remove-image` will be performed only for affected projects.