### PR TITLE
feat: Enable to specify the version of a stack to deploy

### DIFF
--- a/docker/openchallenges/services/apex.yml
+++ b/docker/openchallenges/services/apex.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-apex:
-    image: ghcr.io/sage-bionetworks/openchallenges-apex:local
+    image: ghcr.io/sage-bionetworks/openchallenges-apex:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-apex
     restart: always
     env_file:

--- a/docker/openchallenges/services/api-gateway.yml
+++ b/docker/openchallenges/services/api-gateway.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-api-gateway:
-    image: ghcr.io/sage-bionetworks/openchallenges-api-gateway:local
+    image: ghcr.io/sage-bionetworks/openchallenges-api-gateway:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-api-gateway
     restart: always
     env_file:

--- a/docker/openchallenges/services/app.yml
+++ b/docker/openchallenges/services/app.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-app:
-    image: ghcr.io/sage-bionetworks/openchallenges-app:local
+    image: ghcr.io/sage-bionetworks/openchallenges-app:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-app
     restart: always
     networks:

--- a/docker/openchallenges/services/challenge-service.yml
+++ b/docker/openchallenges/services/challenge-service.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-challenge-service:
-    image: ghcr.io/sage-bionetworks/openchallenges-challenge-service:local
+    image: ghcr.io/sage-bionetworks/openchallenges-challenge-service:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-challenge-service
     restart: always
     env_file:

--- a/docker/openchallenges/services/config-server.yml
+++ b/docker/openchallenges/services/config-server.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-config-server:
-    image: ghcr.io/sage-bionetworks/openchallenges-config-server:local
+    image: ghcr.io/sage-bionetworks/openchallenges-config-server:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-config-server
     restart: always
     env_file:

--- a/docker/openchallenges/services/elasticsearch.yml
+++ b/docker/openchallenges/services/elasticsearch.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-elasticsearch:
-    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-local}
+    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-elasticsearch
     restart: always
     environment:
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
 
   openchallenges-elasticsearch-node-2:
-    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-local}
+    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-elasticsearch-node-2
     restart: always
     environment:
@@ -53,7 +53,7 @@ services:
           memory: 2G
 
   openchallenges-elasticsearch-node-3:
-    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${ELASTIC_VERION:-local}
+    image: ghcr.io/sage-bionetworks/openchallenges-elasticsearch:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-elasticsearch-node-3
     restart: always
     environment:

--- a/docker/openchallenges/services/grafana.yml
+++ b/docker/openchallenges/services/grafana.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-grafana:
-    image: ghcr.io/sage-bionetworks/openchallenges-grafana:local
+    image: ghcr.io/sage-bionetworks/openchallenges-grafana:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-grafana
     restart: always
     env_file:

--- a/docker/openchallenges/services/image-service.yml
+++ b/docker/openchallenges/services/image-service.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-image-service:
-    image: ghcr.io/sage-bionetworks/openchallenges-image-service:local
+    image: ghcr.io/sage-bionetworks/openchallenges-image-service:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-image-service
     restart: always
     env_file:

--- a/docker/openchallenges/services/mariadb.yml
+++ b/docker/openchallenges/services/mariadb.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-mariadb:
-    image: ghcr.io/sage-bionetworks/openchallenges-mariadb:local
+    image: ghcr.io/sage-bionetworks/openchallenges-mariadb:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-mariadb
     restart: always
     env_file:

--- a/docker/openchallenges/services/minio.yml
+++ b/docker/openchallenges/services/minio.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-minio:
-    image: ghcr.io/sage-bionetworks/openchallenges-minio:local
+    image: ghcr.io/sage-bionetworks/openchallenges-minio:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-minio
     restart: always
     env_file:

--- a/docker/openchallenges/services/mysqld-exporter.yml
+++ b/docker/openchallenges/services/mysqld-exporter.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-mysqld-exporter:
-    image: ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:local
+    image: ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-mysqld-exporter
     restart: always
     env_file:

