### PR TITLE
feat: Get org by `id` or `login`

### DIFF
--- a/apps/openchallenges/organization-service/requests.http
+++ b/apps/openchallenges/organization-service/requests.http
@@ -36,10 +36,10 @@ GET {{basePath}}/organizations?sort=name
 
 GET {{basePath}}/organizations?sort=challenge_count&pageSize=5
 
-### Get an organization by its login
+### Get an organization by login
 
 GET {{basePath}}/organizations/dream
 
-### Get an organization by its ID
+### Get an organization by ID
 
 GET {{basePath}}/organizations/1

--- a/apps/openchallenges/organization-service/requests.http
+++ b/apps/openchallenges/organization-service/requests.http
@@ -36,6 +36,10 @@ GET {{basePath}}/organizations?sort=name
 
 GET {{basePath}}/organizations?sort=challenge_count&pageSize=5
 
-### Get an organization by ID
+### Get an organization by its login
 
 GET {{basePath}}/organizations/dream
+
+### Get an organization by its ID
+
+GET {{basePath}}/organizations/1

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApi.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApi.java
@@ -81,7 +81,7 @@ public interface OrganizationApi {
       value = "/organizations/{org}",
       produces = {"application/json", "application/problem+json"})
   default ResponseEntity<OrganizationDto> getOrganization(
-      @Size(min = 1, max = 25)
+      @Size(min = 1, max = 64)
           @Parameter(
               name = "org",
               description = "The id or login of the organization.",

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApi.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApi.java
@@ -33,7 +33,7 @@ public interface OrganizationApi {
   /**
    * GET /organizations/{org} : Get an organization Returns the organization specified
    *
-   * @param org The unique identifier of the organization. (required)
+   * @param org The id or login of the organization. (required)
    * @return An organization (status code 200) or The specified resource was not found (status code
    *     404) or The request cannot be fulfilled due to an unexpected server error (status code 500)
    */
@@ -81,11 +81,10 @@ public interface OrganizationApi {
       value = "/organizations/{org}",
       produces = {"application/json", "application/problem+json"})
   default ResponseEntity<OrganizationDto> getOrganization(
-      @Pattern(regexp = "^[a-z0-9]+(?:-[a-z0-9]+)*$")
-          @Size(min = 2, max = 64)
+      @Size(min = 1, max = 25)
           @Parameter(
               name = "org",
-              description = "The unique identifier of the organization.",
+              description = "The id or login of the organization.",
               required = true)
           @PathVariable("org")
           String org) {

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegate.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegate.java
@@ -24,7 +24,7 @@ public interface OrganizationApiDelegate {
   /**
    * GET /organizations/{org} : Get an organization Returns the organization specified
    *
-   * @param org The unique identifier of the organization. (required)
+   * @param org The id or login of the organization. (required)
    * @return An organization (status code 200) or The specified resource was not found (status code
    *     404) or The request cannot be fulfilled due to an unexpected server error (status code 500)
    * @see OrganizationApi#getOrganization

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegateImpl.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegateImpl.java
@@ -19,7 +19,7 @@ public class OrganizationApiDelegateImpl implements OrganizationApiDelegate {
   }
 
   @Override
-  public ResponseEntity<OrganizationDto> getOrganization(String organizationLogin) {
-    return ResponseEntity.ok(organizationService.getOrganization(organizationLogin));
+  public ResponseEntity<OrganizationDto> getOrganization(String identifier) {
+    return ResponseEntity.ok(organizationService.getOrganization(identifier));
   }
 }

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/configuration/SpringDocConfiguration.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/configuration/SpringDocConfiguration.java
@@ -25,7 +25,8 @@ public class SpringDocConfiguration {
                 .license(
                     new License()
                         .name("Apache 2.0")
-                        .url("https://github.com/Sage-Bionetworks/sage-monorepo"))
+                        .url(
+                            "https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt"))
                 .version("1.0.0"));
   }
 }

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/model/repository/OrganizationRepository.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/model/repository/OrganizationRepository.java
@@ -1,7 +1,11 @@
 package org.sagebionetworks.openchallenges.organization.service.model.repository;
 
+import java.util.Optional;
 import org.sagebionetworks.openchallenges.organization.service.model.entity.OrganizationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrganizationRepository
-    extends JpaRepository<OrganizationEntity, Long>, CustomOrganizationRepository {}
+    extends JpaRepository<OrganizationEntity, Long>, CustomOrganizationRepository {
+
+  Optional<OrganizationEntity> findByIdOrLogin(Long id, String login);
+}

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
@@ -55,18 +55,18 @@ public class OrganizationService {
   }
 
   @Transactional(readOnly = true)
-  public OrganizationDto getOrganization(String organizationLogin) {
+  public OrganizationDto getOrganization(String org) {
     OrganizationEntity orgEntity =
         organizationRepository
-            .findBySimpleNaturalId(organizationLogin)
+            .findBySimpleNaturalId(org)
             .orElseThrow(
                 () ->
                     new OrganizationNotFoundException(
                         String.format(
-                            "The organization with ID %s does not exist.", organizationLogin)));
+                            "The organization with ID %s does not exist.", org)));
 
-    OrganizationDto org = organizationMapper.convertToDto(orgEntity);
+    OrganizationDto orgDto = organizationMapper.convertToDto(orgEntity);
 
-    return org;
+    return orgDto;
   }
 }

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
@@ -55,18 +55,28 @@ public class OrganizationService {
   }
 
   @Transactional(readOnly = true)
-  public OrganizationDto getOrganization(String org) {
+  public OrganizationDto getOrganization(String identifier) {
+    String orgLogin = String.valueOf(identifier);
+    Long orgId = null;
+    try {
+      orgId = Long.valueOf(orgLogin);
+    } catch (Exception ignore) {
+      // Ignore
+    }
+
+    LOG.info("login: {}", orgLogin);
+    LOG.info("id: {}", orgId);
+
     OrganizationEntity orgEntity =
         organizationRepository
-            .findBySimpleNaturalId(org)
+            .findByIdOrLogin(orgId, orgLogin)
             .orElseThrow(
                 () ->
                     new OrganizationNotFoundException(
                         String.format(
-                            "The organization with ID %s does not exist.", org)));
+                            "The organization with the ID or login %s does not exist.",
+                            identifier)));
 
-    OrganizationDto orgDto = organizationMapper.convertToDto(orgEntity);
-
-    return orgDto;
+    return organizationMapper.convertToDto(orgEntity);
   }
 }

--- a/apps/openchallenges/organization-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
+++ b/apps/openchallenges/organization-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
@@ -13,7 +13,7 @@ CREATE TABLE `organization` (
   `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `acronym` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  CONSTRAINT login_check CHECK (char_length(login) >= 2)
+  CONSTRAINT login_check CHECK (char_length(`login`) >= 2 and `login` regexp '^[a-z]')
 );
 
 -- organization_category definition

--- a/apps/openchallenges/organization-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/organization-service/src/main/resources/openapi.yaml
@@ -71,7 +71,7 @@ paths:
         name: org
         required: true
         schema:
-          maxLength: 25
+          maxLength: 64
           minLength: 1
           type: string
         style: simple
@@ -124,7 +124,7 @@ components:
       name: org
       required: true
       schema:
-        maxLength: 25
+        maxLength: 64
         minLength: 1
         type: string
       style: simple

--- a/apps/openchallenges/organization-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/organization-service/src/main/resources/openapi.yaml
@@ -5,11 +5,11 @@ info:
     url: https://github.com/Sage-Bionetworks/sage-monorepo
   license:
     name: Apache 2.0
-    url: https://github.com/Sage-Bionetworks/sage-monorepo
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
   title: OpenChallenges Organization REST API
   version: 1.0.0
   x-logo:
-    url: https://Sage-Bionetworks.github.io/rocc-schemas/logo.png
+    url: https://dev.openchallenges.io/img/unsafe/logo/OpenChallenges-logo.png
 servers:
 - url: http://localhost/v1
 tags:
@@ -60,13 +60,20 @@ paths:
       description: Returns the organization specified
       operationId: getOrganization
       parameters:
-      - description: The unique identifier of the organization.
+      - description: The id or login of the organization.
+        examples:
+          byString:
+            value: dream
+          byId:
+            value: "1"
         explode: false
         in: path
         name: org
         required: true
         schema:
-          $ref: '#/components/schemas/OrganizationLogin'
+          maxLength: 25
+          minLength: 1
+          type: string
         style: simple
       responses:
         "200":
@@ -106,13 +113,20 @@ components:
         $ref: '#/components/schemas/OrganizationSearchQuery'
       style: form
     org:
-      description: The unique identifier of the organization.
+      description: The id or login of the organization.
+      examples:
+        byString:
+          value: dream
+        byId:
+          value: "1"
       explode: false
       in: path
       name: org
       required: true
       schema:
-        $ref: '#/components/schemas/OrganizationLogin'
+        maxLength: 25
+        minLength: 1
+        type: string
       style: simple
   responses:
     BadRequest:

--- a/libs/openchallenges/api-client-angular/src/lib/api/organization.service.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/api/organization.service.ts
@@ -100,7 +100,7 @@ export class OrganizationService {
     /**
      * Get an organization
      * Returns the organization specified
-     * @param org The unique identifier of the organization.
+     * @param org The id or login of the organization.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -1271,7 +1271,7 @@ components:
       schema:
         type: string
         minLength: 1
-        maxLength: 25
+        maxLength: 64
       examples:
         byString:
           value: dream

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -1048,7 +1048,14 @@ components:
     org:
       name: org
       in: path
-      description: The unique identifier of the organization.
+      description: The id or login of the organization.
       required: true
       schema:
-        $ref: '#/components/schemas/OrganizationLogin'
+        type: string
+        minLength: 1
+        maxLength: 25
+      examples:
+        byString:
+          value: dream
+        byId:
+          value: '1'

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -23,6 +23,8 @@ tags:
     description: Operations about images
   - name: Organization
     description: Operations about organizations
+  - name: User
+    description: Operations about users
 paths:
   /challenges:
     get:
@@ -201,6 +203,90 @@ paths:
               schema:
                 $ref: '#/components/schemas/Organization'
         '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /users/register:
+    post:
+      tags:
+        - User
+      summary: Create a user
+      description: Create a user with the specified account name
+      operationId: createUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCreateRequest'
+        required: true
+      responses:
+        '201':
+          description: Account created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCreateResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /users:
+    get:
+      tags:
+        - User
+      summary: Get all users
+      description: Returns the users
+      operationId: listUsers
+      parameters:
+        - $ref: '#/components/parameters/pageNumber'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersPage'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/users/{userId}':
+    parameters:
+      - $ref: '#/components/parameters/userId'
+    get:
+      tags:
+        - User
+      summary: Get a user
+      description: Returns the user specified
+      operationId: getUser
+      responses:
+        '200':
+          description: A user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - User
+      summary: Delete a user
+      description: Deletes the user specified
+      operationId: deleteUser
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptyObject'
+        '400':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
@@ -979,6 +1065,132 @@ components:
             - organizations
       x-java-class-annotations:
         - '@lombok.Builder'
+    UserCreateRequest:
+      type: object
+      description: The information required to create a user account
+      properties:
+        login:
+          type: string
+        email:
+          $ref: '#/components/schemas/Email'
+        password:
+          type: string
+          format: password
+        name:
+          type: string
+          nullable: true
+        avatarUrl:
+          type: string
+          format: url
+          example: 'https://example.com/awesome-avatar.png'
+          nullable: true
+        bio:
+          type: string
+          nullable: true
+      required:
+        - login
+        - email
+        - password
+      example:
+        login: awesome-user
+        email: awesome-user@example.org
+        password: yourpassword
+        name: Awesome User
+        avatarUrl: 'https://example.com/awesome-avatar.png'
+        bio: A great bio
+    AccountId:
+      description: The unique identifier of an account
+      type: integer
+      format: int64
+      example: 1
+    UserCreateResponse:
+      type: object
+      description: The response returned after the creation of the user
+      properties:
+        id:
+          $ref: '#/components/schemas/AccountId'
+      required:
+        - id
+      example:
+        id: 507f1f77bcf86cd799439011
+      x-java-class-annotations:
+        - '@lombok.Builder'
+    UserStatus:
+      description: The account status of a user
+      type: string
+      enum:
+        - pending
+        - approved
+        - disabled
+        - blacklist
+      example: pending
+    User:
+      type: object
+      description: A simple user
+      properties:
+        id:
+          $ref: '#/components/schemas/AccountId'
+        login:
+          type: string
+        email:
+          $ref: '#/components/schemas/Email'
+        name:
+          type: string
+          nullable: true
+        status:
+          $ref: '#/components/schemas/UserStatus'
+        avatarUrl:
+          type: string
+          format: url
+          example: 'https://example.com/awesome-avatar.png'
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        type:
+          type: string
+          example: User
+        bio:
+          type: string
+          nullable: true
+      required:
+        - login
+        - email
+        - createdAt
+        - updatedAt
+        - type
+      example:
+        login: awesome-user
+        email: awesome-user@example.org
+        name: Awesome User
+        status: approved
+        avatarUrl: 'https://example.com/awesome-avatar.png'
+        bio: A great bio
+        createdAt: '2017-07-08T16:18:44-04:00'
+        updatedAt: '2017-07-08T16:18:44-04:00'
+        type: User
+    UsersPage:
+      type: object
+      description: A page of users
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            users:
+              description: A list of users
+              type: array
+              items:
+                $ref: '#/components/schemas/User'
+          required:
+            - users
+      x-java-class-annotations:
+        - '@lombok.Builder'
+    EmptyObject:
+      type: object
+      description: Empty JSON object
   responses:
     BadRequest:
       description: Invalid request
@@ -994,6 +1206,12 @@ components:
             $ref: '#/components/schemas/BasicError'
     NotFound:
       description: The specified resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Conflict:
+      description: The request conflicts with current state of the target resource
       content:
         application/problem+json:
           schema:
@@ -1059,3 +1277,28 @@ components:
           value: dream
         byId:
           value: '1'
+    pageNumber:
+      name: pageNumber
+      description: The page number.
+      in: query
+      schema:
+        type: integer
+        format: int32
+        default: 0
+        minimum: 0
+    pageSize:
+      name: pageSize
+      description: The number of items in a single page.
+      in: query
+      schema:
+        type: integer
+        format: int32
+        default: 100
+        minimum: 1
+    userId:
+      name: userId
+      in: path
+      description: 'The unique identifier of the user, either the user account ID or login'
+      required: true
+      schema:
+        $ref: '#/components/schemas/AccountId'

--- a/libs/openchallenges/api-description/build/organization.openapi.yaml
+++ b/libs/openchallenges/api-description/build/organization.openapi.yaml
@@ -273,10 +273,17 @@ components:
     org:
       name: org
       in: path
-      description: The unique identifier of the organization.
+      description: The id or login of the organization.
       required: true
       schema:
-        $ref: '#/components/schemas/OrganizationLogin'
+        type: string
+        minLength: 1
+        maxLength: 25
+      examples:
+        byString:
+          value: dream
+        byId:
+          value: '1'
   responses:
     BadRequest:
       description: Invalid request

--- a/libs/openchallenges/api-description/build/organization.openapi.yaml
+++ b/libs/openchallenges/api-description/build/organization.openapi.yaml
@@ -278,7 +278,7 @@ components:
       schema:
         type: string
         minLength: 1
-        maxLength: 25
+        maxLength: 64
       examples:
         byString:
           value: dream

--- a/libs/openchallenges/api-description/openapi-merge.yaml
+++ b/libs/openchallenges/api-description/openapi-merge.yaml
@@ -5,5 +5,5 @@ inputs:
   - inputFile: build/challenge.openapi.yaml
   - inputFile: build/image.openapi.yaml
   - inputFile: build/organization.openapi.yaml
-  # - inputFile: build/user.openapi.yaml
+  - inputFile: build/user.openapi.yaml
 output: build/openapi.yaml

--- a/libs/openchallenges/api-description/src/components/parameters/path/org.yaml
+++ b/libs/openchallenges/api-description/src/components/parameters/path/org.yaml
@@ -1,6 +1,13 @@
 name: org
 in: path
-description: The unique identifier of the organization.
+description: The id or login of the organization.
 required: true
 schema:
-  $ref: ../../schemas/OrganizationLogin.yaml
+  type: string
+  minLength: 1
+  maxLength: 25
+examples:
+  byString:
+    value: 'dream'
+  byId:
+    value: '1'

--- a/libs/openchallenges/api-description/src/components/parameters/path/org.yaml
+++ b/libs/openchallenges/api-description/src/components/parameters/path/org.yaml
@@ -5,7 +5,7 @@ required: true
 schema:
   type: string
   minLength: 1
-  maxLength: 25
+  maxLength: 64
 examples:
   byString:
     value: 'dream'

--- a/libs/openchallenges/api-description/src/components/schemas/OrgId.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/OrgId.yaml
@@ -1,3 +1,0 @@
-description: The unique identifier of an organization
-type: string
-example: 507f1f77bcf86cd799439011


### PR DESCRIPTION
Closes #1722

## Changelog

- Update endpoint to access `id` value in addition to `login` values
- Requires org logins to start with a-z
- Update the OC API client for Angular

## Notes

- The motivation for requiring org logins to start with a-z is so that there is never an org login that may be an org ID too, which would otherwise lead to ambiguity when retrieving the organization.

## Preview

### Get an organization by login

```
GET {{basePath}}/organizations/dream

HTTP/1.1 200
{
  "id": 1,
  "name": "DREAM",
  "email": "dream@sagebionetworks.org",
  "login": "dream",
  "description": "Together, we share a vision to enable individuals and groups to collaborate openly so that the “wisdom of the crowd” provides the greatest impact on science and human health.",
  "avatarKey": "logo/dream.png",
  "websiteUrl": "https://dreamchallenges.org/",
  "challengeCount": 47,
  "createdAt": "2023-07-20T21:46:02Z",
  "updatedAt": "2023-07-20T21:46:02Z",
  "acronym": "DREAM"
}
```

### Get an organization by ID

```
GET {{basePath}}/organizations/1

HTTP/1.1 200 
{
  "id": 1,
  "name": "DREAM",
  "email": "dream@sagebionetworks.org",
  "login": "dream",
  "description": "Together, we share a vision to enable individuals and groups to collaborate openly so that the “wisdom of the crowd” provides the greatest impact on science and human health.",
  "avatarKey": "logo/dream.png",
  "websiteUrl": "https://dreamchallenges.org/",
  "challengeCount": 47,
  "createdAt": "2023-07-20T21:46:02Z",
  "updatedAt": "2023-07-20T21:46:02Z",
  "acronym": "DREAM"
}
```

### Requiring org login to start with `a-Z`

The organization service fails to load if we replace the login of DREAM by `4dream`:

```console
$ nx serve openchallenges-organization-service
...
        at org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.handleException(DefaultSqlScriptExecutor.java:275)
        at org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.executeStatement(DefaultSqlScriptExecutor.java:222)
        at org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.execute(DefaultSqlScriptExecutor.java:126)
        at org.flywaydb.core.internal.resolver.sql.SqlMigrationExecutor.executeOnce(SqlMigrationExecutor.java:68)
        at org.flywaydb.core.internal.resolver.sql.SqlMigrationExecutor.lambda$execute$0(SqlMigrationExecutor.java:57)
        at org.flywaydb.core.internal.database.DefaultExecutionStrategy.execute(DefaultExecutionStrategy.java:27)
        at org.flywaydb.core.internal.resolver.sql.SqlMigrationExecutor.execute(SqlMigrationExecutor.java:56)
        at org.flywaydb.core.internal.command.DbMigrate.doMigrateGroup(DbMigrate.java:376)
        ... 153 common frames omitted
Caused by: java.sql.SQLIntegrityConstraintViolationException: CONSTRAINT `login_check` failed for `organization_service`.`organization`
        at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:117)
        at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
        at com.mysql.cj.jdbc.StatementImpl.executeInternal(StatementImpl.java:763)
        at com.mysql.cj.jdbc.StatementImpl.execute(StatementImpl.java:648)
        at com.zaxxer.hikari.pool.ProxyStatement.execute(ProxyStatement.java:94)
        at com.zaxxer.hikari.pool.HikariProxyStatement.execute(HikariProxyStatement.java)
        at org.flywaydb.core.internal.jdbc.JdbcTemplate.executeStatement(JdbcTemplate.java:201)
        at org.flywaydb.core.internal.sqlscript.ParsedSqlStatement.execute(ParsedSqlStatement.java:95)
        at org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.executeStatement(DefaultSqlScriptExecutor.java:210)
        ... 159 common frames omitted
```