### PR TITLE
feat: Cache R packages in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,5 +265,5 @@ jobs:
       #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
       #         --parallel=1"
 
-      - name: Stop the dev container
-        run: docker rm -f sage_devcontainer
+      # - name: Stop the dev container
+      #   run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,8 +223,9 @@ jobs:
 
       - name: Prepare the workspace in the dev container
         run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && sudo chown -R vscode:vscode /home/vscode/.cache \
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c "
+            sudo chown -R vscode:vscode /home/vscode/.cache
+            && . ./dev-env.sh \
             && yarn nx run-many --target=prepare-r"
 
       # - name: Lint the affected projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Set up Renv cache
+        uses: actions/cache@v3
+        with:
+          path: '/tmp/.cache/R/renv/cache'
+          key: ${{ runner.os }}-renv-cache-${{ hashFiles('**/renv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-renv-cache-
+
       - name: Setup poetry cache
         id: cache-poetry
         uses: actions/cache@v3
@@ -83,12 +91,17 @@ jobs:
           # host (i.e. outside the dev container).
           ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-          devcontainer up --workspace-folder ../sage-monorepo \
-            --mount type="bind,source=$HOME/.docker,target=/home/vscode/.docker"
+          mkdir -p /tmp/.cache/R/renv/cache
 
-      - name: Prepare the workspace in the dev container
+          devcontainer up \
+            --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
+            --workspace-folder ../sage-monorepo
+
+      - name: Prepare the workspace
         run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c "
+            sudo chown -R vscode:vscode /home/vscode/.cache \
+            && . ./dev-env.sh \
             && workspace-install"
 
       - name: Lint the affected projects
@@ -221,49 +234,44 @@ jobs:
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --workspace-folder ../sage-monorepo
 
-      - name: Prepare the workspace in the dev container
+      - name: Prepare the workspace
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c "
             sudo chown -R vscode:vscode /home/vscode/.cache \
             && . ./dev-env.sh \
-            && yarn install --immutable"
+            && workspace-install"
 
-      - name: Install R packages
+      - name: Lint the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && yarn nx run-many --target=prepare-r"
+            && nx affected --target=lint"
 
-      # - name: Lint the affected projects
+      - name: Build the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=build"
+
+      - name: Test the affected projects (unit)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=test"
+
+      - name: Test the affected projects (integration)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=integration-test"
+
+      # - name: Build the images of the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=lint"
+      #       && nx affected --target=build-and-remove-image --parallel=1"
 
-      # - name: Build the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build"
+      - name: Build the images of the SELECTED projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=build-and-remove-image \
+              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+              --parallel=1"
 
-      # - name: Test the affected projects (unit)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=test"
-
-      # - name: Test the affected projects (integration)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=integration-test"
-
-      # # - name: Build the images of the affected projects
-      # #   run: |
-      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      # #       && nx affected --target=build-and-remove-image --parallel=1"
-
-      # - name: Build the images of the SELECTED projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=build-and-remove-image \
-      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-      #         --parallel=1"
-
-      # - name: Stop the dev container
-      #   run: docker rm -f sage_devcontainer
+      - name: Stop the dev container
+        run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && sudo chown -R vscode:vscode /home/vscode/.cache \
-            && ls -al /home/vscode/.cache/R/renv/cache"
+            && yarn nx run-many --target=prepare-r"
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,14 +224,13 @@ jobs:
       - name: Prepare the workspace in the dev container
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c "
-            sudo chown -R vscode:vscode /home/vscode/.cache
+            sudo chown -R vscode:vscode /home/vscode/.cache \
             && . ./dev-env.sh \
             && yarn install --immutable"
 
       - name: Install R packages
         run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c "
-            && . ./dev-env.sh \
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && yarn nx run-many --target=prepare-r"
 
       # - name: Lint the affected projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Set up Renv cache
         uses: actions/cache@v3
         with:
-          path: '~/.cache/R/renv/cache'
+          path: '/tmp/.cache/R/renv/cache' # '~/.cache/R/renv/cache'
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: |
             ${{ runner.os }}-renv-
@@ -205,17 +205,19 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-single-buildx
 
-      # - name: Install the devcontainer CLI
-      #   run: npm install -g @devcontainers/cli@0.49.0
+      - name: Install the devcontainer CLI
+        run: npm install -g @devcontainers/cli@0.49.0
 
-      # - name: Start the dev container
-      #   run: |
-      #     # Update the dev container definition to use docker-outside-of-docker instead of
-      #     # docker-in-docker so that the images built inside the dev container are available to the
-      #     # host (i.e. outside the dev container).
-      #     ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
+      - name: Start the dev container
+        run: |
+          # Update the dev container definition to use docker-outside-of-docker instead of
+          # docker-in-docker so that the images built inside the dev container are available to the
+          # host (i.e. outside the dev container).
+          ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-      #     devcontainer up --workspace-folder ../sage-monorepo
+          devcontainer up \
+            --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
+            --workspace-folder ../sage-monorepo
 
       # - name: Prepare the workspace in the dev container
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,13 +159,21 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
 
-      - name: Set up Yarn cache
+      # - name: Set up Yarn cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: '**/.yarn/cache'
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
+
+      - name: Set up Renv cache
         uses: actions/cache@v3
         with:
-          path: '**/.yarn/cache'
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: '~/.cache/R/renv/cache'
+          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-renv-
 
       # - name: Setup poetry cache
       #   id: cache-poetry
@@ -174,77 +182,77 @@ jobs:
       #     path: ~/.local/share/virtualenvs
       #     key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Setup Gradle cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            /root/.gradle/caches
-            /root/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      # - name: Setup Gradle cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       /root/.gradle/caches
+      #       /root/.gradle/wrapper
+      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-gradle-
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+      #   with:
+      #     driver: docker
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-single-buildx
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-single-buildx
 
-      - name: Install the devcontainer CLI
-        run: npm install -g @devcontainers/cli@0.49.0
+      # - name: Install the devcontainer CLI
+      #   run: npm install -g @devcontainers/cli@0.49.0
 
-      - name: Start the dev container
-        run: |
-          # Update the dev container definition to use docker-outside-of-docker instead of
-          # docker-in-docker so that the images built inside the dev container are available to the
-          # host (i.e. outside the dev container).
-          ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
+      # - name: Start the dev container
+      #   run: |
+      #     # Update the dev container definition to use docker-outside-of-docker instead of
+      #     # docker-in-docker so that the images built inside the dev container are available to the
+      #     # host (i.e. outside the dev container).
+      #     ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-          devcontainer up --workspace-folder ../sage-monorepo
+      #     devcontainer up --workspace-folder ../sage-monorepo
 
-      - name: Prepare the workspace in the dev container
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && workspace-install"
-
-      - name: Lint the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=lint"
-
-      - name: Build the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build"
-
-      - name: Test the affected projects (unit)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=test"
-
-      - name: Test the affected projects (integration)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=integration-test"
-
-      # - name: Build the images of the affected projects
+      # - name: Prepare the workspace in the dev container
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build-and-remove-image --parallel=1"
+      #       && workspace-install"
 
-      - name: Build the images of the SELECTED projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image \
-              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-              --parallel=1"
+      # - name: Lint the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=lint"
 
-      - name: Stop the dev container
-        run: docker rm -f sage_devcontainer
+      # - name: Build the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=build"
+
+      # - name: Test the affected projects (unit)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=test"
+
+      # - name: Test the affected projects (integration)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=integration-test"
+
+      # # - name: Build the images of the affected projects
+      # #   run: |
+      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      # #       && nx affected --target=build-and-remove-image --parallel=1"
+
+      # - name: Build the images of the SELECTED projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx run-many --target=build-and-remove-image \
+      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+      #         --parallel=1"
+
+      # - name: Stop the dev container
+      #   run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && sudo chown -R vscode:vscode /home/vscode/.cache/R/renv/cache \
-            && yarn nx run-many --target=prepare-r"
+            && ls -al /home/vscode/.cache/R/renv/cache"
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Prepare the workspace in the dev container
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=prepare-r"
+            && yarn nx run-many --target=prepare-r"
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,7 @@ jobs:
       - name: Prepare the workspace in the dev container
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && chown -R vscode:vscode /home/vscode/.cache/R/renv/cache \
             && yarn nx run-many --target=prepare-r"
 
       # - name: Lint the affected projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,13 +159,13 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
 
-      # - name: Set up Yarn cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: '**/.yarn/cache'
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
+      - name: Set up Yarn cache
+        uses: actions/cache@v3
+        with:
+          path: '**/.yarn/cache'
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Set up Renv cache
         uses: actions/cache@v3
@@ -225,6 +225,12 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c "
             sudo chown -R vscode:vscode /home/vscode/.cache
+            && . ./dev-env.sh \
+            && yarn install --immutable"
+
+      - name: Install R packages
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c "
             && . ./dev-env.sh \
             && yarn nx run-many --target=prepare-r"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Prepare the workspace in the dev container
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && chown -R vscode:vscode /home/vscode/.cache/R/renv/cache \
+            && sudo chown -R vscode:vscode /home/vscode/.cache/R/renv/cache \
             && yarn nx run-many --target=prepare-r"
 
       # - name: Lint the affected projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,11 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && yarn nx run-many --target=prepare-r"
 
+      - name: Enforce cache update for a local NX cache
+        run: |
+          STATE_CACHE_KEY="${{ runner.os }}-renv-${{ github.head_ref }}-${{ hashFiles('**/renv.lock') }}"
+          echo "STATE_CACHE_KEY=${STATE_CACHE_KEY}" >> $GITHUB_ENV
+
       # - name: Lint the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,14 +215,16 @@ jobs:
           # host (i.e. outside the dev container).
           ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
+          mkdir -p /tmp/.cache/R/renv/cache
+
           devcontainer up \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --workspace-folder ../sage-monorepo
 
-      # - name: Prepare the workspace in the dev container
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && workspace-install"
+      - name: Prepare the workspace in the dev container
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=prepare-r"
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Prepare the workspace in the dev container
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && chown -R vscode:vscode /home/vscode/.cache \
+            && sudo chown -R vscode:vscode /home/vscode/.cache \
             && ls -al /home/vscode/.cache/R/renv/cache"
 
       # - name: Lint the affected projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Prepare the workspace in the dev container
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && sudo chown -R vscode:vscode /home/vscode/.cache/R/renv/cache \
+            && chown -R vscode:vscode /home/vscode/.cache \
             && ls -al /home/vscode/.cache/R/renv/cache"
 
       # - name: Lint the affected projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,5 +265,5 @@ jobs:
       #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
       #         --parallel=1"
 
-      # - name: Stop the dev container
-      #   run: docker rm -f sage_devcontainer
+      - name: Stop the dev container
+        run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,10 @@ jobs:
       - name: Set up Renv cache
         uses: actions/cache@v3
         with:
-          path: '/tmp/.cache/R/renv/cache' # '~/.cache/R/renv/cache'
-          key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
+          path: '/tmp/.cache/R/renv/cache'
+          key: ${{ runner.os }}-renv-cache-${{ hashFiles('**/renv.lock') }}
           restore-keys: |
-            ${{ runner.os }}-renv-
+            ${{ runner.os }}-renv-cache-
 
       # - name: Setup poetry cache
       #   id: cache-poetry
@@ -232,11 +232,6 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && yarn nx run-many --target=prepare-r"
-
-      - name: Enforce cache update for a local NX cache
-        run: |
-          STATE_CACHE_KEY="${{ runner.os }}-renv-${{ github.head_ref }}-${{ hashFiles('**/renv.lock') }}"
-          echo "STATE_CACHE_KEY=${STATE_CACHE_KEY}" >> $GITHUB_ENV
 
       # - name: Lint the affected projects
       #   run: |


### PR DESCRIPTION
Contributes to #1975

## Description

Enable the caching of R packages when running the CI workflow. This PR makes the CI workflow runs 3 minutes faster as R packages are cached and no longer need to be downloaded for each run of the workflow.

## Changelog

- Cache R packages
- Remove `--mount type="bind,source=$HOME/.docker,target=/home/vscode/.docker"` from the workflow when pushing to `main`. It was not set for the workflow triggered by push to a PR so it should not be needed.

## Notes

- This PR is similar to #1979 but the tricky part (permissions) here is that the renv cache is outside of the repo folder cloned by the CI workflow (`~/.cache/R/renv/cache`).

## Preview

### Without caching Node.js packages (current)

<img width="643" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/cb6adce7-75eb-498b-83cc-0bfb35319d92">

### When caching Node.js packages (this PR)

<img width="647" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/cd59a692-8ddf-408c-a0be-b6ffebf734ed">