### PR TITLE
fix(ui): Hide in-progess items for soft launch

### DIFF
--- a/libs/openchallenges/challenge/src/lib/challenge-stats/challenge-stats.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-stats/challenge-stats.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="challenge$ | async as challenge" class="stats-group">
   <div class="stat-item">
-    <h3>{{ shorthand(mockViews) }}</h3>
+    <h3>N</h3>
     <p [ngPlural]="mockViews || 0" class="mat-caption">
       <ng-template ngPluralCase="=1">view</ng-template>
       <ng-template ngPluralCase="other">views</ng-template>

--- a/libs/openchallenges/challenge/src/lib/challenge-stats/challenge-stats.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-stats/challenge-stats.component.html
@@ -6,13 +6,13 @@
       <ng-template ngPluralCase="other">views</ng-template>
     </p>
   </div>
-  <div class="stat-item">
+  <!-- <div class="stat-item">
     <h3>{{ shorthand(mockStargazers) }}</h3>
     <p [ngPlural]="mockStargazers || 0" class="mat-caption">
       <ng-template ngPluralCase="=1">stargazer</ng-template>
       <ng-template ngPluralCase="other">stargazers</ng-template>
     </p>
-  </div>
+  </div> -->
   <a href="#" class="stat-item action-btn" *ngIf="loggedIn">
     <mat-icon aria-hidden="true" class="stats-card-icon">edit</mat-icon>
     Edit

--- a/libs/openchallenges/challenge/src/lib/challenge.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.html
@@ -5,7 +5,7 @@
       <div id="profile-details" class="col">
         <h2>
           {{ challenge.name }}
-          <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
+          <!-- <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon> -->
         </h2>
         <p class="username">@{{ challenge.slug }}</p>
         <div

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.html
@@ -9,7 +9,7 @@
       <div id="profile-details" class="col">
         <h2>
           {{ org.name }}
-          <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon>
+          <!-- <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon> -->
         </h2>
         <p class="username">@{{ org.login }}</p>
         <div class="profile-type">Organization</div>


### PR DESCRIPTION
## Changelog
* hide stargazers metric from challenge profile
* display "N views" on challenge profile (instead of a distinct value)
* hide verification badge until we can add a tooltip and/or explanation what it means to be verified on OC

## Preview

<img width="1380" alt="Screenshot 2023-08-05 at 8 53 13 AM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/107411fb-eb7e-44bc-8d0c-7ea7d2f3abf1">
