### PR TITLE
feat: Configure the OC config server to access the git repo with SSH

### DIFF
--- a/apps/openchallenges/api-gateway/src/main/resources/application.yml
+++ b/apps/openchallenges/api-gateway/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: openchallenges-api-gateway
   profiles:
-    active: development,local
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
   cloud:

--- a/apps/openchallenges/challenge-service/src/main/resources/application.yml
+++ b/apps/openchallenges/challenge-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: openchallenges-challenge-service
   profiles:
-    active: development,local
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
   cloud:

--- a/apps/openchallenges/challenge-to-elasticsearch-service/src/main/resources/application.yml
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: openchallenges-challenge-to-elasticsearch-service
   profiles:
-    active: development,local
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
     # name: openchallenges-organization-service,openchallenges

--- a/apps/openchallenges/config-server/.env.example
+++ b/apps/openchallenges/config-server/.env.example
@@ -1,5 +1,6 @@
+GIT_DEFAULT_LABEL=test-2
+GIT_HOST_KEY_ALGORITHM=ssh-ed25519
+GIT_HOST_KEY=AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+GIT_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY-----\nchangeme\n-----END OPENSSH PRIVATE KEY-----"
+GIT_URI=git@github.com:Sage-Bionetworks/openchallenges-config-server-repository.git
 SERVER_PORT=8090
-GIT_URI=https://github.com/Sage-Bionetworks/openchallenges-config-server-repository.git
-GIT_DEFAULT_LABEL=test
-GIT_USERNAME=
-GIT_TOKEN=

--- a/apps/openchallenges/config-server/README.md
+++ b/apps/openchallenges/config-server/README.md
@@ -4,7 +4,7 @@
 
 Update the file `.env` with the required information.
 
-### Data source: GitHub repository
+### Git Backend
 
 One of the data sources of the config server is a GitHub repository where the configuration files of
 the OC services are stored. This GitHub repository should be private and not include sensitive
@@ -20,6 +20,17 @@ GIT_DEFAULT_LABEL=test
 GIT_USERNAME=<username>
 GIT_TOKEN=<token>
 ```
+
+### Authentication with SSH
+
+Generate the SSH key for connecting to the EC2 instance that we will create as part of the stack.
+
+```console
+ssh-keygen -t ed25519 -C "your_email@example.com" -f ~/.ssh/openchallenges-config-server -N ''
+```
+
+Add the public key generated to the "Deploy keys" of the GitHub repo that hosts the config.
+
 
 ### Data source: Vault
 

--- a/apps/openchallenges/config-server/README.md
+++ b/apps/openchallenges/config-server/README.md
@@ -42,7 +42,9 @@ This host key is currently included in the example config file `.env.example` an
 
 After creating `.env` from `.env.example`, the variables shown below must be set:
 
-- `GIT_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY-----\nchangeme\n-----END OPENSSH PRIVATE KEY-----"`
+- `GIT_PRIVATE_KEY`: The private SSH key previously generated. The key must be folded in one line by
+  replacing line breaks by `\n`.
+
 
 ## Vault Storage Backend
 

--- a/apps/openchallenges/config-server/README.md
+++ b/apps/openchallenges/config-server/README.md
@@ -31,7 +31,47 @@ ssh-keygen -t ed25519 -C "your_email@example.com" -f ~/.ssh/openchallenges-confi
 
 Add the public key generated to the "Deploy keys" of the GitHub repo that hosts the config.
 
+Fetch the host key for GitHub:
+
+```console
+$ ssh-keyscan -t ed25519 github.com
+# github.com:22 SSH-2.0-babeld-dc5ec9be
+github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+```
 
 ### Data source: Vault
 
 TBA
+
+## Get config from the Config Server
+
+Build and start the config server (development server):
+
+```console
+nx build openchallenges-config-server
+nx serve openchallenges-config-server
+```
+
+Try to fetch the config of the organization service:
+
+```console
+$ curl -s --user "openchallenges:changeme" \
+  http://openchallenges-config-server:8090/openchallenges-organization-service/development/test | jq
+{
+  "name": "openchallenges-organization-service",
+  "profiles": [
+    "dev"
+  ],
+  "label": "test",
+  "version": null,
+  "state": null,
+  "propertySources": [
+    {
+      "name": "https://github.com/Sage-Bionetworks/openchallenges-config-server-repository.git/openchallenges-organization-service-dev.yml",
+      "source": {
+        "openchallenges-organization-service.welcome-message": "Welcome to the Organization service."
+      }
+    }
+  ]
+}
+```

