### PR TITLE
fix: Fix images that depend on a base image

### DIFF
--- a/apps/openchallenges/api-docs/docker-compose.yml
+++ b/apps/openchallenges/api-docs/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-api-docs:
-    image: sagebionetworks/openchallenges-api-docs:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-api-docs:local
     container_name: openchallenges-api-docs
     restart: always
     env_file:

--- a/apps/openchallenges/api-docs/project.json
+++ b/apps/openchallenges/api-docs/project.json
@@ -39,7 +39,7 @@
       "options": {
         "context": "apps/openchallenges/api-docs",
         "push": false,
-        "tags": ["sagebionetworks/openchallenges-api-docs:latest"]
+        "tags": ["ghcr.io/sage-bionetworks/openchallenges-api-docs:local"]
       }
     }
   },

--- a/apps/openchallenges/api-gateway/Dockerfile
+++ b/apps/openchallenges/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM sagebionetworks/openchallenges-api-gateway-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-api-gateway-base:latest
 
 USER root
 

--- a/apps/openchallenges/api-gateway/Dockerfile
+++ b/apps/openchallenges/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sage-bionetworks/openchallenges-api-gateway-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-api-gateway-base:local
 
 USER root
 

--- a/apps/openchallenges/api-gateway/build.gradle
+++ b/apps/openchallenges/api-gateway/build.gradle
@@ -44,5 +44,5 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:latest"
+  imageName = "sagebionetworks/${project.name}-base:local"
 }

--- a/apps/openchallenges/api-gateway/build.gradle
+++ b/apps/openchallenges/api-gateway/build.gradle
@@ -44,5 +44,5 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:local"
+  imageName = "ghcr.io/sage-bionetworks/${project.name}-base:local"
 }

--- a/apps/openchallenges/auth-service/build.gradle
+++ b/apps/openchallenges/auth-service/build.gradle
@@ -45,5 +45,5 @@ springBoot {
 }
 
 bootBuildImage {
-  imageName = 'sagebionetworks/openchallenges-auth-service:latest'
+  imageName = 'ghcr.io/sage-bionetworks/openchallenges-auth-service:local'
 }

--- a/apps/openchallenges/auth-service/docker-compose.yml
+++ b/apps/openchallenges/auth-service/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-auth-service:
-    image: sagebionetworks/openchallenges-auth-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-auth-service:local
     container_name: openchallenges-auth-service
     restart: always
     env_file:

--- a/apps/openchallenges/challenge-service/Dockerfile
+++ b/apps/openchallenges/challenge-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sage-bionetworks/openchallenges-challenge-service-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-challenge-service-base:local
 
 USER root
 

--- a/apps/openchallenges/challenge-service/Dockerfile
+++ b/apps/openchallenges/challenge-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM sagebionetworks/openchallenges-challenge-service-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-challenge-service-base:latest
 
 USER root
 

