### PR TITLE
feat(ui): Adjust layout of cards

### DIFF
--- a/libs/openchallenges/challenge/src/lib/challenge-organizers/challenge-organizers.component.scss
+++ b/libs/openchallenges/challenge/src/lib/challenge-organizers/challenge-organizers.component.scss
@@ -3,5 +3,5 @@
 }
 
 .card-group {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 23%));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.scss
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.scss
@@ -7,7 +7,9 @@
 .section-title {
   margin-bottom: 42px;
 }
-
+.card-group {
+  justify-items: center;
+}
 #organizations {
   padding: 88px 0;
 

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.scss
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.scss
@@ -16,8 +16,3 @@
     padding: 26px 40px;
   }
 }
-
-// CARDS
-.card-group {
-  justify-items: center;
-}

--- a/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.scss
+++ b/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.scss
@@ -6,7 +6,9 @@
 .section-title {
   margin-bottom: 42px;
 }
-
+.card-group {
+  justify-items: center;
+}
 // SECTION: featured
 #featured-challenges {
   padding: 64px 0;

--- a/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.scss
+++ b/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.scss
@@ -6,9 +6,6 @@
 .section-title {
   margin-bottom: 42px;
 }
-.card-group {
-  justify-items: center;
-}
 
 // SECTION: featured
 #featured-challenges {

--- a/libs/openchallenges/org-profile/src/lib/org-profile-members/org-profile-members.component.scss
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-members/org-profile-members.component.scss
@@ -3,5 +3,5 @@
 }
 
 .card-group {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 23%));
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -246,7 +246,7 @@ table {
 // CARDS
 .card-group {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 24px;
   padding: 16px 0;
 }

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -246,7 +246,7 @@ table {
 // CARDS
 .card-group {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 24px;
   padding: 16px 0;
 }
@@ -312,10 +312,6 @@ table {
   .content {
     flex-direction: column;
   }
-  .card-group {
-    flex-direction: column;
-    align-items: center;
-  }
 }
 @media screen and (min-width: constants.$md-breakpoint) {
   .col,
@@ -373,5 +369,10 @@ table {
 @media only screen and (max-width: constants.$lg-breakpoint) {
   html {
     margin-top: constants.$navbar-height-tall;
+  }
+
+  .card-group {
+    grid-template-columns: 60%;
+    justify-content: center;
   }
 }

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .challenge-card {
-  min-width: 300px;
+  width: 300px;
   min-height: 360px;
   padding: 12px 12px 4px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .challenge-card {
-  min-width: 320px;
+  min-width: 300px;
   min-height: 360px;
   padding: 12px 12px 4px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .challenge-card {
-  width: 300px;
+  width: 320px;
   min-height: 360px;
   padding: 12px 12px 4px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .challenge-card {
-  width: 320px;
+  min-width: 320px;
   min-height: 360px;
   padding: 12px 12px 4px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .challenge-card {
-  width: 320px;
+  width: 300px;
   min-height: 360px;
   padding: 12px 12px 4px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .organization-card {
-  width: 320px;
+  width: 300px;
   min-height: 180px;
   padding: 12px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .organization-card {
-  min-width: 300px;
+  width: 300px;
   min-height: 180px;
   padding: 12px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .organization-card {
-  width: 300px;
+  width: 320px;
   min-height: 180px;
   padding: 12px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .organization-card {
-  min-width: 320px;
+  min-width: 300px;
   min-height: 180px;
   padding: 12px;
   display: flex;

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/openchallenges/styles/src/lib/_constants' as constants;
 
 .organization-card {
-  width: 320px;
+  min-width: 320px;
   min-height: 180px;
   padding: 12px;
   display: flex;


### PR DESCRIPTION
- fixes #1928 

## Changelog
- Replace `auto-fit` by `auto-fill` in grid layout. `Auto-fill` will actually remain the layout and not fill the empty grid (which confused me by its name)
- ~~Make cards stretchable a bit to better fit in the container~~

## Preview

>**Note**
>The cards have remained to use fixed width as @tschaffter suggests.

![Recording 2023-08-04 at 12 58 28](https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/a0f2b320-02d8-44ff-b5d4-7d1d9cc5cf7a)
<img width="707" alt="Screen Shot 2023-08-04 at 12 57 29 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/4be1459c-08f7-406c-85ac-f43f9505e0fb">


![Recording 2023-08-04 at 12 59 53](https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/197a710d-8ec6-4d55-a22a-0742e91114c6)
