### PR TITLE
fix(ui): remove drop shadows from select cards

### DIFF
--- a/libs/openchallenges/about/src/lib/about.component.scss
+++ b/libs/openchallenges/about/src/lib/about.component.scss
@@ -41,7 +41,7 @@ h3,
     min-width: 260px;
     padding: 24px 15px 15px;
     margin: 15px 8px;
-    box-shadow: 1px 5px 18px rgba(0, 0, 0, 0.1);
+    // border: solid 1px rgba(0, 0, 0, 0.5);
     border-radius: 8px;
 
     .card-header {

--- a/libs/openchallenges/ui/src/lib/organization-card/_organization-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/_organization-card-theme.scss
@@ -13,7 +13,7 @@
     box-shadow: 1px 5px 18px 0px rgba(0, 0, 0, 0.24);
   }
   .organization-card-banner {
-    // border: solid 2px mat.get-color-from-palette($primary, 600);
+    border: solid 1px rgba(black, 0.38);
     box-shadow: none !important;
   }
 }

--- a/libs/openchallenges/ui/src/lib/organization-card/_organization-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/_organization-card-theme.scss
@@ -13,7 +13,8 @@
     box-shadow: 1px 5px 18px 0px rgba(0, 0, 0, 0.24);
   }
   .organization-card-banner {
-    box-shadow: 1px 5px 18px 0px #d4d4d4;
+    // border: solid 2px mat.get-color-from-palette($primary, 600);
+    box-shadow: none !important;
   }
 }
 


### PR DESCRIPTION
Fixes #1830 

## Changelog
* remove drop shadow surrounding avatar on organization card
* remove drop shadow from goal card

> **Note**: the drop shadows will remain on the profile pages, e.g.
> ![Screenshot 2023-08-02 at 1 55 37 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/5f060d36-0ac0-47f5-b12e-d658b9f66a3c)

## Preview

**Organization cards**
![Screenshot 2023-08-02 at 1 55 26 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/67d4e14b-c32f-4794-b804-5bcf08505195)

**Goal cards**
![Screenshot 2023-08-02 at 1 57 04 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/dcf77211-0a14-4554-9e9b-48844d8b3272)

### Alternative designs

**Organization cards (blue border)**
![Screenshot 2023-08-02 at 1 54 56 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/022cee0c-c294-41f8-97ce-bdb905ced0c5)

**Organization cards (black border)**
![Screenshot 2023-08-02 at 1 55 11 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/a317bfad-f5dc-4b30-8c14-374f92fc0782)

**Goal cards (border)**
![Screenshot 2023-08-02 at 1 57 40 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/41029669-5f0b-463f-b9df-923232ea6484)