### PR TITLE
feat: Investigate yarn cache folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,13 @@ jobs:
       #   id: yarn-cache-dir-path
       #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+      # - uses: actions/cache@v3
+      #   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      #   with:
+      #     path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
 
       # - name: Setup poetry cache
       #   id: cache-poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
           # Update the dev container definition to use docker-outside-of-docker instead of
           # docker-in-docker so that the images built inside the dev container are available to the
           # host (i.e. outside the dev container).
-          #./tools/switch-devcontainer-to-docker-outside-of-docker.sh
+          ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
           devcontainer up --workspace-folder ../sage-monorepo
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Yarn cache
         uses: actions/cache@v3
         with:
-          path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
+          path: '**/.yarn/cache'
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -162,7 +162,7 @@ jobs:
       - name: Set up Yarn cache
         uses: actions/cache@v3
         with:
-          path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
+          path: '**/.yarn/cache'
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,12 +167,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Setup poetry cache
-        id: cache-poetry
-        uses: actions/cache@v3
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+      # - name: Setup poetry cache
+      #   id: cache-poetry
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.local/share/virtualenvs
+      #     key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
       - name: Setup Gradle cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,10 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
 
-      - name: Setup Node.js cache
-        id: cache-node
+      - name: Set up Yarn cache
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -170,8 +159,8 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
 
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Set up Yarn cache
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,11 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && ls -al /workspaces/sage-monorepo/.yarn/cache"
 
+      - name: Install Node.js packages
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && yarn install --immutable"
+
       # - name: Prepare the workspace in the dev container
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,19 +167,21 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v3
+      # - name: Derive appropriate SHAs for base and head for `nx affected` commands
+      #   uses: nrwl/nx-set-shas@v3
 
-      - name: Setup Node.js cache
-        id: cache-node
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      # - name: Setup Node.js cache
+      #   id: cache-node
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: '**/node_modules'
+      #     key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      # - name: Get yarn cache directory path
+      #   id: yarn-cache-dir-path
+      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+      - run: pwd
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -189,27 +191,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Setup poetry cache
-        id: cache-poetry
-        uses: actions/cache@v3
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+      # - name: Setup poetry cache
+      #   id: cache-poetry
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.local/share/virtualenvs
+      #     key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Setup Gradle cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            /root/.gradle/caches
-            /root/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      # - name: Setup Gradle cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       /root/.gradle/caches
+      #       /root/.gradle/wrapper
+      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-gradle-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+      #   with:
+      #     driver: docker
 
       # - name: Cache Docker layers
       #   uses: actions/cache@v3
@@ -219,54 +221,54 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-single-buildx
 
-      - name: Install the devcontainer CLI
-        run: npm install -g @devcontainers/cli@0.49.0
+      # - name: Install the devcontainer CLI
+      #   run: npm install -g @devcontainers/cli@0.49.0
 
-      - name: Start the dev container
-        run: |
-          # Update the dev container definition to use docker-outside-of-docker instead of
-          # docker-in-docker so that the images built inside the dev container are available to the
-          # host (i.e. outside the dev container).
-          ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
+      # - name: Start the dev container
+      #   run: |
+      #     # Update the dev container definition to use docker-outside-of-docker instead of
+      #     # docker-in-docker so that the images built inside the dev container are available to the
+      #     # host (i.e. outside the dev container).
+      #     ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-          devcontainer up --workspace-folder ../sage-monorepo
+      #     devcontainer up --workspace-folder ../sage-monorepo
 
-      - name: Prepare the workspace in the dev container
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && workspace-install"
-
-      - name: Lint the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=lint"
-
-      - name: Build the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build"
-
-      - name: Test the affected projects (unit)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=test"
-
-      - name: Test the affected projects (integration)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=integration-test"
-
-      # - name: Build the images of the affected projects
+      # - name: Prepare the workspace in the dev container
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build-and-remove-image --parallel=1"
+      #       && workspace-install"
 
-      - name: Build the images of the SELECTED projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image \
-              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-              --parallel=1"
+      # - name: Lint the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=lint"
 