--- a/apps/openchallenges/challenge-service/build.gradle
+++ b/apps/openchallenges/challenge-service/build.gradle
@@ -79,7 +79,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:latest"
+  imageName = "sagebionetworks/${project.name}-base:local"
 }
 
 spotless {

--- a/apps/openchallenges/challenge-service/build.gradle
+++ b/apps/openchallenges/challenge-service/build.gradle
@@ -79,7 +79,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:local"
+  imageName = "ghcr.io/sage-bionetworks/${project.name}-base:local"
 }
 
 spotless {

--- a/apps/openchallenges/challenge-to-elasticsearch-service/build.gradle
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/build.gradle
@@ -55,7 +55,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = 'sagebionetworks/openchallenges-challenge-to-elasticsearch-service:latest'
+  imageName = 'ghcr.io/sage-bionetworks/openchallenges-challenge-to-elasticsearch-service:local'
 }
 
 spotless {

--- a/apps/openchallenges/challenge-to-elasticsearch-service/docker-compose.yml
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-challenge-to-elasticsearch-service:
-    image: sagebionetworks/openchallenges-challenge-to-elasticsearch-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-challenge-to-elasticsearch-service:local
     container_name: openchallenges-challenge-to-elasticsearch-service
     restart: always
     env_file:

--- a/apps/openchallenges/config-server/Dockerfile
+++ b/apps/openchallenges/config-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sage-bionetworks/openchallenges-config-server-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-config-server-base:local
 
 USER root
 

--- a/apps/openchallenges/config-server/Dockerfile
+++ b/apps/openchallenges/config-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM sagebionetworks/openchallenges-config-server-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-config-server-base:latest
 
 USER root
 

--- a/apps/openchallenges/config-server/build.gradle
+++ b/apps/openchallenges/config-server/build.gradle
@@ -48,7 +48,7 @@ tasks.withType(JavaCompile) {
 // }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:local"
+  imageName = "ghcr.io/sage-bionetworks/${project.name}-base:local"
 }
 
 spotless {

--- a/apps/openchallenges/config-server/build.gradle
+++ b/apps/openchallenges/config-server/build.gradle
@@ -48,7 +48,7 @@ tasks.withType(JavaCompile) {
 // }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:latest"
+  imageName = "sagebionetworks/${project.name}-base:local"
 }
 
 spotless {

--- a/apps/openchallenges/core-service/build.gradle
+++ b/apps/openchallenges/core-service/build.gradle
@@ -52,5 +52,5 @@ springBoot {
 }
 
 bootBuildImage {
-  imageName = 'sagebionetworks/openchallenges-core-service:latest'
+  imageName = 'ghcr.io/sage-bionetworks/openchallenges-core-service:local'
 }

--- a/apps/openchallenges/core-service/docker-compose.yml
+++ b/apps/openchallenges/core-service/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-core-service:
-    image: sagebionetworks/openchallenges-core-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-core-service:local
     container_name: openchallenges-core-service
     restart: always
     env_file:

--- a/apps/openchallenges/image-service/Dockerfile
+++ b/apps/openchallenges/image-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM sagebionetworks/openchallenges-image-service-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-image-service-base:latest
 
 USER root
 

--- a/apps/openchallenges/image-service/Dockerfile
+++ b/apps/openchallenges/image-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sage-bionetworks/openchallenges-image-service-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-image-service-base:local
 
 USER root
 

--- a/apps/openchallenges/image-service/build.gradle
+++ b/apps/openchallenges/image-service/build.gradle
@@ -87,7 +87,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:local"
+  imageName = "ghcr.io/sage-bionetworks/${project.name}-base:local"
 }
 
 test {

--- a/apps/openchallenges/image-service/build.gradle
+++ b/apps/openchallenges/image-service/build.gradle
@@ -87,7 +87,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:latest"
+  imageName = "sagebionetworks/${project.name}-base:local"
 }
 
 test {

--- a/apps/openchallenges/kaggle-to-kafka-service/build.gradle
+++ b/apps/openchallenges/kaggle-to-kafka-service/build.gradle
@@ -52,7 +52,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = 'sagebionetworks/openchallenges-kaggle-to-kafka-service:latest'
+  imageName = 'ghcr.io/sage-bionetworks/openchallenges-kaggle-to-kafka-service:local'
 }
 
 spotless {

--- a/apps/openchallenges/kaggle-to-kafka-service/docker-compose.yml
+++ b/apps/openchallenges/kaggle-to-kafka-service/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-kaggle-to-kafka-service:
-    image: sagebionetworks/openchallenges-kaggle-to-kafka-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-kaggle-to-kafka-service:local
     container_name: openchallenges-kaggle-to-kafka-service
     restart: always
     env_file:

--- a/apps/openchallenges/keycloak/docker-compose.yml
+++ b/apps/openchallenges/keycloak/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-keycloak:
-    image: sagebionetworks/openchallenges-keycloak:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-keycloak:local
     container_name: openchallenges-keycloak
     restart: always
     env_file:

--- a/apps/openchallenges/keycloak/project.json
+++ b/apps/openchallenges/keycloak/project.json
@@ -31,7 +31,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "docker run --rm --env-file .env -v \"$(pwd)\"/data/h2:/opt/keycloak/data/h2 -v \"$(pwd)\"/data/import:/opt/keycloak/data/import:ro sagebionetworks/openchallenges-keycloak:latest import --dir /opt/keycloak/data/import --override true"
+          "docker run --rm --env-file .env -v \"$(pwd)\"/data/h2:/opt/keycloak/data/h2 -v \"$(pwd)\"/data/import:/opt/keycloak/data/import:ro ghcr.io/sage-bionetworks/openchallenges-keycloak:local import --dir /opt/keycloak/data/import --override true"
         ],
         "cwd": "apps/openchallenges/keycloak"
       },
@@ -41,7 +41,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "docker run --rm --env-file .env -v \"$(pwd)\"/data/h2:/opt/keycloak/data/h2 -v \"$(pwd)\"/data/import:/opt/keycloak/data/import sagebionetworks/openchallenges-keycloak:latest export --dir /opt/keycloak/data/import"
+          "docker run --rm --env-file .env -v \"$(pwd)\"/data/h2:/opt/keycloak/data/h2 -v \"$(pwd)\"/data/import:/opt/keycloak/data/import ghcr.io/sage-bionetworks/openchallenges-keycloak:local export --dir /opt/keycloak/data/import"
         ],
         "cwd": "apps/openchallenges/keycloak"
       },
