### PR TITLE
chore: Update devcontainer to `55645b0` (now Ubuntu 22.04)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Sage Dev Container",
-  "image": "ghcr.io/sage-bionetworks/sage-devcontainer:1859079",
+  "image": "ghcr.io/sage-bionetworks/sage-devcontainer:55645b0",
 
   "containerEnv": {
     "NX_BASE": "${localEnv:NX_BASE}",

--- a/apps/schematic/api/prepare-python.sh
+++ b/apps/schematic/api/prepare-python.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo $0
+
 pyenv install --skip-existing 3.10.0
 pyenv local 3.10.0
 poetry env use 3.10.0

--- a/apps/schematic/api/prepare-python.sh
+++ b/apps/schematic/api/prepare-python.sh
@@ -8,7 +8,6 @@ pyenv install --skip-existing $PYTHON_VERSION
 # installed above is not detected.
 eval "$(pyenv init -)"
 
-
 pyenv local $PYTHON_VERSION
 poetry env use $PYTHON_VERSION
 poetry run pip install "cython<3.0.0"

--- a/apps/schematic/api/prepare-python.sh
+++ b/apps/schematic/api/prepare-python.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
-pyenv install --skip-existing 3.10.0
+PYTHON_VERSION="3.10.0"
 
-echo "INIT"
+pyenv install --skip-existing $PYTHON_VERSION
+
+# Initializing pyenv again solves an issue encountered by GitHub action where the version of Python
+# installed above is not detected.
 eval "$(pyenv init -)"
-# eval "$(pyenv virtualenv-init -)"
 
-echo "pyenv local"
-pyenv local 3.10.0
 
-echo "poetry env use"
-poetry env use 3.10.0
-
+pyenv local $PYTHON_VERSION
+poetry env use $PYTHON_VERSION
 poetry run pip install "cython<3.0.0"
 poetry run pip install --no-build-isolation pyyaml==5.4.1
 poetry install --with prod,dev

--- a/apps/schematic/api/prepare-python.sh
+++ b/apps/schematic/api/prepare-python.sh
@@ -2,6 +2,10 @@
 
 pyenv install --skip-existing 3.10.0
 
+echo "INIT"
+eval "$(pyenv init -)"
+# eval "$(pyenv virtualenv-init -)"
+
 echo "pyenv local"
 pyenv local 3.10.0
 

--- a/apps/schematic/api/prepare-python.sh
+++ b/apps/schematic/api/prepare-python.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-echo $0
-
 pyenv install --skip-existing 3.10.0
+
+echo "pyenv local"
 pyenv local 3.10.0
+
+echo "poetry env use"
 poetry env use 3.10.0
+
 poetry run pip install "cython<3.0.0"
 poetry run pip install --no-build-isolation pyyaml==5.4.1
 poetry install --with prod,dev

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -27,11 +27,12 @@ function workspace-cd {
 export PATH="$PATH:$WORKSPACE_DIR/node_modules/.bin"
 
 function workspace-install {
-  yarn install --immutable
+  echo $0
+  # yarn install --immutable
   # TODO: Find a more efficient way than looping through all the Java project to execute the same
   # task (download gradle), enough though caching already helps.
-  nx run-many --target=prepare
-  nx run-many --target=prepare-java --parallel=1
+  # nx run-many --target=prepare
+  # nx run-many --target=prepare-java --parallel=1
   nx run-many --target=prepare-python
 }
 

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -27,12 +27,11 @@ function workspace-cd {
 export PATH="$PATH:$WORKSPACE_DIR/node_modules/.bin"
 
 function workspace-install {
-  echo $0
-  # yarn install --immutable
+  yarn install --immutable
   # TODO: Find a more efficient way than looping through all the Java project to execute the same
   # task (download gradle), enough though caching already helps.
-  # nx run-many --target=prepare
-  # nx run-many --target=prepare-java --parallel=1
+  nx run-many --target=prepare
+  nx run-many --target=prepare-java --parallel=1
   nx run-many --target=prepare-python
 }
 


### PR DESCRIPTION
## Changelog

- Update the devcontainer to version `55645b0`
- Update the `prepare-python.sh` of the project `schematic-api` to re-initialize `pyenv` after installing new Python env

## Notes

- The new devcontainer image was built by #1844
- This PR fixes an issue encountered when running the task `prepare-python` for the project `schematic-api` in a GitHub workflow. This error could not be reproduced locally. The difference between the task `prepare-python` of `schematic-api` compared to the other Python projects is that `schematic-api` is using a version of Python not pre-installed by the devcontainer. This is actually a feature of Sage Monorepo to give developers the flexibility to use any Python version for their project. Yet, making projects use pre-installed Python versions contributes to speed up the execution of the task `prepare-python` for developers locally and in CI workflow. Hence, a future PR could update the project `schematic-api` to use a pre-installed version of Python.