### PR TITLE
fix(ui): add links to Google Forms

### DIFF
--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
@@ -76,7 +76,13 @@
     </div>
   </div> -->
   <hr />
-  <span class="mat-caption created-updated-dates"
-    >Added to the OC on {{ challenge.createdAt }} and last modified on {{ challenge.updatedAt }}
+  <span class="mat-caption created-updated-dates">
+    Added to the OC on {{ challenge.createdAt }} and last modified on {{ challenge.updatedAt }} //
+    See something missing or not up-to-date?
+    <a
+      href="https://docs.google.com/forms/d/e/1FAIpQLSdkgAVOuof-tE4PvCnpPbbGnQvvMhLuTkXikDXTbsCHqcMVSw/viewform?usp=pp_url&entry.1040159972={{challenge.slug}}"
+      target="_blank"
+      >Suggest an edit here!</a
+    >
   </span>
 </main>

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
@@ -80,7 +80,7 @@
     Added to the OC on {{ challenge.createdAt }} and last modified on {{ challenge.updatedAt }} //
     See something missing or not up-to-date?
     <a
-      href="https://docs.google.com/forms/d/e/1FAIpQLSdkgAVOuof-tE4PvCnpPbbGnQvvMhLuTkXikDXTbsCHqcMVSw/viewform?usp=pp_url&entry.1040159972={{challenge.slug}}"
+      href="https://docs.google.com/forms/d/e/1FAIpQLSdkgAVOuof-tE4PvCnpPbbGnQvvMhLuTkXikDXTbsCHqcMVSw/viewform?usp=pp_url&entry.2102238281={{challenge.id}}&entry.1040159972={{challenge.slug}}"
       target="_blank"
       >Suggest an edit here!</a
     >

--- a/libs/openchallenges/home/src/lib/challenge-registration/challenge-registration.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-registration/challenge-registration.component.html
@@ -14,12 +14,12 @@
           Add your challenges to the OpenChallenges registry and see the participant numbers roll
           in.
         </p>
-        <p class="mat-caption">(App feature coming soon! For now, Google Sheets :-))</p>
+        <p class="mat-caption">(App feature coming soon! For now, Google Forms :-))</p>
         <br/>
         <a
           mat-raised-button
           class="btn-block"
-          href="https://docs.google.com/spreadsheets/d/1-3LO7h_JJf6rnEBvVJWjDD4FBmHCu-oiBNlxvSSnkwo/edit?usp=sharing"
+          href="https://docs.google.com/forms/d/e/1FAIpQLSdLZ6C5ZIzLZS147bmvNm2eJ3kq_88ecHS7ADjD4KaapGhO8g/viewform"
           target="_blank"
           >Add a Challenge</a
         >

--- a/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.html
@@ -27,7 +27,7 @@
     >Added to the OC on {{ org.createdAt }} and last modified on {{ org.updatedAt }} //
     See something missing or not up-to-date?
     <a
-      href="https://docs.google.com/forms/d/e/1FAIpQLSfQbQl11MG_5TXT7fL07YenRD3MIQYfG2lXrpo3jnh_iA4nsw/viewform?usp=pp_url&entry.1040159972={{org.login}}"
+      href="https://docs.google.com/forms/d/e/1FAIpQLSfQbQl11MG_5TXT7fL07YenRD3MIQYfG2lXrpo3jnh_iA4nsw/viewform?usp=pp_url&entry.414773782={{organization.id}}&entry.1040159972={{organization.login}}"
       target="_blank"
     >Suggest an edit here!</a>
   </span>

--- a/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.html
@@ -22,8 +22,13 @@
       </tr>
     </table>
   </div>
-  <hr>
+  <hr />
   <span class="mat-caption created-updated-dates"
-    >Added to the OC on {{ org.createdAt }} and last modified on {{ org.updatedAt }}
+    >Added to the OC on {{ org.createdAt }} and last modified on {{ org.updatedAt }} //
+    See something missing or not up-to-date?
+    <a
+      href="https://docs.google.com/forms/d/e/1FAIpQLSfQbQl11MG_5TXT7fL07YenRD3MIQYfG2lXrpo3jnh_iA4nsw/viewform?usp=pp_url&entry.1040159972={{org.login}}"
+      target="_blank"
+    >Suggest an edit here!</a>
   </span>
 </main>


### PR DESCRIPTION
Fixes #1855 

## Changelog

* replace link on home page to the "Add New Challenge" google form
* add pre-filled link to the profile page footer for challenges and organizations

## Preview

Profile page update:

<img width="991" alt="Screenshot 2023-07-27 at 1 39 32 AM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/6c35dfb8-3149-4d48-82ed-98409409b2e1">

