### PR TITLE
fix: Remove the About button from the navbar

### DIFF
--- a/apps/openchallenges/app/src/app/app-sections.ts
+++ b/apps/openchallenges/app/src/app/app-sections.ts
@@ -1,10 +1,6 @@
 import { NavbarSection } from '@sagebionetworks/openchallenges/ui';
 
 export const APP_SECTIONS: { [key: string]: NavbarSection } = {
-  about: {
-    name: 'About',
-    summary: 'About OpenChallenges',
-  },
   challenge: {
     name: 'Challenges',
     summary: 'Explore challenges',


### PR DESCRIPTION
Closes #1864

## Description

Remove the About button from the navbar to simplify the flow. Visitor will now land on the page and not hesitate between reading the home page and clicking on About (another "issue" was that About was listed first in the navbar).

The About page is still accessible from a link in the footer.