@@ -52,7 +52,7 @@
       "options": {
         "context": "apps/openchallenges/keycloak",
         "push": false,
-        "tags": ["sagebionetworks/openchallenges-keycloak:latest"]
+        "tags": ["ghcr.io/sage-bionetworks/openchallenges-keycloak:local"]
       }
     }
   },

--- a/apps/openchallenges/minio/project.json
+++ b/apps/openchallenges/minio/project.json
@@ -23,7 +23,7 @@
       "options": {
         "context": "apps/openchallenges/minio",
         "push": false,
-        "tags": ["sagebionetworks/openchallenges-minio:latest"]
+        "tags": ["ghcr.io/sage-bionetworks/openchallenges-minio:local"]
       }
     }
   },

--- a/apps/openchallenges/mongo/docker-compose.yml
+++ b/apps/openchallenges/mongo/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-mongo:
-    image: sagebionetworks/openchallenges-mongo:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-mongo:local
     container_name: openchallenges-mongo
     restart: always
     env_file:

--- a/apps/openchallenges/mongo/project.json
+++ b/apps/openchallenges/mongo/project.json
@@ -24,7 +24,7 @@
       "options": {
         "context": "apps/openchallenges/mongo",
         "push": false,
-        "tags": ["sagebionetworks/openchallenges-mongo:latest"]
+        "tags": ["ghcr.io/sage-bionetworks/openchallenges-mongo:local"]
       }
     }
   },

--- a/apps/openchallenges/notebook/docker-compose.yml
+++ b/apps/openchallenges/notebook/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-notebook:
-    image: sagebionetworks/openchallenges-notebook:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-notebook:local
     container_name: openchallenges-notebook
     restart: always
     env_file:

--- a/apps/openchallenges/notebook/project.json
+++ b/apps/openchallenges/notebook/project.json
@@ -45,7 +45,7 @@
     //   "options": {
     //     "context": "apps/openchallenges/notebook",
     //     "push": false,
-    //     "tags": ["sagebionetworks/openchallenges-notebook:latest"]
+    //     "tags": ["ghcr.io/sage-bionetworks/openchallenges-notebook:latest"]
     //   }
     // }
   },

--- a/apps/openchallenges/organization-service/Dockerfile
+++ b/apps/openchallenges/organization-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM sagebionetworks/openchallenges-organization-service-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-organization-service-base:latest
 
 USER root
 

--- a/apps/openchallenges/organization-service/Dockerfile
+++ b/apps/openchallenges/organization-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sage-bionetworks/openchallenges-organization-service-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-organization-service-base:local
 
 USER root
 