--- a/apps/openchallenges/config-server/README.md
+++ b/apps/openchallenges/config-server/README.md
@@ -62,7 +62,7 @@ Try to fetch the config of the organization service:
 
 ```console
 $ curl -s --user "openchallenges:changeme" \
-  http://openchallenges-config-server:8090/openchallenges-organization-service/development/test | jq
+  http://openchallenges-config-server:8090/openchallenges-organization-service/dev/test-2 | jq
 {
   "name": "openchallenges-organization-service",
   "profiles": [

--- a/apps/openchallenges/config-server/README.md
+++ b/apps/openchallenges/config-server/README.md
@@ -1,27 +1,26 @@
 # OpenChallenges Config Server
 
+## Overview
+
+This Spring Cloud Config Server provides externalized configuration in a distributed system of
+OpenChallenges.
+
 ## Configuration
 
-Update the file `.env` with the required information.
+The config of the config server lives in two files:
 
-### Git Backend
+- `.env`
+- `src/main/resources/application.yml`
 
-One of the data sources of the config server is a GitHub repository where the configuration files of
-the OC services are stored. This GitHub repository should be private and not include sensitive
-information like credentials, which should be stored in the project Vault instance.
+## Config Storage Backends
 
-```console
-GIT_URI=https://github.com/Sage-Bionetworks/openchallenges-config-server-repository.git
+This config server pulls the configuration of the OpenChallenges distributed system from two storage
+backends. By order of priority:
 
-# Name of the branch or tag
-GIT_DEFAULT_LABEL=test
+- Vault
+- Git repository
 
-# The token only needs read access to the repo
-GIT_USERNAME=<username>
-GIT_TOKEN=<token>
-```
-
-### Authentication with SSH
+## Git Storage Backend
 
 Generate the SSH key for connecting to the EC2 instance that we will create as part of the stack.
 
@@ -39,16 +38,21 @@ $ ssh-keyscan -t ed25519 github.com
 github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
 ```
 
-### Data source: Vault
+This host key is currently included in the example config file `.env.example` and can be left as is.
+
+After creating `.env` from `.env.example`, the variables shown below must be set:
+
+- `GIT_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY-----\nchangeme\n-----END OPENSSH PRIVATE KEY-----"`
+
+## Vault Storage Backend
 
 TBA
 
-## Get config from the Config Server
+## Test: Fetch the config of a component
 
 Build and start the config server (development server):
 
 ```console
-nx build openchallenges-config-server
 nx serve openchallenges-config-server
 ```
 

--- a/apps/openchallenges/config-server/src/main/resources/application.yml
+++ b/apps/openchallenges/config-server/src/main/resources/application.yml
@@ -17,9 +17,11 @@ spring:
           token: changeme
         git:
           uri: ${GIT_URI}
+          ignoreLocalSshSettings: true
+          hostKey: ${GIT_HOST_KEY}
+          hostKeyAlgorithm: ${GIT_HOST_KEY_ALGORITHM}
+          privateKey: ${GIT_PRIVATE_KEY}
           default-label: ${GIT_DEFAULT_LABEL}
-          username: ${GIT_USERNAME}
-          password: ${GIT_TOKEN}
           clone-on-start: true
           order: 2
     fail-fast: true

--- a/apps/openchallenges/image-service/src/main/resources/application.yml
+++ b/apps/openchallenges/image-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: openchallenges-image-service
   profiles:
-    active: development,local
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
   cloud:

--- a/apps/openchallenges/kaggle-to-kafka-service/src/main/resources/application.yml
+++ b/apps/openchallenges/kaggle-to-kafka-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: openchallenges-kaggle-to-kafka-service
   profiles:
-    active: development,local
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
   cloud:

--- a/apps/openchallenges/organization-service/src/main/resources/application.yml
+++ b/apps/openchallenges/organization-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: openchallenges-organization-service
   profiles:
-    active: development,local
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
     # name: openchallenges-organization-service,openchallenges

--- a/apps/openchallenges/service-registry/src/main/resources/application.yml
+++ b/apps/openchallenges/service-registry/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: openchallenges-service-registry
   profiles:
-    active: development,local
+    active: dev,local
   config:
     import: 'configserver:http://openchallenges-config-server:8090'
   cloud:


### PR DESCRIPTION
Closes #1760

## Changelog

- Configure the config server to access the private git repository with an SSH key instead of user credentials
- Rename the service profile name `development` to `dev`

## TODO

- [x] Share this change with the developers of OpenChallenges as it requires them to update the `.env` of the project `openchallenges-config-server`.

## Preview

### Video

Click on the image to learn everything there is to know about this PR (XP Sharing video series).

[![IMAGE ALT TEXT](http://img.youtube.com/vi/cHPcwdAdDzc/0.jpg)](http://www.youtube.com/watch?v=cHPcwdAdDzc "Video Title")

> **Note** Please share your feedback about this video in this thread or in DM (video content, format, etc.).

### New Config Server config file

This is what the `.env` of the OpenChallenges config server looks like (see `.env.example`):

```
GIT_DEFAULT_LABEL=test-2
GIT_HOST_KEY_ALGORITHM=ssh-ed25519
GIT_HOST_KEY=AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
GIT_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY-----\nchangeme\n-----END OPENSSH PRIVATE KEY-----"
GIT_URI=git@github.com:Sage-Bionetworks/openchallenges-config-server-repository.git
SERVER_PORT=8090
```

where the string `changeme` must be replaced by the private key of a deploy key registered to the private GitHub repo that include the configuration of the OpenChallenges distributed system.