### PR TITLE
fix: Fix images that depend on a base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install the devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v3
@@ -199,6 +201,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v3
@@ -207,8 +211,6 @@ jobs:
           key: ${{ runner.os }}-single-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-single-buildx
-
-      - run: docker buildx ls
 
       - name: Install the devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Build the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build --projects=openchallenges-api-gateway"
+            && nx affected --target=build"
 
       # - name: Test the affected projects (unit)
       #   run: |
@@ -250,7 +250,7 @@ jobs:
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-and-remove-image --parallel=1 --projects=openchallenges-api-gateway"
+            && nx run-many --target=publish-and-remove-image --parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v3
@@ -201,8 +199,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
 
+      - run: docker buildx ls
+
       - name: Install the devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,13 +208,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install the devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
 
@@ -232,30 +225,30 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && workspace-install"
 
-      # - name: Lint the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=lint"
+      - name: Lint the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=lint"
 
       - name: Build the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=build"
 
-      # - name: Test the affected projects (unit)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=test"
+      - name: Test the affected projects (unit)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=test"
 
-      # - name: Test the affected projects (integration)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=integration-test"
+      - name: Test the affected projects (integration)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=integration-test"
 
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-and-remove-image --parallel=1"
+            && nx run-many --target=build-and-remove-image --parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,30 +229,30 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && workspace-install"
 
-      - name: Lint the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=lint"
+      # - name: Lint the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=lint"
 
       - name: Build the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build"
+            && nx affected --target=build --projects=openchallenges-api-gateway"
 
-      - name: Test the affected projects (unit)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=test"
+      # - name: Test the affected projects (unit)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=test"
 
-      - name: Test the affected projects (integration)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=integration-test"
+      # - name: Test the affected projects (integration)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=integration-test"
 
       - name: Build the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image --parallel=1"
+            && nx run-many --target=publish-and-remove-image --parallel=1 --projects=openchallenges-api-gateway"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer

--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -45,7 +45,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -89,7 +89,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -164,7 +164,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -98,7 +98,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -106,7 +106,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/elasticsearch/project.json
+++ b/apps/openchallenges/elasticsearch/project.json
@@ -45,7 +45,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -48,7 +48,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -105,7 +105,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/mariadb/project.json
+++ b/apps/openchallenges/mariadb/project.json
@@ -44,7 +44,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/mysqld-exporter/project.json
+++ b/apps/openchallenges/mysqld-exporter/project.json
@@ -45,7 +45,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -98,7 +98,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/prometheus/project.json
+++ b/apps/openchallenges/prometheus/project.json
@@ -45,7 +45,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/rstudio/project.json
+++ b/apps/openchallenges/rstudio/project.json
@@ -45,7 +45,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -94,7 +94,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -44,7 +44,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/vault/project.json
+++ b/apps/openchallenges/vault/project.json
@@ -44,7 +44,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -44,7 +44,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -64,7 +64,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",

--- a/apps/synapse/rstudio/project.json
+++ b/apps/synapse/rstudio/project.json
@@ -38,7 +38,8 @@
           ]
         },
         "push": true
-      }
+      },
+      "dependsOn": ["build-image"]
     },
     "publish-and-remove-image": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
Closes #1748

## Changelog

- Make the task `publish-image` depend on `build-image`.

## Note

- Another solution would have to make the `publish-image` task depends on `build-image-base` only for projects that have a base image (e.g. `openchallenges-api-gateway`). Instead, I prefer to make all the task `publish-image` depend on `build-image` to have a more general solution. Thanks to image caching, the task `publish-image` is fast because the image has already been built by the task `build-image`.

## Preview

Save your personal access token (classic). We recommend saving your token as an environment variable.

```console
export CR_PAT=YOUR_TOKEN
```

Using the CLI for your container type, sign in to the Container registry service at `ghcr.io`.

```console
$ echo $CR_PAT | docker login ghcr.io -u USERNAME --password-stdin
   > Login Succeeded
```

Before this PR, publishing the image of the API gateway fails (it use a base image):

```console
$ nx publish-and-remove-image openchallenges-api-gateway
...
#0 building with "default" instance using docker driver
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 602B done
#1 DONE 0.0s
#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s
#3 [internal] load metadata for ghcr.io/sage-bionetworks/openchallenges-api-gateway-base:local
#3 ERROR: ghcr.io/sage-bionetworks/openchallenges-api-gateway-base:local: not found
#4 [auth] sage-bionetworks/openchallenges-api-gateway-base:pull token for ghcr.io
#4 DONE 0.0s
------
 > [internal] load metadata for ghcr.io/sage-bionetworks/openchallenges-api-gateway-base:local:
------
ERROR: failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: ghcr.io/sage-bionetworks/openchallenges-api-gateway-base:local: not found
```

Thanks to this PR, all the images are now built and published to GHCR.