--- a/apps/openchallenges/organization-service/build.gradle
+++ b/apps/openchallenges/organization-service/build.gradle
@@ -72,7 +72,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:latest"
+  imageName = "sagebionetworks/${project.name}-base:local"
 }
 
 spotless {

--- a/apps/openchallenges/organization-service/build.gradle
+++ b/apps/openchallenges/organization-service/build.gradle
@@ -72,7 +72,7 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:local"
+  imageName = "ghcr.io/sage-bionetworks/${project.name}-base:local"
 }
 
 spotless {

--- a/apps/openchallenges/postgres/docker-compose.yml
+++ b/apps/openchallenges/postgres/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-postgres:
-    image: sagebionetworks/openchallenges-postgres:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-postgres:local
     container_name: openchallenges-postgres
     env_file:
       - .env

--- a/apps/openchallenges/postgres/project.json
+++ b/apps/openchallenges/postgres/project.json
@@ -32,7 +32,7 @@
       "options": {
         "context": "apps/openchallenges/postgres",
         "push": false,
-        "tags": ["sagebionetworks/openchallenges-postgres:latest"]
+        "tags": ["ghcr.io/sage-bionetworks/openchallenges-postgres:local"]
       }
     }
   },

--- a/apps/openchallenges/service-registry/Dockerfile
+++ b/apps/openchallenges/service-registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sage-bionetworks/openchallenges-service-registry-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-service-registry-base:local
 
 USER root
 

--- a/apps/openchallenges/service-registry/Dockerfile
+++ b/apps/openchallenges/service-registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM sagebionetworks/openchallenges-service-registry-base:latest
+FROM ghcr.io/sage-bionetworks/openchallenges-service-registry-base:latest
 
 USER root
 

--- a/apps/openchallenges/service-registry/build.gradle
+++ b/apps/openchallenges/service-registry/build.gradle
@@ -39,5 +39,5 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:latest"
+  imageName = "sagebionetworks/${project.name}-base:local"
 }

--- a/apps/openchallenges/service-registry/build.gradle
+++ b/apps/openchallenges/service-registry/build.gradle
@@ -39,5 +39,5 @@ tasks.withType(JavaCompile) {
 }
 
 bootBuildImage {
-  imageName = "sagebionetworks/${project.name}-base:local"
+  imageName = "ghcr.io/sage-bionetworks/${project.name}-base:local"
 }

