### PR TITLE
feat: Scan edge images with Trivy

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   trivy-edge:
-    name: ${{ matrix.image }} image scan
+    name: ${{ matrix.image }}
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - 'ghcr.io/sage-bionetworks/openchallenges-zipkin:edge'
-          - 'ghcr.io/sage-bionetworks/openchallenges-apex:edge'
+          - 'openchallenges-zipkin'
+          - 'openchallenges-apex'
 
     steps:
       - name: Login to GitHub Container Registry
@@ -32,42 +32,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull the image for the architecture we're testing
+      - name: Pull the image
         run: |
-          docker pull ${{ matrix.image }}
+          docker pull ghcr.io/sage-bionetworks/${{ matrix.image }}:edge
 
       # Deliberately chosen master here to keep up-to-date.
       - name: Run Trivy vulnerability scanner for any major issues
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ matrix.image }}
+          image-ref: ghcr.io/sage-bionetworks/${{ matrix.image }}:edge
           # Filter out any that have no current fix.
           ignore-unfixed: true
           # Only include major issues.
           severity: CRITICAL,HIGH
           format: template
           template: '@/contrib/sarif.tpl'
-          output: trivy-results-${{ matrix.image }}.sarif
+          output: trivy-results-${{ matrix.image }}-edge.sarif
 
       # Show all detected issues.
       # Note this will show a lot more, including major un-fixed ones.
       - name: Run Trivy vulnerability scanner for local output
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ matrix.image }}
+          image-ref: ghcr.io/sage-bionetworks/${{ matrix.image }}:edge
           format: table
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: trivy-results-${{ matrix.image }}.sarif
-          category: ${{ matrix.image }} image
+          sarif_file: trivy-results-${{ matrix.image }}-edge.sarif
+          category: ${{ matrix.image }}:edge image
           wait-for-processing: true
 
       # In case we need to analyse the uploaded files for some reason.
       - name: Detain results for debug if needed
         uses: actions/upload-artifact@v3
         with:
-          name: trivy-results-${{ matrix.image }}.sarif
-          path: trivy-results-${{ matrix.image }}.sarif
+          name: trivy-results-${{ matrix.image }}-edge.sarif
+          path: trivy-results-${{ matrix.image }}-edge.sarif
           if-no-files-found: error

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   trivy-edge:
-    name: ${{ matrix.repo }} image scan
+    name: ${{ matrix.image }} image scan
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -21,8 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - 'openchallenges-zipkin'
           - 'openchallenges-apex'
+          - 'openchallenges-api-gateway'
+          - 'openchallenges-challenge-service'
+          - 'openchallenges-zipkin'
 
     steps:
       - name: Login to GitHub Container Registry

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -1,4 +1,4 @@
-name: Trivy security analysis of edge images
+name: Scan image
 
 on:
   push:

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -1,16 +1,15 @@
 name: Scan image
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  # schedule:
-  # 13:44 on Thursday
-  # - cron: 44 13 * * 4
-  # every 10 minutes
-  # - cron: '*/10 * * * *'
-  # workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  schedule:
+    # 19:29 on Thursday
+    - cron: 29 19 * * 4
+    # every 2 hours (during evaluation)
+    - cron: 0 */2 * * *
 
 jobs:
   trivy-edge:

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -1,0 +1,73 @@
+name: Trivy security analysis of edge images
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  # schedule:
+  # 13:44 on Thursday
+  # - cron: 44 13 * * 4
+  # every 10 minutes
+  # - cron: '*/10 * * * *'
+  # workflow_dispatch:
+
+jobs:
+  trivy-edge:
+    name: ${{ matrix.repo }} image scan
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - 'ghcr.io/sage-bionetworks/openchallenges-zipkin:edge'
+          - 'ghcr.io/sage-bionetworks/openchallenges-apex:edge'
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull the image for the architecture we're testing
+        run: |
+          docker pull ${{ matrix.image }}
+
+      # Deliberately chosen master here to keep up-to-date.
+      - name: Run Trivy vulnerability scanner for any major issues
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ matrix.image }}
+          # Filter out any that have no current fix.
+          ignore-unfixed: true
+          # Only include major issues.
+          severity: CRITICAL,HIGH
+          format: template
+          template: '@/contrib/sarif.tpl'
+          output: trivy-results-${{ matrix.image }}.sarif
+
+      # Show all detected issues.
+      # Note this will show a lot more, including major un-fixed ones.
+      - name: Run Trivy vulnerability scanner for local output
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ matrix.image }}
+          format: table
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-results-${{ matrix.image }}.sarif
+          category: ${{ matrix.image }} image
+          wait-for-processing: true
+
+      # In case we need to analyse the uploaded files for some reason.
+      - name: Detain results for debug if needed
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivy-results-${{ matrix.image }}.sarif
+          path: trivy-results-${{ matrix.image }}.sarif
+          if-no-files-found: error


### PR DESCRIPTION
Closes #1759

## Changelog

- Add GitHub workflow that scan the edge images published by Sage Monorepo with Trivy

## References

- https://github.com/fluent/fluent-bit/blob/master/.github/workflows/cron-trivy.yaml