### PR TITLE
chore: Point `openchallenges.io` to the OC preview EC2 instance

### DIFF
--- a/apps/openchallenges/infra/src/dns/openchallenges-dev-dns.ts
+++ b/apps/openchallenges/infra/src/dns/openchallenges-dev-dns.ts
@@ -4,6 +4,7 @@ import { Alb } from '@cdktf/provider-aws/lib/alb';
 
 export class OpenChallengesDevDns extends Construct {
   record: Route53Record;
+  prodRecord: Route53Record;
 
   constructor(scope: Construct, id: string, lb: Alb) {
     super(scope, id);
@@ -12,6 +13,17 @@ export class OpenChallengesDevDns extends Construct {
     this.record = new Route53Record(this, 'record', {
       name: 'dev.openchallenges.io',
       zoneId: `Z08311133Q4NQKBJPU4ZX`,
+      type: 'A',
+      alias: {
+        name: lb.dnsName,
+        zoneId: lb.zoneId,
+        evaluateTargetHealth: true,
+      },
+    });
+
+    this.prodRecord = new Route53Record(this, 'openchallenges-prod-record', {
+      name: 'openchallenges.io',
+      zoneId: `Z00419882TA5J7Q3IFTKQ`,
       type: 'A',
       alias: {
         name: lb.dnsName,

--- a/apps/openchallenges/infra/src/preview-instance-alb/preview-instance-alb.ts
+++ b/apps/openchallenges/infra/src/preview-instance-alb/preview-instance-alb.ts
@@ -63,7 +63,7 @@ export class PreviewInstanceAlb extends Construct {
         port: 443,
         protocol: 'HTTPS',
         certificateArn:
-          'arn:aws:acm:us-east-1:384625883722:certificate/b1c70716-8f19-4d06-9737-1dd34f56afc4',
+          'arn:aws:acm:us-east-1:384625883722:certificate/c1d8b793-66d1-41eb-bddf-3cfedbad6a72',
 
         defaultAction: [
           {


### PR DESCRIPTION
Closes #1898

## Changelog

- Update the preview instance ALB to use the certificate created in #1925
- Add Route53 record for `openchallenges.io`

## Notes

- I'm keeping the record for `dev.openchallenges.io` so that the stack continues to work before Sage Week without changing host names in the configuration of the stack (requests are sent under the hood to `dev.openchallenges.io`) 

## Preview

<img width="1435" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/85cfc3d4-3669-4097-a243-f9d7c95f1874">
