### PR TITLE
feat(ui): Make width of challenge and org cards consistent

### DIFF
--- a/libs/openchallenges/org-profile/src/lib/org-profile-challenges/org-profile-challenges.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-challenges/org-profile-challenges.component.html
@@ -1,5 +1,5 @@
 <main>
-  <div id="challenges" class="row col">
+  <div id="challenges">
     <h3>Challenges</h3>
     <div class="card-group">
       <openchallenges-challenge-card *ngFor="let challenge of challenges" [challenge]="challenge">

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -246,7 +246,7 @@ table {
 // CARDS
 .card-group {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 24px;
   padding: 16px 0;
 }

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
@@ -1,8 +1,8 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .organization-card {
-  width: 300px;
-  min-height: 160px;
+  width: 320px;
+  min-height: 180px;
   padding: 12px;
   display: flex;
   position: relative;

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.spec.ts
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.spec.ts
@@ -39,7 +39,7 @@ describe('OrganizationCardComponent', () => {
     expect(component.organizationAvatar).toEqual({
       name: MOCK_ORGANIZATION_CARDS[0].name,
       src: MOCK_ORGANIZATION_CARDS[0].avatarUrl,
-      size: 140,
+      size: 160,
     });
   });
 
@@ -49,7 +49,7 @@ describe('OrganizationCardComponent', () => {
     expect(component.organizationAvatar).toEqual({
       name: MOCK_ORGANIZATION_CARDS[0].name,
       src: undefined,
-      size: 140,
+      size: 160,
     });
   });
 
@@ -59,7 +59,7 @@ describe('OrganizationCardComponent', () => {
   //   expect(component.organizationAvatar).toEqual({
   //     name: MOCK_ORGANIZATIONS[0].login.replace(/-/g, ' '),
   //     src: '',
-  //     size: 140,
+  //     size: 160,
   //   });
   // });
 });

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.ts
@@ -24,7 +24,7 @@ export class OrganizationCardComponent implements OnInit {
       this.organizationAvatar = {
         name: this.organizationCard.name,
         src: this.organizationCard.avatarUrl,
-        size: 140,
+        size: 160,
       };
     }
 

--- a/libs/openchallenges/user-profile/src/lib/user-profile-challenges/user-profile-challenges.component.html
+++ b/libs/openchallenges/user-profile/src/lib/user-profile-challenges/user-profile-challenges.component.html
@@ -1,5 +1,5 @@
 <main>
-  <div id="challenges" class="row col">
+  <div id="challenges">
     <h3>Challenges</h3>
     <div class="card-group">
       <openchallenges-challenge-card *ngFor="let challenge of challenges" [challenge]="challenge">


### PR DESCRIPTION
- closes #1917 

## Changelog
- Scale up org card a bit to make its width consistent with challenge card's

## Preview

- search bar is not removed - here just for demoing the width between two types of cards
- star button is removed from the latest version in `main`
 
 <img width="566" alt="Screen Shot 2023-08-03 at 3 29 51 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/19ee494a-974a-4701-985c-9736c195402d">
