### PR TITLE
feat(UI): Open and reorder challenge filters 

### DIFF
--- a/libs/openchallenges/challenge-search/src/lib/challenge-search-filters.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search-filters.ts
@@ -38,21 +38,21 @@ export const challengeSubmissionTypesFilter: Filter = {
   query: 'submissionTypes',
   label: 'Submission Type',
   values: challengeSubmissionTypesFilterValues,
-  collapsed: true,
+  collapsed: false,
 };
 
 export const challengeIncentivesFilter: Filter = {
   query: 'incentives',
   label: 'Incentive Type',
   values: challengeIncentivesFilterValues,
-  collapsed: true,
+  collapsed: false,
 };
 
 export const challengePlatformsFilter: Filter = {
   query: 'platforms',
   label: 'Platform',
   values: challengePlatformsFilterValues,
-  collapsed: true,
+  collapsed: false,
 };
 
 // dropdown filters
@@ -68,14 +68,14 @@ export const challengeCategoriesFilter: Filter = {
   query: 'categories',
   label: 'Category',
   values: challengeCategoriesFilterValues,
-  collapsed: true,
+  collapsed: false,
 };
 
 export const challengeOrganizationsFilter: Filter = {
   query: 'organizations',
   label: 'Organization',
   values: challengeOrganizationsFilterValues,
-  collapsed: true,
+  collapsed: false,
   showAvatar: true,
 };
 
@@ -83,6 +83,6 @@ export const challengeOrganizatersFilter: Filter = {
   query: 'organizers',
   label: 'Organizer',
   values: challengeOrganizersFilterValues,
-  collapsed: true,
+  collapsed: false,
   showAvatar: true,
 };

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -35,6 +35,19 @@
   <section id="bottom" class="content">
     <div class="facets">
       <p-panel
+        header="{{ statusFilter.label }}"
+        [toggleable]="true"
+        [collapsed]="statusFilter.collapsed"
+      >
+        <openchallenges-checkbox-filter
+          [values]="statusFilter.values"
+          [selectedValues]="selectedStatus"
+          (selectionChange)="onStatusChange($event)"
+          inputId="{{ statusFilter.query }}"
+        ></openchallenges-checkbox-filter>
+      </p-panel>
+      <p-divider></p-divider>
+      <p-panel
         header="Challenge Year"
         [toggleable]="true"
         [collapsed]="startYearRangeFilter.collapsed"
@@ -66,42 +79,19 @@
       </p-panel>
       <p-divider></p-divider>
       <p-panel
-        header="{{ statusFilter.label }}"
+        header="{{ inputDataTypesFilter.label }}"
         [toggleable]="true"
-        [collapsed]="statusFilter.collapsed"
+        [collapsed]="inputDataTypesFilter.collapsed"
       >
-        <openchallenges-checkbox-filter
-          [values]="statusFilter.values"
-          [selectedValues]="selectedStatus"
-          (selectionChange)="onStatusChange($event)"
-          inputId="{{ statusFilter.query }}"
-        ></openchallenges-checkbox-filter>
-      </p-panel>
-      <p-divider></p-divider>
-      <p-panel
-        header="{{ submissionTypesFilter.label }}"
-        [toggleable]="true"
-        [collapsed]="submissionTypesFilter.collapsed"
-      >
-        <openchallenges-checkbox-filter
-          [values]="submissionTypesFilter.values"
-          [selectedValues]="selectedSubmissionTypes"
-          (selectionChange)="onSubmissionTypesChange($event)"
-          inputId="{{ submissionTypesFilter.query }}"
-        ></openchallenges-checkbox-filter>
-      </p-panel>
-      <p-divider></p-divider>
-      <p-panel
-        header="{{ incentivesFilter.label }}"
-        [toggleable]="true"
-        [collapsed]="incentivesFilter.collapsed"
-      >
-        <openchallenges-checkbox-filter
-          [values]="incentivesFilter.values"
-          [selectedValues]="selectedIncentives"
-          (selectionChange)="onIncentivesChange($event)"
-          inputId="{{ incentivesFilter.query }}"
-        ></openchallenges-checkbox-filter>
+        <openchallenges-search-dropdown-filter
+          [values]="inputDataTypesFilter.values"
+          [selectedValues]="selectedInputDataTypes"
+          placeholder="{{ inputDataTypesFilter.label.toLowerCase() + '(s)' }}  "
+          [showAvatar]="inputDataTypesFilter.showAvatar"
+          [filterByApiClient]="true"
+          (selectionChange)="onInputDataTypesChange($event)"
+          (searchChange)="onInputDataTypeSearchChange($event)"
+        ></openchallenges-search-dropdown-filter>
       </p-panel>
       <p-divider></p-divider>
       <p-panel
