### PR TITLE
feat: Configure the OC Apex to target the API docs

### DIFF
--- a/apps/openchallenges/apex/.env.example
+++ b/apps/openchallenges/apex/.env.example
@@ -1,3 +1,5 @@
+API_DOCS_HOST=openchallenges-api-docs
+API_DOCS_PORT=8010
 API_GATEWAY_HOST=openchallenges-api-gateway
 API_GATEWAY_PORT=8082
 APP_HOST=openchallenges-app

--- a/apps/openchallenges/apex/templates/http.conf.template
+++ b/apps/openchallenges/apex/templates/http.conf.template
@@ -61,7 +61,7 @@ http {
       proxy_set_header Connection "Keep-Alive";
       proxy_set_header Proxy-Connection "Keep-Alive";
 
-      proxy_pass http://api-docs;
+      proxy_pass http://api-docs/;
     }
 
     location /api {

--- a/apps/openchallenges/apex/templates/http.conf.template
+++ b/apps/openchallenges/apex/templates/http.conf.template
@@ -2,6 +2,11 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
+  upstream api-docs {
+    server ${API_DOCS_HOST}:${API_DOCS_PORT};
+    keepalive 15;
+  }
+
   upstream api-gateway {
     server ${API_GATEWAY_HOST}:${API_GATEWAY_PORT};
     keepalive 15;
@@ -42,6 +47,21 @@ http {
       proxy_set_header Proxy-Connection "Keep-Alive";
 
       proxy_pass http://app;
+    }
+
+    location /api-docs {
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header Host $http_host;
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+
+      proxy_set_header Connection "Keep-Alive";
+      proxy_set_header Proxy-Connection "Keep-Alive";
+
+      proxy_pass http://api-docs;
     }
 
     location /api {

--- a/apps/openchallenges/api-docs/Dockerfile
+++ b/apps/openchallenges/api-docs/Dockerfile
@@ -1,5 +1,8 @@
 FROM redocly/redoc:v2.0.0
 
+HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
+  CMD curl --fail --silent "localhost:8010" || exit 1
+
 COPY build/redoc-static.html /usr/share/nginx/html/index.html
 COPY favicon.ico /usr/share/nginx/html/
 

--- a/docker/openchallenges/services/apex.yml
+++ b/docker/openchallenges/services/apex.yml
@@ -15,6 +15,8 @@ services:
     ports:
       - '8000:8000'
     depends_on:
+      openchallenges-api-docs:
+        condition: service_healthy
       openchallenges-api-gateway:
         condition: service_healthy
       openchallenges-app:


### PR DESCRIPTION
Closes #1780

## Changelog

- Add `HEALTHCHECK` to the image of `openchallenges-api-docs`
- Start the API docs container when starting the OC apex container
- Configure the OC apex to redirect traffic to `/api-docs` to the API docs container

## Preview

Starting the OC stack now serves the API docs on `localhost:8000/api-docs`.

```console
# Remove the existing Docker containers (if any)
workspace-docker-stop
docker system prune --force

openchallenges-build-images
nx serve-detach openchallenges-apex
```

<img width="1440" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/c2fe781e-16a4-4ca5-aa91-ffd8d9ede5c5">