-      - name: Stop the dev container
-        run: docker rm -f sage_devcontainer
+      # - name: Build the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=build"
+
+      # - name: Test the affected projects (unit)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=test"
+
+      # - name: Test the affected projects (integration)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=integration-test"
+
+      # # - name: Build the images of the affected projects
+      # #   run: |
+      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      # #       && nx affected --target=build-and-remove-image --parallel=1"
+
+      # - name: Build the images of the SELECTED projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx run-many --target=build-and-remove-image \
+      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+      #         --parallel=1"
+
+      # - name: Stop the dev container
+      #   run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,13 @@ jobs:
       #   id: yarn-cache-dir-path
       #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      # - uses: actions/cache@v3
-      #   id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      #   with:
-      #     path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       # - name: Setup poetry cache
       #   id: cache-poetry
@@ -230,11 +230,6 @@ jobs:
           #./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
           devcontainer up --workspace-folder ../sage-monorepo
-
-      # - name: ls yarn cache folder inside the dev container
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && ls -al /workspaces/sage-monorepo/.yarn/cache"
 
       - name: Install Node.js packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,10 +231,10 @@ jobs:
 
           devcontainer up --workspace-folder ../sage-monorepo
 
-      - name: ls yarn cache folder inside the dev container
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && ls -al /workspaces/sage-monorepo/.yarn/cache"
+      # - name: ls yarn cache folder inside the dev container
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && ls -al /workspaces/sage-monorepo/.yarn/cache"
 
       - name: Install Node.js packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: ls -al /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
-
       # - name: Setup poetry cache
       #   id: cache-poetry
       #   uses: actions/cache@v3
@@ -221,17 +219,22 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-single-buildx
 
-      # - name: Install the devcontainer CLI
-      #   run: npm install -g @devcontainers/cli@0.49.0
+      - name: Install the devcontainer CLI
+        run: npm install -g @devcontainers/cli@0.49.0
 
-      # - name: Start the dev container
-      #   run: |
-      #     # Update the dev container definition to use docker-outside-of-docker instead of
-      #     # docker-in-docker so that the images built inside the dev container are available to the
-      #     # host (i.e. outside the dev container).
-      #     ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
+      - name: Start the dev container
+        run: |
+          # Update the dev container definition to use docker-outside-of-docker instead of
+          # docker-in-docker so that the images built inside the dev container are available to the
+          # host (i.e. outside the dev container).
+          #./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-      #     devcontainer up --workspace-folder ../sage-monorepo
+          devcontainer up --workspace-folder ../sage-monorepo
+
+      - name: ls yarn cache folder inside the dev container
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && ls -al /workspaces/sage-monorepo/.yarn/cache"
 
       # - name: Prepare the workspace in the dev container
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,15 +181,15 @@ jobs:
       #   id: yarn-cache-dir-path
       #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      - run: pwd
-
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - run: ls -al /home/runner/work/sage-monorepo/sage-monorepo/.yarn/cache
 
       # - name: Setup poetry cache
       #   id: cache-poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,19 +167,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
-      # - name: Derive appropriate SHAs for base and head for `nx affected` commands
-      #   uses: nrwl/nx-set-shas@v3
-
-      # - name: Setup Node.js cache
-      #   id: cache-node
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: '**/node_modules'
-      #     key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-      # - name: Get yarn cache directory path
-      #   id: yarn-cache-dir-path
-      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v3
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -189,35 +178,35 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      # - name: Setup poetry cache
-      #   id: cache-poetry
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/.local/share/virtualenvs
-      #     key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+      - name: Setup poetry cache
+        id: cache-poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
-      # - name: Setup Gradle cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       /root/.gradle/caches
-      #       /root/.gradle/wrapper
-      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-gradle-
+      - name: Setup Gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /root/.gradle/caches
+            /root/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v2
-      #   with:
-      #     driver: docker
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: docker
 
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-single-buildx-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-single-buildx
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
 
       - name: Install the devcontainer CLI
         run: npm install -g @devcontainers/cli@0.49.0
@@ -231,47 +220,42 @@ jobs:
 
           devcontainer up --workspace-folder ../sage-monorepo
 
-      - name: Install Node.js packages
+      - name: Prepare the workspace in the dev container
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && yarn install --immutable"
+            && workspace-install"
 
-      # - name: Prepare the workspace in the dev container
+      - name: Lint the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=lint"
+
+      - name: Build the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=build"
+
+      - name: Test the affected projects (unit)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=test"
+
+      - name: Test the affected projects (integration)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=integration-test"
+
+      # - name: Build the images of the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && workspace-install"
+      #       && nx affected --target=build-and-remove-image --parallel=1"
 
