### PR TITLE
fix: Build selected image instead of all affected projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,17 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
-      - name: Publish the images of the affected projects
+      # - name: Publish the images of the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=publish-and-remove-image --parallel=1"
+
+      - name: Publish the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=publish-and-remove-image --parallel=1"
+            && nx run-many --target=publish-and-remove-image \
+              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+              --parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
@@ -249,10 +256,17 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
-      - name: Build the images of the affected projects
+      # - name: Build the images of the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=build-and-remove-image --parallel=1"
+
+      - name: Build the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build-and-remove-image --parallel=1"
+            && nx run-many --target=build-and-remove-image \
+              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+              --parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer


### PR DESCRIPTION
Temporary fix to the out of storage space issue encountered by the CI workflow when building the Docker images of the affected projects.