### PR TITLE
fix: Remove QEMU and setup buildx to use the docker driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set buildx as the default builder
-        run: docker buildx install
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v3
@@ -200,11 +199,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set buildx as the default builder
-        run: docker buildx install
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v3


### PR DESCRIPTION
Closes #1748

## Changelog

- Remove QEMU as we don't need to build image for multiple plaftorms
- Use GH Action from the marketplace to setup buildx
- Configure buildx to use the driver `docker` instead of `docker-container` (default)

## Notes

- Using the driver `docker` enables to build images that depends on local images (e.g. the `-base:local` images). However, we loose the ability to cache Docker layers in the CI workflow, which makes the workflow slower.
  - If we want to continue to benefit from caching layers, two solutions would be to:
    - Push the base images to the GHCR registry
    - Use a local registry to store the `-base` images (see comment in #1748)

## References

- https://github.com/docker/setup-buildx-action#inputs
- https://docs.docker.com/engine/reference/commandline/buildx_create/#driver