-      # - name: Lint the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=lint"
+      - name: Build the images of the SELECTED projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=build-and-remove-image \
+              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+              --parallel=1"
 
-      # - name: Build the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build"
-
-      # - name: Test the affected projects (unit)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=test"
-
-      # - name: Test the affected projects (integration)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=integration-test"
-
-      # # - name: Build the images of the affected projects
-      # #   run: |
-      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      # #       && nx affected --target=build-and-remove-image --parallel=1"
-
-      # - name: Build the images of the SELECTED projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=build-and-remove-image \
-      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-      #         --parallel=1"
-
-      # - name: Stop the dev container
-      #   run: docker rm -f sage_devcontainer
+      - name: Stop the dev container
+        run: docker rm -f sage_devcontainer


### PR DESCRIPTION
Contributes to #1975

## Description

Enable the caching of Node.js packages when running the CI workflow. This PR makes the CI workflow runs 3 minutes faster as Node.js packages are cached and no longer need to be downloaded for each run of the workflow.

See this [comment](https://github.com/Sage-Bionetworks/sage-monorepo/issues/1975#issuecomment-1682529163) for more details.

UPDATE: The caching of Node.js packages was already active before this PR. The scope of this PR is limited to providing a more clean implementation of the Node.js packages caching.

## Preview

### Without caching Node.js packages (current)

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/61d7913d-0a25-4727-8643-612916f2aebf)

### When caching Node.js packages (this PR)

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/c67283ef-12af-4166-b3af-70c6f8a0a984)

Details of `yarn install --immutable`, which is executed by `workspace-install`:

