### PR TITLE
fix: Use default avatar if image service is down

### DIFF
--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -321,7 +321,7 @@ export class ChallengeSearchComponent
             avatarUrls: forkJoinConcurrent(
               orgs.map((org) => this.getOrganizationAvatarUrl(org)),
               Infinity
-            ) as unknown as Observable<(Image | undefined)[]>,
+            ),
           })
         )
       )
@@ -539,17 +539,20 @@ export class ChallengeSearchComponent
     });
   }
 
-  private getOrganizationAvatarUrl(
-    org: Organization
-  ): Observable<Image | undefined> {
-    if (org.avatarKey && org.avatarKey.length > 0) {
-      return this.imageService.getImage({
+  private getOrganizationAvatarUrl(org: Organization): Observable<Image> {
+    return this.imageService
+      .getImage({
         objectKey: org.avatarKey,
-        height: ImageHeight._32px,
+        height: ImageHeight._140px,
         aspectRatio: ImageAspectRatio._11,
-      } as ImageQuery);
-    } else {
-      return of(undefined);
-    }
+      } as ImageQuery)
+      .pipe(
+        catchError(() => {
+          console.error(
+            'Unable to get the image url. Please check the logs of image service'
+          );
+          return of({ url: '' });
+        })
+      );
   }
 }

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -543,7 +543,7 @@ export class ChallengeSearchComponent
     return this.imageService
       .getImage({
         objectKey: org.avatarKey,
-        height: ImageHeight._140px,
+        height: ImageHeight._32px,
         aspectRatio: ImageAspectRatio._11,
       } as ImageQuery)
       .pipe(

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -549,7 +549,7 @@ export class ChallengeSearchComponent
       .pipe(
         catchError(() => {
           console.error(
-            'Unable to get the image url. Please check the logs of image service'
+            'Unable to get the image url. Please check the logs of the image service.'
           );
           return of({ url: '' });
         })

--- a/libs/openchallenges/challenge/src/lib/challenge-contributors/challenge-contributors.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge-contributors/challenge-contributors.component.ts
@@ -12,7 +12,7 @@ import {
 } from '@sagebionetworks/openchallenges/api-client-angular';
 import { OrganizationCard } from '@sagebionetworks/openchallenges/ui';
 import { forkJoinConcurrent } from '@sagebionetworks/openchallenges/util';
-import { Observable, forkJoin, map, of, switchMap } from 'rxjs';
+import { Observable, catchError, forkJoin, map, of, switchMap } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-challenge-contributors',
@@ -49,7 +49,7 @@ export class ChallengeContributorsComponent implements OnInit {
             avatarUrls: forkJoinConcurrent(
               orgs.map((org) => this.getOrganizationAvatarUrl(org)),
               Infinity
-            ) as unknown as Observable<(Image | undefined)[]>,
+            ),
           })
         ),
         switchMap(({ orgs, avatarUrls }) =>
@@ -67,24 +67,27 @@ export class ChallengeContributorsComponent implements OnInit {
   }
 
   // TODO Avoid duplicated code (see org search component)
-  private getOrganizationAvatarUrl(
-    org: Organization
-  ): Observable<Image | undefined> {
-    if (org.avatarKey && org.avatarKey.length > 0) {
-      return this.imageService.getImage({
+  private getOrganizationAvatarUrl(org: Organization): Observable<Image> {
+    return this.imageService
+      .getImage({
         objectKey: org.avatarKey,
         height: ImageHeight._140px,
         aspectRatio: ImageAspectRatio._11,
-      } as ImageQuery);
-    } else {
-      return of(undefined);
-    }
+      } as ImageQuery)
+      .pipe(
+        catchError(() => {
+          console.error(
+            'Unable to get the image url. Please check the logs of image service'
+          );
+          return of({ url: '' });
+        })
+      );
   }
 
   // TODO Avoid duplicated code (see org search component)
   private getOrganizationCard(
     org: Organization,
-    avatarUrl: Image | undefined
+    avatarUrl: Image
   ): OrganizationCard {
     return {
       acronym: org.acronym,

--- a/libs/openchallenges/challenge/src/lib/challenge-contributors/challenge-contributors.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge-contributors/challenge-contributors.component.ts
@@ -77,7 +77,7 @@ export class ChallengeContributorsComponent implements OnInit {
       .pipe(
         catchError(() => {
           console.error(
-            'Unable to get the image url. Please check the logs of image service'
+            'Unable to get the image url. Please check the logs of the image service.'
           );
           return of({ url: '' });
         })

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
@@ -74,7 +74,7 @@ export class ChallengeHostListComponent implements OnInit {
       .pipe(
         catchError(() => {
           console.error(
-            'Unable to get the image url. Please check the logs of image service'
+            'Unable to get the image url. Please check the logs of the image service.'
           );
           return of({ url: '' });
         })

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
@@ -50,7 +50,7 @@ export class ChallengeHostListComponent implements OnInit {
           avatarUrls: forkJoinConcurrent(
             orgs.map((org) => this.getOrganizationAvatarUrl(org)),
             Infinity
-          ) as unknown as Observable<(Image | undefined)[]>,
+          ),
         })
       ),
       switchMap(({ orgs, avatarUrls }) =>
@@ -64,24 +64,27 @@ export class ChallengeHostListComponent implements OnInit {
   }
 
   // TODO Avoid duplicated code (see org search component)
-  private getOrganizationAvatarUrl(
-    org: Organization
-  ): Observable<Image | undefined> {
-    if (org.avatarKey && org.avatarKey.length > 0) {
-      return this.imageService.getImage({
+  private getOrganizationAvatarUrl(org: Organization): Observable<Image> {
+    return this.imageService
+      .getImage({
         objectKey: org.avatarKey,
         height: ImageHeight._140px,
         aspectRatio: ImageAspectRatio._11,
-      } as ImageQuery);
-    } else {
-      return of(undefined);
-    }
+      } as ImageQuery)
+      .pipe(
+        catchError(() => {
+          console.error(
+            'Unable to get the image url. Please check the logs of image service'
+          );
+          return of({ url: '' });
+        })
+      );
   }
 
   // TODO Avoid duplicated code (see org search component)
   private getOrganizationCard(
     org: Organization,
-    avatarUrl: Image | undefined
+    avatarUrl: Image
   ): OrganizationCard {
     return {
       acronym: org.acronym,

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
@@ -106,7 +106,7 @@ export class OrgProfileComponent implements OnInit {
     return this.imageService
       .getImage({
         objectKey: org.avatarKey,
-        height: ImageHeight._140px,
+        height: ImageHeight._250px,
         aspectRatio: ImageAspectRatio._11,
       } as ImageQuery)
       .pipe(

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
@@ -112,7 +112,7 @@ export class OrgProfileComponent implements OnInit {
       .pipe(
         catchError(() => {
           console.error(
-            'Unable to get the image url. Please check the logs of image service'
+            'Unable to get the image url. Please check the logs of the image service.'
           );
           return of({ url: '' });
         })

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
@@ -102,17 +102,20 @@ export class OrgProfileComponent implements OnInit {
     this.subscriptions.push(activeTabSub);
   }
 
-  private getOrganizationAvatarUrl(
-    org: Organization
-  ): Observable<Image | undefined> {
-    if (org.avatarKey && org.avatarKey.length > 0) {
-      return this.imageService.getImage({
+  private getOrganizationAvatarUrl(org: Organization): Observable<Image> {
+    return this.imageService
+      .getImage({
         objectKey: org.avatarKey,
-        height: ImageHeight._250px,
+        height: ImageHeight._140px,
         aspectRatio: ImageAspectRatio._11,
-      } as ImageQuery);
-    } else {
-      return of(undefined);
-    }
+      } as ImageQuery)
+      .pipe(
+        catchError(() => {
+          console.error(
+            'Unable to get the image url. Please check the logs of image service'
+          );
+          return of({ url: '' });
+        })
+      );
   }
 }

--- a/libs/openchallenges/org-search/src/lib/org-search.component.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.ts
@@ -166,16 +166,16 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
           avatarUrls: forkJoinConcurrent(
             orgs.map((org) => this.getOrganizationAvatarUrl(org)),
             Infinity
-          ) as unknown as Observable<(Image | undefined)[]>,
+          ),
         })
       ),
-      switchMap(({ orgs, avatarUrls }) =>
-        of(
+      switchMap(({ orgs, avatarUrls }) => {
+        return of(
           orgs.map((org, index) =>
             this.getOrganizationCard(org, avatarUrls[index])
           )
-        )
-      )
+        );
+      })
     );
 
     orgPage$.subscribe((page) => {
@@ -250,23 +250,26 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
     });
   }
 
-  private getOrganizationAvatarUrl(
-    org: Organization
-  ): Observable<Image | undefined> {
-    if (org.avatarKey && org.avatarKey.length > 0) {
-      return this.imageService.getImage({
+  private getOrganizationAvatarUrl(org: Organization): Observable<Image> {
+    return this.imageService
+      .getImage({
         objectKey: org.avatarKey,
         height: ImageHeight._140px,
         aspectRatio: ImageAspectRatio._11,
-      } as ImageQuery);
-    } else {
-      return of(undefined);
-    }
+      } as ImageQuery)
+      .pipe(
+        catchError(() => {
+          console.error(
+            'Unable to get the image url. Please check the logs of image service'
+          );
+          return of({ url: '' });
+        })
+      );
   }
 
   private getOrganizationCard(
     org: Organization,
-    avatarUrl: Image | undefined
+    avatarUrl: Image
   ): OrganizationCard {
     return {
       acronym: org.acronym,

--- a/libs/openchallenges/org-search/src/lib/org-search.component.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.ts
@@ -169,13 +169,13 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
           ),
         })
       ),
-      switchMap(({ orgs, avatarUrls }) => {
-        return of(
+      switchMap(({ orgs, avatarUrls }) =>
+        of(
           orgs.map((org, index) =>
             this.getOrganizationCard(org, avatarUrls[index])
           )
-        );
-      })
+        )
+      )
     );
 
     orgPage$.subscribe((page) => {


### PR DESCRIPTION
- fixes #1659 

When the image url is not successfully retrieved from image service, the organization card is not loaded at all. To avoid this behavior, this pr is to return default empty string as avatarUrl if the image service is failed.

## Preview

<img width="1005" alt="Screen Shot 2023-08-03 at 5 54 14 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/e7f1f99b-33c6-41bd-97b5-e9692bc1fde7">