@@ -121,31 +111,15 @@
       </p-panel>
       <p-divider></p-divider>
       <p-panel
-        header="{{ inputDataTypesFilter.label }}"
+        header="{{ incentivesFilter.label }}"
         [toggleable]="true"
-        [collapsed]="inputDataTypesFilter.collapsed"
-      >
-        <openchallenges-search-dropdown-filter
-          [values]="inputDataTypesFilter.values"
-          [selectedValues]="selectedInputDataTypes"
-          placeholder="{{ inputDataTypesFilter.label.toLowerCase() + '(s)' }}  "
-          [showAvatar]="inputDataTypesFilter.showAvatar"
-          [filterByApiClient]="true"
-          (selectionChange)="onInputDataTypesChange($event)"
-          (searchChange)="onInputDataTypeSearchChange($event)"
-        ></openchallenges-search-dropdown-filter>
-      </p-panel>
-      <p-divider></p-divider>
-      <p-panel
-        header="{{ categoriesFilter.label }}"
-        [toggleable]="true"
-        [collapsed]="categoriesFilter.collapsed"
+        [collapsed]="incentivesFilter.collapsed"
       >
         <openchallenges-checkbox-filter
-          [values]="categoriesFilter.values"
-          [selectedValues]="selectedCategories"
-          (selectionChange)="onCategoriesChange($event)"
-          inputId="{{ categoriesFilter.query }}"
+          [values]="incentivesFilter.values"
+          [selectedValues]="selectedIncentives"
+          (selectionChange)="onIncentivesChange($event)"
+          inputId="{{ incentivesFilter.query }}"
         ></openchallenges-checkbox-filter>
       </p-panel>
       <p-divider></p-divider>
@@ -163,6 +137,32 @@
           (selectionChange)="onOrganizationsChange($event)"
           (searchChange)="onOrganizationSearchChange($event)"
         ></openchallenges-search-dropdown-filter>
+      </p-panel>
+      <p-divider></p-divider>
+      <p-panel
+        header="{{ submissionTypesFilter.label }}"
+        [toggleable]="true"
+        [collapsed]="submissionTypesFilter.collapsed"
+      >
+        <openchallenges-checkbox-filter
+          [values]="submissionTypesFilter.values"
+          [selectedValues]="selectedSubmissionTypes"
+          (selectionChange)="onSubmissionTypesChange($event)"
+          inputId="{{ submissionTypesFilter.query }}"
+        ></openchallenges-checkbox-filter>
+      </p-panel>
+      <p-divider></p-divider>
+      <p-panel
+        header="{{ categoriesFilter.label }}"
+        [toggleable]="true"
+        [collapsed]="categoriesFilter.collapsed"
+      >
+        <openchallenges-checkbox-filter
+          [values]="categoriesFilter.values"
+          [selectedValues]="selectedCategories"
+          (selectionChange)="onCategoriesChange($event)"
+          inputId="{{ categoriesFilter.query }}"
+        ></openchallenges-checkbox-filter>
       </p-panel>
     </div>
     <div class="main col">


### PR DESCRIPTION
- closes #1831

## Changelog
- expand all challenge filters initially 
- reorder challenge filters: 
  1. Status (I see it as the most frequently used filters for universal users)
  2. Challenge Year (useful for exploring purpose)
  3. Input Data Type (one of the most interested filters)
  4. Platform (useful for organizers, as well as the users come from/attracted by specific platforms) 
  5. Incentive Type (I see it'll be used often since reward is always attractive initially for users)
  6. Organization (likely, only organizers or people come with organization names will use)
  7. Submission Type (I don't see it will be used frequently for users)
  8. Category (move to the last since it now only has one option)

## Preview
<img width="1023" alt="Screen Shot 2023-08-02 at 6 32 34 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/6cf221fb-9b79-4694-bf1d-13e887149392">