--- a/docker/openchallenges/services/organization-service.yml
+++ b/docker/openchallenges/services/organization-service.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-organization-service:
-    image: ghcr.io/sage-bionetworks/openchallenges-organization-service:local
+    image: ghcr.io/sage-bionetworks/openchallenges-organization-service:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-organization-service
     restart: always
     env_file:

--- a/docker/openchallenges/services/prometheus.yml
+++ b/docker/openchallenges/services/prometheus.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-prometheus:
-    image: ghcr.io/sage-bionetworks/openchallenges-prometheus:local
+    image: ghcr.io/sage-bionetworks/openchallenges-prometheus:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-prometheus
     restart: always
     env_file:

--- a/docker/openchallenges/services/rstudio.yml
+++ b/docker/openchallenges/services/rstudio.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-rstudio:
-    image: ghcr.io/sage-bionetworks/openchallenges-rstudio:local
+    image: ghcr.io/sage-bionetworks/openchallenges-rstudio:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-rstudio
     restart: always
     env_file:

--- a/docker/openchallenges/services/service-registry.yml
+++ b/docker/openchallenges/services/service-registry.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-service-registry:
-    image: ghcr.io/sage-bionetworks/openchallenges-service-registry:local
+    image: ghcr.io/sage-bionetworks/openchallenges-service-registry:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-service-registry
     restart: always
     env_file:

--- a/docker/openchallenges/services/thumbor.yml
+++ b/docker/openchallenges/services/thumbor.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-thumbor:
-    image: ghcr.io/sage-bionetworks/openchallenges-thumbor:local
+    image: ghcr.io/sage-bionetworks/openchallenges-thumbor:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-thumbor
     restart: always
     env_file:

--- a/docker/openchallenges/services/vault.yml
+++ b/docker/openchallenges/services/vault.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-vault:
-    image: ghcr.io/sage-bionetworks/openchallenges-vault:local
+    image: ghcr.io/sage-bionetworks/openchallenges-vault:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-vault
     restart: always
     env_file:

--- a/docker/openchallenges/services/zipkin.yml
+++ b/docker/openchallenges/services/zipkin.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   openchallenges-zipkin:
-    image: ghcr.io/sage-bionetworks/openchallenges-zipkin:local
+    image: ghcr.io/sage-bionetworks/openchallenges-zipkin:${OPENCHALLENGES_VERION:-local}
     container_name: openchallenges-zipkin
     restart: always
     env_file:

--- a/docker/schematic/services/api.yml
+++ b/docker/schematic/services/api.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   schematic-api:
-    image: ghcr.io/sage-bionetworks/schematic-api:local
+    image: ghcr.io/sage-bionetworks/schematic-api:${SCHEMATIC_VERION:-local}
     container_name: schematic-api
     restart: always
     env_file:

--- a/docker/synapse/services/rstudio.yml
+++ b/docker/synapse/services/rstudio.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   synapse-rstudio:
-    image: ghcr.io/sage-bionetworks/synapse-rstudio:local
+    image: ghcr.io/sage-bionetworks/synapse-rstudio:${SYNAPSE_VERION:-local}
     container_name: synapse-rstudio
     restart: always
     env_file:


### PR DESCRIPTION
Closes #1756

## Description

See #1756 for a description of this feature.

## Changelog

- Enable to specify the version of the stack to deploy

## Preview

### Login to GHCR

This step is required to pull and deploy the images with the tag `edge` (see below).

See [instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).

> **Note**: The visibility of the images may be set to public in the future to enable anonymous download.

### Deploy OpenChallenges

Build and deploy the `local` version:

> **Note** This is the same command that we have used until now (improved DX).

```console
openchallenges-build-images

nx serve-detach openchallenges-apex
```

Deploy the `edge` version:

```console
OPENCHALLENGES_VERSION=edge nx serve-detach openchallenges-apex
```

### Deploy Schematic REST API

Deploy the `local` version:

```console
schematic-build-images

nx serve-detach schematic-api
```

Deploy the `edge` version:

```console
SCHEMATIC_VERSION=edge nx serve-detach schematic-api
```