--- a/apps/openchallenges/user-service/build.gradle
+++ b/apps/openchallenges/user-service/build.gradle
@@ -64,7 +64,7 @@ springBoot {
 }
 
 bootBuildImage {
-  imageName = 'sagebionetworks/openchallenges-user-service:latest'
+  imageName = 'ghcr.io/sage-bionetworks/openchallenges-user-service:local'
 }
 
 spotless {

--- a/apps/openchallenges/user-service/docker-compose.yml
+++ b/apps/openchallenges/user-service/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   openchallenges-user-service:
-    image: sagebionetworks/openchallenges-user-service:latest
+    image: ghcr.io/sage-bionetworks/openchallenges-user-service:local
     container_name: openchallenges-user-service
     restart: always
     env_file:

--- a/apps/schematic/api-docs/docker-compose.yml
+++ b/apps/schematic/api-docs/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   schematic-api-docs:
-    image: sagebionetworks/schematic-api-docs:latest
+    image: ghcr.io/sage-bionetworks/schematic-api-docs:local
     container_name: schematic-api-docs
     restart: always
     env_file:

--- a/apps/schematic/api/docker-compose.yml
+++ b/apps/schematic/api/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   schematic-api:
-    image: sagebionetworks/schematic-api:latest
+    image: ghcr.io/sage-bionetworks/schematic-api:local
     container_name: schematic-api
     restart: always
     env_file:

--- a/apps/schematic/notebook/docker-compose.yml
+++ b/apps/schematic/notebook/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   schematic-notebook:
-    image: sagebionetworks/schematic-notebook:latest
+    image: ghcr.io/sage-bionetworks/schematic-notebook:local
     container_name: schematic-notebook
     restart: always
     env_file:


### PR DESCRIPTION
Closes #1748

## Changelog

- Update the name of the remaining images so that they use GHCR
- Replace the image tag `latest` by `local`

## Preview

```console
openchallenges-build-images
schematic-build-images
synapse-build-images
```

```console
vscode@3be174c018e7:/workspaces/sage-monorepo$ docker images
REPOSITORY                                                                   TAG           IMAGE ID       CREATED          SIZE
ghcr.io/sage-bionetworks/openchallenges-image-service                        local         a7e74da98f9c   4 minutes ago    323MB
ghcr.io/sage-bionetworks/openchallenges-image-service                        sha-8b2c3f8   a7e74da98f9c   4 minutes ago    323MB
ghcr.io/sage-bionetworks/openchallenges-challenge-service                    local         f70b7e667b39   4 minutes ago    358MB
ghcr.io/sage-bionetworks/openchallenges-challenge-service                    sha-8b2c3f8   f70b7e667b39   4 minutes ago    358MB
ghcr.io/sage-bionetworks/openchallenges-organization-service                 local         33ccb72e231b   4 minutes ago    356MB
ghcr.io/sage-bionetworks/openchallenges-organization-service                 sha-8b2c3f8   33ccb72e231b   4 minutes ago    356MB
ghcr.io/sage-bionetworks/openchallenges-config-server                        local         51436d519914   4 minutes ago    308MB
ghcr.io/sage-bionetworks/openchallenges-config-server                        sha-8b2c3f8   51436d519914   4 minutes ago    308MB
ghcr.io/sage-bionetworks/openchallenges-service-registry                     local         1a917f28ba31   5 minutes ago    322MB
ghcr.io/sage-bionetworks/openchallenges-service-registry                     sha-8b2c3f8   1a917f28ba31   5 minutes ago    322MB
<none>                                                                       <none>        7ce75ff68d8d   10 minutes ago   323MB
ghcr.io/sage-bionetworks/openchallenges-api-gateway                          local         ccafc205d9e2   10 minutes ago   323MB
ghcr.io/sage-bionetworks/openchallenges-api-gateway                          sha-8b2c3f8   ccafc205d9e2   10 minutes ago   323MB
ghcr.io/sage-bionetworks/openchallenges-app                                  local         e2f83f1d2bbd   41 minutes ago   27MB
ghcr.io/sage-bionetworks/openchallenges-app                                  sha-8b2c3f8   e2f83f1d2bbd   41 minutes ago   27MB
ghcr.io/sage-bionetworks/openchallenges-apex                                 local         12f1a12f4f22   42 minutes ago   143MB
ghcr.io/sage-bionetworks/openchallenges-apex                                 sha-8b2c3f8   12f1a12f4f22   42 minutes ago   143MB
ghcr.io/sage-bionetworks/openchallenges-vault                                local         11ae2a503223   42 minutes ago   230MB
ghcr.io/sage-bionetworks/openchallenges-vault                                sha-8b2c3f8   11ae2a503223   42 minutes ago   230MB
ghcr.io/sage-bionetworks/openchallenges-mariadb                              local         a268cc905382   43 minutes ago   384MB
ghcr.io/sage-bionetworks/openchallenges-mariadb                              sha-8b2c3f8   a268cc905382   43 minutes ago   384MB
ghcr.io/sage-bionetworks/openchallenges-elasticsearch                        local         0dd082231b11   43 minutes ago   622MB
ghcr.io/sage-bionetworks/openchallenges-elasticsearch                        sha-8b2c3f8   0dd082231b11   43 minutes ago   622MB
ghcr.io/sage-bionetworks/schematic-api                                       local         2eee94dbc696   22 hours ago     1.23GB
ghcr.io/sage-bionetworks/schematic-api                                       sha-8b2c3f8   2eee94dbc696   22 hours ago     1.23GB
paketobuildpacks/run                                                         base-cnb      f2e5000af0cb   10 days ago      87.1MB
ghcr.io/sage-bionetworks/synapse-rstudio                                     local         5964eecd8bd8   12 days ago      1.87GB
ghcr.io/sage-bionetworks/synapse-rstudio                                     sha-8b2c3f8   5964eecd8bd8   12 days ago      1.87GB
ghcr.io/sage-bionetworks/openchallenges-rstudio                              local         4282ff0f4edf   12 days ago      1.87GB
ghcr.io/sage-bionetworks/openchallenges-rstudio                              sha-8b2c3f8   4282ff0f4edf   12 days ago      1.87GB
ghcr.io/sage-bionetworks/openchallenges-zipkin                               local         5ac61de93100   5 weeks ago      157MB
ghcr.io/sage-bionetworks/openchallenges-zipkin                               sha-8b2c3f8   5ac61de93100   5 weeks ago      157MB
ghcr.io/sage-bionetworks/openchallenges-thumbor                              local         09834690aab2   2 months ago     606MB
ghcr.io/sage-bionetworks/openchallenges-thumbor                              sha-8b2c3f8   09834690aab2   2 months ago     606MB
ghcr.io/sage-bionetworks/openchallenges-grafana                              local         605a681b56bd   4 months ago     329MB
ghcr.io/sage-bionetworks/openchallenges-grafana                              sha-8b2c3f8   605a681b56bd   4 months ago     329MB
ghcr.io/sage-bionetworks/openchallenges-prometheus                           local         c7647398a326   5 months ago     232MB
ghcr.io/sage-bionetworks/openchallenges-prometheus                           sha-8b2c3f8   c7647398a326   5 months ago     232MB
ghcr.io/sage-bionetworks/openchallenges-mongo                                local         6bd422e35f78   7 months ago     700MB
ghcr.io/sage-bionetworks/openchallenges-keycloak                             local         7e056640ba34   8 months ago     546MB
ghcr.io/sage-bionetworks/openchallenges-postgres                             local         f80233e85a39   9 months ago     216MB
ghcr.io/sage-bionetworks/openchallenges-api-docs                             local         d526ff253f89   10 months ago    33.4MB
ghcr.io/sage-bionetworks/schematic-api-docs                                  local         f8dbb39615ff   10 months ago    33.4MB
ghcr.io/sage-bionetworks/schematic-api-docs                                  sha-8b2c3f8   f8dbb39615ff   10 months ago    33.4MB
ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter                      local         0b7db9dfbb1d   16 months ago    17.8MB
ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter                      sha-8b2c3f8   0b7db9dfbb1d   16 months ago    17.8MB
ghcr.io/sage-bionetworks/openchallenges-user-service                         local         02d2494369c9   43 years ago     339MB
ghcr.io/sage-bionetworks/openchallenges-image-service-base                   local         1202cb115827   43 years ago     313MB
ghcr.io/sage-bionetworks/openchallenges-config-server-base                   local         1eeb46e30103   43 years ago     299MB
ghcr.io/sage-bionetworks/openchallenges-organization-service-base            local         0d74b6e15c73   43 years ago     346MB
ghcr.io/sage-bionetworks/openchallenges-core-service                         local         59648a0260cf   43 years ago     323MB
paketobuildpacks/builder                                                     base          d405df64bebf   43 years ago     1.34GB
ghcr.io/sage-bionetworks/openchallenges-api-gateway-base                     local         cb19aa498042   43 years ago     313MB
ghcr.io/sage-bionetworks/openchallenges-service-registry-base                local         de5e63c10a87   43 years ago     312MB
ghcr.io/sage-bionetworks/openchallenges-challenge-service-base               local         25ae94f79abe   43 years ago     348MB
ghcr.io/sage-bionetworks/openchallenges-challenge-to-elasticsearch-service   local         ebdb4d32a03e   43 years ago     319MB
ghcr.io/sage-bionetworks/openchallenges-auth-service                         local         238f09d499d5   43 years ago     304MB
ghcr.io/sage-bionetworks/openchallenges-kaggle-to-kafka-service              local         f3563338302f   43 years ago     317MB
ghcr.io/sage-bionetworks/openchallenges-minio                                local         0a43e4ca196e   N/A              215MB
```