### PR TITLE
feat: Specify the data version in the OC footer

### DIFF
--- a/apps/openchallenges/app/.env.example
+++ b/apps/openchallenges/app/.env.example
@@ -1,3 +1,4 @@
-API_URL=http://localhost:8082/api/v1
-APP_VERSION=1.2.3
-ENVIRONMENT=prod
+API_URL="http://localhost:8082/api/v1"
+APP_VERSION="1.0.0-alpha"
+DATA_UPDATED_ON="2023-08-03"
+ENVIRONMENT="prod"

--- a/apps/openchallenges/app/src/config/config.json
+++ b/apps/openchallenges/app/src/config/config.json
@@ -1,6 +1,7 @@
 {
   "environment": "dev",
   "apiUrl": "http://localhost:8082/api/v1",
-  "appVersion": "0.0.1",
+  "appVersion": "1.0.0-alpha",
+  "dataUpdatedOn": "2023-08-04",
   "keycloakRealm": "test"
 }

--- a/apps/openchallenges/app/src/config/config.json.template
+++ b/apps/openchallenges/app/src/config/config.json.template
@@ -2,5 +2,6 @@
   "environment": "${ENVIRONMENT}",
   "apiUrl": "${API_URL}",
   "appVersion": "${APP_VERSION}",
+  "dataUpdatedOn": "${DATA_UPDATED_ON}",
   "keycloakRealm": "${KEYCLOAK_REALM}"
 }

