### PR TITLE
chore: Update the active devcontainer to `1859079`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
-  "name": "Sage",
-  "image": "sagebionetworks/sage-devcontainer:b397cf3",
+  "name": "Sage Dev Container",
+  "image": "ghcr.io/sage-bionetworks/sage-devcontainer:1859079",
 
   "containerEnv": {
     "NX_BASE": "${localEnv:NX_BASE}",


### PR DESCRIPTION
Closes #1806

## Changelog

- Update the active devcontainer

## Notes

- This is the first time the image of the active devcontainer comes from GHCR