```console
yarn install --immutable

➤ YN0000: ┌ Resolution step
➤ YN0002: │ @cdktf/cli-core@npm:0.16.1 doesn't provide ink (pa54fc), requested by ink-select-input
➤ YN0002: │ @cdktf/cli-core@npm:0.16.1 doesn't provide react (pc5634), requested by ink-select-input
➤ YN0002: │ @nguniversal/builders@npm:16.1.1 [15c3d] doesn't provide @angular/common (p75b58), requested by @nguniversal/common
➤ YN0002: │ @nguniversal/builders@npm:16.1.1 [15c3d] doesn't provide @angular/core (p4bbf4), requested by @nguniversal/common
➤ YN0002: │ @nguniversal/builders@npm:16.1.1 [15c3d] doesn't provide typescript (pf6c9e), requested by guess-parser
➤ YN0002: │ @nrwl/angular@npm:16.5.5 doesn't provide @angular-devkit/build-angular (p49df6), requested by @nx/angular
➤ YN0002: │ @nrwl/angular@npm:16.5.5 doesn't provide @angular-devkit/core (pdb297), requested by @nx/angular
➤ YN0002: │ @nrwl/angular@npm:16.5.5 doesn't provide @angular-devkit/schematics (pabc35), requested by @nx/angular
➤ YN0002: │ @nrwl/angular@npm:16.5.5 doesn't provide @schematics/angular (pf9cd8), requested by @nx/angular
➤ YN0002: │ @nrwl/angular@npm:16.5.5 doesn't provide rxjs (p9ee52), requested by @nx/angular
➤ YN0002: │ @nrwl/devkit@npm:16.5.5 doesn't provide nx (p47dff), requested by @nx/devkit
➤ YN0002: │ @nrwl/eslint-plugin-nx@npm:16.5.5 doesn't provide @typescript-eslint/parser (pe6d11), requested by @nx/eslint-plugin
➤ YN0002: │ @nx-tools/ci-context@npm:4.0.3 doesn't provide @nrwl/devkit (p0afeb), requested by @nx-tools/core
➤ YN0002: │ @nx/angular@npm:16.5.5 [15c3d] doesn't provide @types/node (p482c9), requested by ts-node
➤ YN0002: │ @nx/angular@npm:16.5.5 [15c3d] doesn't provide eslint (p2e500), requested by @typescript-eslint/type-utils
➤ YN0002: │ @nx/angular@npm:16.5.5 [15c3d] doesn't provide nx (p33a52), requested by @nx/devkit
➤ YN0002: │ @nx/angular@npm:16.5.5 [15c3d] doesn't provide typescript (pd0fd8), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/angular@npm:16.5.5 [15c3d] doesn't provide typescript (p43879), requested by ts-node
➤ YN0002: │ @nx/angular@npm:16.5.5 [6daf3] doesn't provide @types/node (peb274), requested by ts-node
➤ YN0002: │ @nx/angular@npm:16.5.5 [6daf3] doesn't provide eslint (pd513c), requested by @typescript-eslint/type-utils
➤ YN0002: │ @nx/angular@npm:16.5.5 [6daf3] doesn't provide nx (p0f6cb), requested by @nx/devkit
➤ YN0002: │ @nx/angular@npm:16.5.5 [6daf3] doesn't provide typescript (p1a910), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/angular@npm:16.5.5 [6daf3] doesn't provide typescript (p2a7ff), requested by ts-node
➤ YN0002: │ @nx/cypress@npm:16.5.5 [15c3d] doesn't provide nx (p38dcd), requested by @nx/devkit
➤ YN0002: │ @nx/cypress@npm:16.5.5 [15c3d] doesn't provide typescript (p22c15), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/cypress@npm:16.5.5 [59428] doesn't provide nx (pea7d2), requested by @nx/devkit
➤ YN0002: │ @nx/cypress@npm:16.5.5 [59428] doesn't provide typescript (p16e6e), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/eslint-plugin@npm:16.5.5 [15c3d] doesn't provide eslint (p1a1dc), requested by @typescript-eslint/type-utils
➤ YN0002: │ @nx/eslint-plugin@npm:16.5.5 [15c3d] doesn't provide nx (pbf066), requested by @nx/devkit
➤ YN0002: │ @nx/eslint-plugin@npm:16.5.5 [a70d6] doesn't provide eslint (pe4a6d), requested by @typescript-eslint/type-utils
➤ YN0002: │ @nx/eslint-plugin@npm:16.5.5 [a70d6] doesn't provide nx (p0255e), requested by @nx/devkit
➤ YN0002: │ @nx/jest@npm:16.5.5 doesn't provide nx (p1f5cd), requested by @nx/devkit
➤ YN0002: │ @nx/jest@npm:16.5.5 doesn't provide typescript (p574e8), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/js@npm:16.5.5 [2ada8] doesn't provide nx (pdda41), requested by @nx/devkit
➤ YN0002: │ @nx/js@npm:16.5.5 [2ada8] doesn't provide typescript (pab347), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/linter@npm:16.5.5 [15c3d] doesn't provide nx (p474f5), requested by @nx/devkit
➤ YN0002: │ @nx/linter@npm:16.5.5 [15c3d] doesn't provide typescript (pacf07), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/linter@npm:16.5.5 [adb5a] doesn't provide nx (p9edac), requested by @nx/devkit
➤ YN0002: │ @nx/linter@npm:16.5.5 [adb5a] doesn't provide typescript (p54f7a), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/node@npm:16.5.5 doesn't provide nx (pcf0f1), requested by @nx/devkit
➤ YN0002: │ @nx/plugin@npm:16.5.5 doesn't provide nx (p44e30), requested by @nx/devkit
➤ YN0002: │ @nx/plugin@npm:16.5.5 doesn't provide typescript (p73761), requested by @phenomnomnominal/tsquery
➤ YN0002: │ @nx/web@npm:16.5.5 doesn't provide nx (p677b5), requested by @nx/devkit
➤ YN0002: │ @nx/webpack@npm:16.5.5 doesn't provide @types/node (p79eda), requested by ts-node
➤ YN0002: │ @nx/webpack@npm:16.5.5 doesn't provide nx (peb14c), requested by @nx/devkit
➤ YN0002: │ @nx/webpack@npm:16.5.5 doesn't provide typescript (p6e888), requested by fork-ts-checker-webpack-plugin
➤ YN0002: │ @nx/webpack@npm:16.5.5 doesn't provide typescript (p88287), requested by ts-loader
➤ YN0002: │ @nx/webpack@npm:16.5.5 doesn't provide typescript (p21fdc), requested by ts-node
➤ YN0002: │ @redocly/cli@npm:1.0.0-beta.131 doesn't provide core-js (p1e785), requested by redoc
➤ YN0002: │ @redocly/cli@npm:1.0.0-beta.131 doesn't provide react-is (pbb956), requested by styled-components
➤ YN0002: │ babel-plugin-styled-components@npm:2.1.4 [faab3] doesn't provide @babel/core (pe2512), requested by @babel/plugin-syntax-jsx
➤ YN0002: │ cdktf-cli@npm:0.16.1 doesn't provide ink (pefa35), requested by ink-select-input
➤ YN0002: │ cdktf-cli@npm:0.16.1 doesn't provide ink (p16a82), requested by ink-table
➤ YN0002: │ cdktf-cli@npm:0.16.1 doesn't provide react (p56d8e), requested by ink-select-input
➤ YN0002: │ cdktf-cli@npm:0.16.1 doesn't provide react (pfdc7b), requested by ink-table
➤ YN0002: │ redoc@npm:2.0.0 [c0186] doesn't provide webpack (p1e822), requested by style-loader
➤ YN0060: │ sage-monorepo@workspace:. provides @angular/common (pf28f0) with version 16.1.7, which doesn't satisfy what keycloak-angular requests
➤ YN0060: │ sage-monorepo@workspace:. provides @angular/common (p10304) with version 16.1.7, which doesn't satisfy what ngx-avatars requests
➤ YN0060: │ sage-monorepo@workspace:. provides @angular/core (p854c4) with version 16.1.7, which doesn't satisfy what keycloak-angular requests
➤ YN0060: │ sage-monorepo@workspace:. provides @angular/core (p49492) with version 16.1.7, which doesn't satisfy what ngx-avatars requests
➤ YN0060: │ sage-monorepo@workspace:. provides @angular/router (p32acf) with version 16.1.7, which doesn't satisfy what keycloak-angular requests
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide @babel/core (p24f51), requested by babel-jest
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide @nrwl/devkit (p1b0f5), requested by @nx-tools/container-metadata
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide @nrwl/devkit (pb8c30), requested by @nx-tools/nx-container
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide dotenv (p556a0), requested by @nx-tools/container-metadata
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide dotenv (p0b997), requested by @nx-tools/nx-container
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide express (p7c88c), requested by @nguniversal/express-engine
➤ YN0060: │ sage-monorepo@workspace:. provides jest (p327f0) with version 29.4.3, which doesn't satisfy what @angular-devkit/build-angular requests
➤ YN0060: │ sage-monorepo@workspace:. provides jest-environment-jsdom (p98342) with version 29.4.3, which doesn't satisfy what @angular-devkit/build-angular requests
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide postcss (p24f92), requested by postcss-preset-env
➤ YN0002: │ sage-monorepo@workspace:. doesn't provide postcss (p7230a), requested by postcss-url
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 1s 69ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 1s 653ms
➤ YN0000: ┌ Link step
➤ YN0007: │ @nestjs/core@npm:8.4.4 [3041e] must be built because it never has been before or the last one failed
➤ YN0007: │ @swc/core@npm:1.3.19 must be built because it never has been before or the last one failed
➤ YN0007: │ canvas@npm:2.10.2 must be built because it never has been before or the last one failed
➤ YN0007: │ core-js@npm:3.25.5 must be built because it never has been before or the last one failed
➤ YN0007: │ cypress@npm:12.17.2 must be built because it never has been before or the last one failed
➤ YN0007: │ esbuild@npm:0.17.19 must be built because it never has been before or the last one failed
➤ YN0007: │ @parcel/watcher@npm:2.0.4 must be built because it never has been before or the last one failed
➤ YN0007: │ canvas@npm:2.11.2 must be built because it never has been before or the last one failed
➤ YN0007: │ nice-napi@npm:1.0.2 must be built because it never has been before or the last one failed
➤ YN0007: │ esbuild@npm:0.18.17 must be built because it never has been before or the last one failed
➤ YN0007: │ @cdktf/node-pty-prebuilt-multiarch@npm:0.10.1-pre.10 must be built because it never has been before or the last one failed
➤ YN0007: │ core-js@npm:3.32.0 must be built because it never has been before or the last one failed
➤ YN0007: │ es5-ext@npm:0.10.62 must be built because it never has been before or the last one failed
➤ YN0007: │ core-js-pure@npm:3.32.0 must be built because it never has been before or the last one failed
➤ YN0007: │ @openapitools/openapi-generator-cli@npm:2.5.2 must be built because it never has been before or the last one failed
➤ YN0007: │ serverless@npm:3.22.0 must be built because it never has been before or the last one failed
➤ YN0007: │ nx@npm:16.5.5 [15c3d] must be built because it never has been before or the last one failed
➤ YN0007: │ sage-monorepo@workspace:. must be built because it never has been before or the last one failed
➤ YN0000: └ Completed in 1m 23s
➤ YN0000: Done with warnings in 1m 26s
```