--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -122,4 +122,7 @@
     </div>
   </section>
 </main>
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/about/src/lib/about.component.ts
+++ b/libs/openchallenges/about/src/lib/about.component.ts
@@ -12,8 +12,10 @@ import { FooterComponent } from '@sagebionetworks/openchallenges/ui';
 })
 export class AboutComponent {
   public appVersion: string;
+  public dataUpdatedOn: string;
 
   constructor(private readonly configService: ConfigService) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 }

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -182,4 +182,7 @@
   </section>
 </main>
 
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -78,6 +78,7 @@ export class ChallengeSearchComponent
   implements OnInit, AfterContentInit, OnDestroy
 {
   public appVersion: string;
+  public dataUpdatedOn: string;
   datePipe: DatePipe = new DatePipe('en-US');
 
   private query: BehaviorSubject<ChallengeSearchQuery> =
@@ -158,6 +159,7 @@ export class ChallengeSearchComponent
     private _snackBar: MatSnackBar
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit() {

--- a/libs/openchallenges/challenge/src/lib/challenge.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.html
@@ -87,4 +87,7 @@
     </section>
   </ng-container>
 </main>
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/challenge/src/lib/challenge.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.ts
@@ -29,6 +29,7 @@ import {
 })
 export class ChallengeComponent implements OnInit {
   public appVersion: string;
+  public dataUpdatedOn: string;
   challenge$!: Observable<Challenge>;
   loggedIn = false;
   // progressValue = 0;
@@ -46,6 +47,7 @@ export class ChallengeComponent implements OnInit {
     private readonly configService: ConfigService
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit(): void {

--- a/libs/openchallenges/config/src/lib/app.config.ts
+++ b/libs/openchallenges/config/src/lib/app.config.ts
@@ -12,6 +12,7 @@ export interface AppConfig {
   environment: Environment;
   apiUrl: string;
   appVersion: string;
+  dataUpdatedOn: string;
   keycloakRealm: string;
   isPlatformServer: boolean;
   privacyPolicyUrl: string;

--- a/libs/openchallenges/config/src/lib/mock-app.config.ts
+++ b/libs/openchallenges/config/src/lib/mock-app.config.ts
@@ -4,6 +4,7 @@ export const MOCK_APP_CONFIG: AppConfig = {
   environment: Environment.Test,
   apiUrl: 'http://localhost:4200/api',
   appVersion: '0.0.1',
+  dataUpdatedOn: '2023-08-04',
   keycloakRealm: 'test',
   isPlatformServer: false,
   privacyPolicyUrl: '',

--- a/libs/openchallenges/home/src/lib/home.component.html
+++ b/libs/openchallenges/home/src/lib/home.component.html
@@ -12,4 +12,7 @@
   <openchallenges-sponsor-list *sageAppShellNoRender></openchallenges-sponsor-list>
 </main>
 
-<openchallenges-footer [version]="appVersion" *sageAppShellNoRender></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/home/src/lib/home.component.ts
+++ b/libs/openchallenges/home/src/lib/home.component.ts
@@ -8,8 +8,10 @@ import { ConfigService } from '@sagebionetworks/openchallenges/config';
 })
 export class HomeComponent {
   public appVersion: string;
+  public dataUpdatedOn: string;
 
   constructor(private readonly configService: ConfigService) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 }

--- a/libs/openchallenges/login/src/lib/login.component.ts
+++ b/libs/openchallenges/login/src/lib/login.component.ts
@@ -19,6 +19,7 @@ import { BasicError as ApiClientError } from '@sagebionetworks/openchallenges/ap
 })
 export class LoginComponent implements OnInit, OnDestroy {
   public appVersion: string;
+  public dataUpdatedOn: string;
 
   loginForm!: UntypedFormGroup;
   errors = {
@@ -35,6 +36,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     private readonly configService: ConfigService
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit(): void {

--- a/libs/openchallenges/not-found/src/lib/not-found.component.html
+++ b/libs/openchallenges/not-found/src/lib/not-found.component.html
@@ -6,8 +6,16 @@
   </div>
   <div class="btn-group">
     <a mat-raised-button class="home-btn" href="/home">Home</a>
-    <a mat-raised-button color="basic" href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose">Contact Us</a>
+    <a
+      mat-raised-button
+      color="basic"
+      href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose"
+      >Contact Us</a
+    >
   </div>
 </main>
 
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/not-found/src/lib/not-found.component.ts
+++ b/libs/openchallenges/not-found/src/lib/not-found.component.ts
@@ -8,8 +8,10 @@ import { ConfigService } from '@sagebionetworks/openchallenges/config';
 })
 export class NotFoundComponent {
   public appVersion: string;
+  public dataUpdatedOn: string;
 
   constructor(private readonly configService: ConfigService) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 }

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.html
@@ -69,4 +69,7 @@
     </section>
   </ng-container>
 </main>
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
@@ -37,6 +37,7 @@ import {
 })
 export class OrgProfileComponent implements OnInit {
   public appVersion: string;
+  public dataUpdatedOn: string;
   account$!: Observable<Account | undefined>;
   organization$!: Observable<Organization>;
   organizationAvatar$!: Observable<Avatar>;
@@ -55,6 +56,7 @@ export class OrgProfileComponent implements OnInit {
     private imageService: ImageService
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit(): void {

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -79,4 +79,7 @@
   </section>
 </main>
 
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/org-search/src/lib/org-search.component.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.ts
@@ -51,6 +51,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 })
 export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
   public appVersion: string;
+  public dataUpdatedOn: string;
 
   private query: BehaviorSubject<OrganizationSearchQuery> =
     new BehaviorSubject<OrganizationSearchQuery>({});
@@ -96,6 +97,7 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
     private _snackBar: MatSnackBar
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit() {

--- a/libs/openchallenges/signup/src/lib/signup.component.ts
+++ b/libs/openchallenges/signup/src/lib/signup.component.ts
@@ -21,6 +21,7 @@ import { isApiClientError } from '@sagebionetworks/openchallenges/util';
 })
 export class SignupComponent implements OnInit {
   public appVersion: string;
+  public dataUpdatedOn: string;
 
   newUserForm!: UntypedFormGroup;
   errors = {
@@ -37,6 +38,7 @@ export class SignupComponent implements OnInit {
     private readonly configService: ConfigService
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit(): void {

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -45,4 +45,7 @@
     </div>
   </div>
 </main>
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/team/src/lib/team.component.ts
+++ b/libs/openchallenges/team/src/lib/team.component.ts
@@ -13,6 +13,7 @@ import { Observable } from 'rxjs';
 })
 export class TeamComponent implements OnInit {
   public appVersion: string;
+  public dataUpdatedOn: string;
   public logo$: Observable<Image> | undefined;
   public thomas$: Observable<Image> | undefined;
   public rong$: Observable<Image> | undefined;
@@ -26,6 +27,7 @@ export class TeamComponent implements OnInit {
     private imageService: ImageService
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit() {

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -21,7 +21,8 @@
     </div>
     <div class="col-4 app-info">
       <ul>
-        <li>Current version: 1.0.0-beta</li>
+        <li>App version: {{ appVersion }}</li>
+        <li>Data updated on: {{ dataUpdatedOn }}</li>
         <li>Code licensed under Apache License 2.0</li>
         <li>Documentation licensed under CC-BY 4.0</li>
       </ul>

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.ts
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ConfigService } from '@sagebionetworks/openchallenges/config';
 
 @Component({
   selector: 'openchallenges-footer',
@@ -10,12 +9,8 @@ import { ConfigService } from '@sagebionetworks/openchallenges/config';
   styleUrls: ['./footer.component.scss'],
 })
 export class FooterComponent {
-  @Input() version = 'x.y.z';
-  privacyPolicyUrl: string;
-  termsOfUseUrl: string;
-
-  constructor(private readonly configService: ConfigService) {
-    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
-    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
-  }
+  @Input() appVersion = '';
+  @Input() dataUpdatedOn = '';
+  @Input() privacyPolicyUrl = '';
+  @Input() termsOfUseUrl = '';
 }

--- a/libs/openchallenges/user-profile/src/lib/user-profile.component.html
+++ b/libs/openchallenges/user-profile/src/lib/user-profile.component.html
@@ -20,7 +20,7 @@
     <div class="profile-sidenav col">
       <div class="profile-nav-group">
         <a
-        class="profile-nav-item"
+          class="profile-nav-item"
           routerLink="."
           [queryParams]="{ tab: 'overview' }"
           [ngClass]="{ 'active-tab': activeTab === tabs['overview'] }"
@@ -28,7 +28,7 @@
           Biography
         </a>
         <a
-        class="profile-nav-item"
+          class="profile-nav-item"
           routerLink="."
           [queryParams]="{ tab: 'challenges' }"
           [ngClass]="{ 'active-tab': activeTab === tabs['challenges'] }"
@@ -36,7 +36,7 @@
           Challenges
         </a>
         <a
-        class="profile-nav-item"
+          class="profile-nav-item"
           routerLink="."
           [queryParams]="{ tab: 'starred' }"
           [ngClass]="{ 'active-tab': activeTab === tabs['starred'] }"
@@ -62,4 +62,7 @@
   </section>
 </main>
 
-<openchallenges-footer [version]="appVersion"></openchallenges-footer>
+<openchallenges-footer
+  [appVersion]="appVersion"
+  [dataUpdatedOn]="dataUpdatedOn"
+></openchallenges-footer>

--- a/libs/openchallenges/user-profile/src/lib/user-profile.component.ts
+++ b/libs/openchallenges/user-profile/src/lib/user-profile.component.ts
@@ -36,6 +36,7 @@ import { getUserProfileSeoData } from './user-profile-seo';
 })
 export class UserProfileComponent implements OnInit {
   public appVersion: string;
+  public dataUpdatedOn: string;
   account$!: Observable<Account | undefined>;
   user$: Observable<User> = of(MOCK_USER);
   loggedIn = true;
@@ -57,6 +58,7 @@ export class UserProfileComponent implements OnInit {
     private renderer2: Renderer2
   ) {
     this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Closes #1794

## Description

Add the property `Data updated on` to the OC footer.

## Notes

- This PR adds the property `DATA_UPDATED_ON` to the `.env` of the project `openchallenges-app` (see `.env.example` updated by this PR)

## Preview

<img width="1438" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/53072fd5-13a4-4cf5-b951-15c0c788b945">
