### PR TITLE
fix: Fix `CVE-2023-35945` in OC apex

### DIFF
--- a/apps/openchallenges/apex/Dockerfile
+++ b/apps/openchallenges/apex/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.0-alpine
+FROM nginx:1.25.1-alpine
 
 RUN apk add --no-cache jq
 


### PR DESCRIPTION
Closes #1822

## Changelog

- Update `openchallenges-apex` base image