### PR TITLE
fix: Set `vm.max_map_count` when starting a new terminal

### DIFF
--- a/dev-env.sh
+++ b/dev-env.sh
@@ -137,4 +137,7 @@ function workspace-initialize-env {
   if [ -f "./tools/configure-hostnames.sh" ]; then
     sudo ./tools/configure-hostnames.sh
   fi
+
+  # Needed to run ES containers (see https://github.com/Sage-Bionetworks/sage-monorepo/issues/1311)
+  sudo sysctl -w vm.max_map_count=262144 1> /dev/null
 }

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -138,6 +138,7 @@ function workspace-initialize-env {
     sudo ./tools/configure-hostnames.sh
   fi
 
-  # Needed to run ES containers (see https://github.com/Sage-Bionetworks/sage-monorepo/issues/1311)
+  # Needed to run ES containers
+  # See https://github.com/Sage-Bionetworks/sage-monorepo/issues/1899
   sudo sysctl -w vm.max_map_count=262144 1> /dev/null
 }


### PR DESCRIPTION
Closes #1899

## Description

This solution seamlessly solves the issue described in #1899 for developers.

## Notes

- The code added via this PR had been previously removed during the upgrade of the dev container to Ubuntu. At the time the command was throwing an error for me. I'm now in the Ubuntu dev container and I can run this command fine.