### PR TITLE
feat: Add ACM certificate for OC prod DNS

### DIFF
--- a/apps/openchallenges/infra/src/cnb-dev-stack.ts
+++ b/apps/openchallenges/infra/src/cnb-dev-stack.ts
@@ -33,8 +33,8 @@ export class CnbDevStack extends SageStack {
     new TerraformOutput(this, 'dev_zone_id', {
       value: dns.devZone.id,
     });
-    new TerraformOutput(this, 'cert_arn', {
-      value: dns.cert.arn,
+    new TerraformOutput(this, 'openchallenges_cert_arn', {
+      value: dns.openchallengesCert.arn,
     });
   }
 }

--- a/apps/openchallenges/infra/src/cnb-dev-stack.ts
+++ b/apps/openchallenges/infra/src/cnb-dev-stack.ts
@@ -33,8 +33,11 @@ export class CnbDevStack extends SageStack {
     new TerraformOutput(this, 'dev_zone_id', {
       value: dns.devZone.id,
     });
-    new TerraformOutput(this, 'cert_arn', {
-      value: dns.cert.arn,
+    new TerraformOutput(this, 'openchallenge_dev_cert_arn', {
+      value: dns.openchallengesDevCert.arn,
+    });
+    new TerraformOutput(this, 'openchallenge_prod_cert_arn', {
+      value: dns.openchallengesProdCert.arn,
     });
   }
 }

--- a/apps/openchallenges/infra/src/cnb-dev-stack.ts
+++ b/apps/openchallenges/infra/src/cnb-dev-stack.ts
@@ -33,7 +33,7 @@ export class CnbDevStack extends SageStack {
     new TerraformOutput(this, 'dev_zone_id', {
       value: dns.devZone.id,
     });
-    new TerraformOutput(this, 'openchallenges_cert_arn', {
+    new TerraformOutput(this, 'cert_arn', {
       value: dns.cert.arn,
     });
   }

--- a/apps/openchallenges/infra/src/cnb-dev-stack.ts
+++ b/apps/openchallenges/infra/src/cnb-dev-stack.ts
@@ -33,11 +33,8 @@ export class CnbDevStack extends SageStack {
     new TerraformOutput(this, 'dev_zone_id', {
       value: dns.devZone.id,
     });
-    new TerraformOutput(this, 'openchallenges_dev_cert_arn', {
-      value: dns.openchallengesDevCert.arn,
-    });
-    new TerraformOutput(this, 'openchallenges_prod_cert_arn', {
-      value: dns.openchallengesProdCert.arn,
+    new TerraformOutput(this, 'openchallenges_cert_arn', {
+      value: dns.openchallengesCert.arn,
     });
   }
 }

--- a/apps/openchallenges/infra/src/cnb-dev-stack.ts
+++ b/apps/openchallenges/infra/src/cnb-dev-stack.ts
@@ -34,7 +34,7 @@ export class CnbDevStack extends SageStack {
       value: dns.devZone.id,
     });
     new TerraformOutput(this, 'openchallenges_cert_arn', {
-      value: dns.openchallengesCert.arn,
+      value: dns.cert.arn,
     });
   }
 }

--- a/apps/openchallenges/infra/src/cnb-dev-stack.ts
+++ b/apps/openchallenges/infra/src/cnb-dev-stack.ts
@@ -33,10 +33,10 @@ export class CnbDevStack extends SageStack {
     new TerraformOutput(this, 'dev_zone_id', {
       value: dns.devZone.id,
     });
-    new TerraformOutput(this, 'openchallenge_dev_cert_arn', {
+    new TerraformOutput(this, 'openchallenges_dev_cert_arn', {
       value: dns.openchallengesDevCert.arn,
     });
-    new TerraformOutput(this, 'openchallenge_prod_cert_arn', {
+    new TerraformOutput(this, 'openchallenges_prod_cert_arn', {
       value: dns.openchallengesProdCert.arn,
     });
   }

--- a/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
+++ b/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
@@ -4,7 +4,8 @@ import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
 
 export class CnbDevDns extends Construct {
   devZone: Route53Zone;
-  cert: AcmCertificate;
+  openchallengesDevCert: AcmCertificate;
+  openchallengesProdCert: AcmCertificate;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -18,21 +19,47 @@ export class CnbDevDns extends Construct {
       },
     });
 
-    this.cert = new AcmCertificate(this, 'openchallenges_cert', {
-      domainName: 'dev.openchallenges.io',
-      validationMethod: 'DNS',
-      validationOption: [
-        {
-          domainName: 'dev.openchallenges.io',
-          validationDomain: 'openchallenges.io',
+    this.openchallengesDevCert = new AcmCertificate(
+      this,
+      'openchallenges_dev_cert',
+      {
+        domainName: 'dev.openchallenges.io',
+        validationMethod: 'DNS',
+        validationOption: [
+          {
+            domainName: 'dev.openchallenges.io',
+            validationDomain: 'openchallenges.io',
+          },
+        ],
+        lifecycle: {
+          createBeforeDestroy: true,
         },
-      ],
-      lifecycle: {
-        createBeforeDestroy: true,
-      },
-      tags: {
-        Name: `${nameTagPrefix}-openchallenges-cert`,
-      },
-    });
+        tags: {
+          Name: `${nameTagPrefix}-openchallenges-dev-cert`,
+        },
+      }
+    );
+
+    this.openchallengesProdCert = new AcmCertificate(
+      this,
+      'openchallenges_prod_cert',
+      {
+        domainName: 'openchallenges.io',
+        subjectAlternativeNames: ['*.openchallenges.io'],
+        validationMethod: 'DNS',
+        validationOption: [
+          {
+            domainName: 'openchallenges.io',
+            validationDomain: 'openchallenges.io',
+          },
+        ],
+        lifecycle: {
+          createBeforeDestroy: true,
+        },
+        tags: {
+          Name: `${nameTagPrefix}-openchallenges-prod-cert`,
+        },
+      }
+    );
   }
 }

--- a/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
+++ b/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
@@ -4,8 +4,7 @@ import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
 
 export class CnbDevDns extends Construct {
   devZone: Route53Zone;
-  openchallengesDevCert: AcmCertificate;
-  openchallengesProdCert: AcmCertificate;
+  openchallengesCert: AcmCertificate;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -19,47 +18,22 @@ export class CnbDevDns extends Construct {
       },
     });
 
-    this.openchallengesDevCert = new AcmCertificate(
-      this,
-      'openchallenges_dev_cert',
-      {
-        domainName: 'dev.openchallenges.io',
-        validationMethod: 'DNS',
-        validationOption: [
-          {
-            domainName: 'dev.openchallenges.io',
-            validationDomain: 'openchallenges.io',
-          },
-        ],
-        lifecycle: {
-          createBeforeDestroy: true,
+    this.openchallengesCert = new AcmCertificate(this, 'openchallenges_cert', {
+      domainName: 'openchallenges.io',
+      subjectAlternativeNames: ['*.openchallenges.io'],
+      validationMethod: 'DNS',
+      validationOption: [
+        {
+          domainName: 'openchallenges.io',
+          validationDomain: 'openchallenges.io',
         },
-        tags: {
-          Name: `${nameTagPrefix}-openchallenges-dev-cert`,
-        },
-      }
-    );
-
-    this.openchallengesProdCert = new AcmCertificate(
-      this,
-      'openchallenges_prod_cert',
-      {
-        domainName: 'openchallenges.io',
-        subjectAlternativeNames: ['*.openchallenges.io'],
-        validationMethod: 'DNS',
-        validationOption: [
-          {
-            domainName: 'openchallenges.io',
-            validationDomain: 'openchallenges.io',
-          },
-        ],
-        lifecycle: {
-          createBeforeDestroy: true,
-        },
-        tags: {
-          Name: `${nameTagPrefix}-openchallenges-prod-cert`,
-        },
-      }
-    );
+      ],
+      lifecycle: {
+        createBeforeDestroy: true,
+      },
+      tags: {
+        Name: `${nameTagPrefix}-openchallenges-cert`,
+      },
+    });
   }
 }

--- a/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
+++ b/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
@@ -4,7 +4,7 @@ import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
 
 export class CnbDevDns extends Construct {
   devZone: Route53Zone;
-  cert: AcmCertificate;
+  openchallengesCert: AcmCertificate;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -18,17 +18,19 @@ export class CnbDevDns extends Construct {
       },
     });
 
-    this.cert = new AcmCertificate(this, 'openchallenges_cert', {
-      domainName: 'dev.openchallenges.io',
+    this.openchallengesCert = new AcmCertificate(this, 'openchallenges_cert', {
+      domainName: 'openchallenges.io',
+      subjectAlternativeNames: ['*.openchallenges.io'],
       validationMethod: 'DNS',
       validationOption: [
         {
-          domainName: 'dev.openchallenges.io',
+          domainName: 'openchallenges.io',
           validationDomain: 'openchallenges.io',
         },
       ],
       lifecycle: {
-        createBeforeDestroy: true,
+        // createBeforeDestroy: true,
+        preventDestroy: true,
       },
       tags: {
         Name: `${nameTagPrefix}-openchallenges-cert`,

--- a/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
+++ b/apps/openchallenges/infra/src/dns/cnb-dev-dns.ts
@@ -4,7 +4,7 @@ import { AcmCertificate } from '@cdktf/provider-aws/lib/acm-certificate';
 
 export class CnbDevDns extends Construct {
   devZone: Route53Zone;
-  openchallengesCert: AcmCertificate;
+  cert: AcmCertificate;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -18,13 +18,12 @@ export class CnbDevDns extends Construct {
       },
     });
 
-    this.openchallengesCert = new AcmCertificate(this, 'openchallenges_cert', {
-      domainName: 'openchallenges.io',
-      subjectAlternativeNames: ['*.openchallenges.io'],
+    this.cert = new AcmCertificate(this, 'openchallenges_cert', {
+      domainName: 'dev.openchallenges.io',
       validationMethod: 'DNS',
       validationOption: [
         {
-          domainName: 'openchallenges.io',
+          domainName: 'dev.openchallenges.io',
           validationDomain: 'openchallenges.io',
         },
       ],


### PR DESCRIPTION
Contributes to #1898

## Changelog

- Add a ACM certificate to the stack `cnb-dev` for all OC DNS names

## TODO

- [ ] Manually delete the old certificate with ID `b1c70716-8f19-4d06-9737-1dd34f56afc4`

## Notes

- Once applied (`cdktf deploy cnb-dev`), the existing certificate for `dev.openchallenges.io` will be removed according to the diff output shown below.

## Preview

Output of `cdktf diff cnb-dev`

```console
cnb-dev  Terraform used the selected providers to generate the following execution
         plan. Resource actions are indicated with the following symbols:
         +/- create replacement and then destroy

         Terraform will perform the following actions:
cnb-dev    # aws_acm_certificate.dns_openchallenges_cert_42540034 (dns/openchallenges_cert) must be replaced
         +/- resource "aws_acm_certificate" "dns_openchallenges_cert_42540034" {
               ~ arn                       = "arn:aws:acm:us-east-1:384625883722:certificate/b1c70716-8f19-4d06-9737-1dd34f56afc4" -> (known after apply)
               ~ domain_name               = "dev.openchallenges.io" -> "openchallenges.io" # forces replacement
               ~ domain_validation_options = [
                   - {
                       - domain_name           = "dev.openchallenges.io"
                       - resource_record_name  = "_8c411fb9dbec6c9424a1173ab736b81e.dev.openchallenges.io."
                       - resource_record_type  = "CNAME"
                       - resource_record_value = "_06aa7293b30f9eda06f0f47165ff7632.zsqxqtfsbl.acm-validations.aws."
                     },
                   + {
                       + domain_name           = "*.openchallenges.io"
                       + resource_record_name  = (known after apply)
                       + resource_record_type  = (known after apply)
                       + resource_record_value = (known after apply)
                     },
                   + {
                       + domain_name           = "openchallenges.io"
                       + resource_record_name  = (known after apply)
                       + resource_record_type  = (known after apply)
                       + resource_record_value = (known after apply)
                     },
                 ]
               ~ id                        = "arn:aws:acm:us-east-1:384625883722:certificate/b1c70716-8f19-4d06-9737-1dd34f56afc4" -> (known after apply)
               ~ key_algorithm             = "RSA_2048" -> (known after apply)
               ~ not_after                 = "2024-08-10T23:59:59Z" -> (known after apply)
               ~ not_before                = "2023-07-13T00:00:00Z" -> (known after apply)
               ~ pending_renewal           = false -> (known after apply)
               ~ renewal_eligibility       = "ELIGIBLE" -> (known after apply)
               ~ renewal_summary           = [] -> (known after apply)
               ~ status                    = "ISSUED" -> (known after apply)
               ~ subject_alternative_names = [ # forces replacement
                   - "dev.openchallenges.io",
                   + "*.openchallenges.io",
                   + "openchallenges.io",
                 ]
                 tags                      = {
                     "CostCenter" = "ITCR / 101600"
                     "Name"       = "cnb-dev-openchallenges-cert"
                     "OwnerEmail" = "thomas.schaffter@sagebionetworks.org"
                 }
               ~ type                      = "AMAZON_ISSUED" -> (known after apply)
               ~ validation_emails         = [] -> (known after apply)
                 # (2 unchanged attributes hidden)

               - options {
                   - certificate_transparency_logging_preference = "ENABLED" -> null
                 }

               - validation_option { # forces replacement
                   - domain_name       = "dev.openchallenges.io" -> null
                   - validation_domain = "openchallenges.io" -> null
                 }
               + validation_option { # forces replacement
                   + domain_name       = "openchallenges.io"
                   + validation_domain = "openchallenges.io"
                 }
             }

         Plan: 1 to add, 0 to change, 1 to destroy.
         
         Changes to Outputs:
           - cert_arn                = "arn:aws:acm:us-east-1:384625883722:certificate/b1c70716-8f19-4d06-9737-1dd34f56afc4" -> null
           + openchallenges_cert_arn = (known after apply)
```