### PR TITLE
feat: Cache Poetry and venv in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,8 +265,8 @@ jobs:
 
       - name: Debug
         run: |
-        ls -al /tmp/.local/share/virtualenv
-        ls -al apps/schematic/api/.venv
+          ls -al /tmp/.local/share/virtualenv
+          ls -al apps/schematic/api/.venv
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,8 @@ jobs:
             && ls -al ~/.local/share/virtualenv \
             && ls -al apps/schematic/api/.venv"
 
-      - run: |
+      - name: Debug
+        run: |
         ls -al /tmp/.local/share/virtualenv
         ls -al apps/schematic/api/.venv
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,12 +188,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-renv-cache-
 
-      # - name: Setup poetry cache
-      #   id: cache-poetry
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ~/.local/share/virtualenvs
-      #     key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+      - name: Set up Poetry cache
+        uses: actions/cache@v3
+        with:
+          path: '/tmp/.cache/pypoetry'
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Set up venv cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            '/tmp/.local/share/virtualenv'
+            '**/.venv'
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
       # - name: Setup Gradle cache
       #   uses: actions/cache@v3
@@ -228,50 +235,57 @@ jobs:
           # host (i.e. outside the dev container).
           ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-          mkdir -p /tmp/.cache/R/renv/cache
+          mkdir -p \
+            /tmp/.cache/R/renv/cache \
+            /tmp/.cache/pypoetry \
+            /tmp/.local/share/virtualenv
 
           devcontainer up \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
+            --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \
+            --mount type=bind,source=/tmp/.local/share/virtualenv,target=/home/vscode/.local/share/virtualenv \
             --workspace-folder ../sage-monorepo
 
       - name: Prepare the workspace
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c "
-            sudo chown -R vscode:vscode /home/vscode/.cache \
+            sudo chown -R vscode:vscode \
+              /home/vscode/.cache \
+              /home/vscode/.local \
             && . ./dev-env.sh \
-            && workspace-install"
+            && yarn nx run-many --target=prepare-python"
 
-      - name: Lint the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=lint"
-
-      - name: Build the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build"
-
-      - name: Test the affected projects (unit)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=test"
-
-      - name: Test the affected projects (integration)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=integration-test"
-
-      # - name: Build the images of the affected projects
+      # - name: Lint the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build-and-remove-image --parallel=1"
+      #       && nx affected --target=lint"
 
-      - name: Build the images of the SELECTED projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image \
-              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-              --parallel=1"
+      # - name: Build the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=build"
 
-      - name: Stop the dev container
-        run: docker rm -f sage_devcontainer
+      # - name: Test the affected projects (unit)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=test"
+
+      # - name: Test the affected projects (integration)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=integration-test"
+
+      # # - name: Build the images of the affected projects
+      # #   run: |
+      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      # #       && nx affected --target=build-and-remove-image --parallel=1"
+
+      # - name: Build the images of the SELECTED projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx run-many --target=build-and-remove-image \
+      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+      #         --parallel=1"
+
+      # - name: Stop the dev container
+      #   run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,11 +189,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-renv-cache-
 
-      # - name: Set up Poetry cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: '/tmp/.cache/pypoetry'
-      #     key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+      - name: Set up Poetry cache
+        uses: actions/cache@v3
+        with:
+          path: '/tmp/.cache/pypoetry'
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
       # - name: Set up venv cache
       #   uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,37 +268,37 @@ jobs:
           ls -al /tmp/.local/share/virtualenv
           ls -al apps/schematic/api/.venv
 
-      # - name: Lint the affected projects
+      - name: Lint the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=lint"
+
+      - name: Build the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=build"
+
+      - name: Test the affected projects (unit)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=test"
+
+      - name: Test the affected projects (integration)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=integration-test"
+
+      # - name: Build the images of the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=lint"
+      #       && nx affected --target=build-and-remove-image --parallel=1"
 
-      # - name: Build the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build"
+      - name: Build the images of the SELECTED projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=build-and-remove-image \
+              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+              --parallel=1"
 
-      # - name: Test the affected projects (unit)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=test"
-
-      # - name: Test the affected projects (integration)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=integration-test"
-
-      # # - name: Build the images of the affected projects
-      # #   run: |
-      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      # #       && nx affected --target=build-and-remove-image --parallel=1"
-
-      # - name: Build the images of the SELECTED projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=build-and-remove-image \
-      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-      #         --parallel=1"
-
-      # - name: Stop the dev container
-      #   run: docker rm -f sage_devcontainer
+      - name: Stop the dev container
+        run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,12 @@ jobs:
               /home/vscode/.cache \
               /home/vscode/.local \
             && . ./dev-env.sh \
-            && yarn nx run-many --target=prepare-python"
+            && yarn install --immutable"
+
+      - name: Install Python packages
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=prepare-python"
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,27 +44,34 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-renv-cache-
 
-      - name: Setup poetry cache
-        id: cache-poetry
+      - name: Set up Poetry cache
         uses: actions/cache@v3
         with:
-          path: ~/.local/share/virtualenvs
+          path: '/tmp/.cache/pypoetry'
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Setup Gradle cache
+      - name: Set up venv cache
         uses: actions/cache@v3
         with:
           path: |
-            /root/.gradle/caches
-            /root/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+            /tmp/.local/share/virtualenv
+            **/.venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver: docker
+      # - name: Setup Gradle cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       /root/.gradle/caches
+      #       /root/.gradle/wrapper
+      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-gradle-
+
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+      #   with:
+      #     driver: docker
 
       # - name: Cache Docker layers
       #   uses: actions/cache@v3
@@ -81,7 +88,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install the devcontainer CLI
+      - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container
@@ -91,17 +98,23 @@ jobs:
           # host (i.e. outside the dev container).
           ./tools/switch-devcontainer-to-docker-outside-of-docker.sh
 
-          mkdir -p /tmp/.cache/R/renv/cache
+          mkdir -p \
+            /tmp/.cache/R/renv/cache \
+            /tmp/.cache/pypoetry \
+            /tmp/.local/share/virtualenv
 
           devcontainer up \
-            --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
+            --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \
+            --mount type=bind,source=/tmp/.local/share/virtualenv,target=/home/vscode/.local/share/virtualenv \
             --workspace-folder ../sage-monorepo
 
       - name: Prepare the workspace
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c "
-            sudo chown -R vscode:vscode /home/vscode/.cache \
+            sudo chown -R vscode:vscode \
+              /home/vscode/.cache \
+              /home/vscode/.local \
             && . ./dev-env.sh \
             && workspace-install"
 
@@ -226,7 +239,7 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-single-buildx
 
-      - name: Install the devcontainer CLI
+      - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0
 
       - name: Start the dev container
@@ -254,19 +267,7 @@ jobs:
               /home/vscode/.cache \
               /home/vscode/.local \
             && . ./dev-env.sh \
-            && yarn install --immutable"
-
-      - name: Install Python packages
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=prepare-python \
-            && ls -al ~/.local/share/virtualenv \
-            && ls -al apps/schematic/api/.venv"
-
-      - name: Debug
-        run: |
-          ls -al /tmp/.local/share/virtualenv
-          ls -al apps/schematic/api/.venv
+            && workspace-install"
 
       - name: Lint the affected projects
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,9 @@ jobs:
       - name: Install Python packages
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=prepare-python"
+            && nx run-many --target=prepare-python \
+            && ls -al ~/.local/share/virtualenv \
+            && ls -al apps/schematic/api/.venv"
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,13 +195,13 @@ jobs:
           path: '/tmp/.cache/pypoetry'
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
-      # - name: Set up venv cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       /tmp/.local/share/virtualenv
-      #       **/.venv
-      #     key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
+      - name: Set up venv cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /tmp/.local/share/virtualenv
+            **/.venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
       # - name: Setup Gradle cache
       #   uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            '/tmp/.local/share/virtualenv'
-            '**/.venv'
+            /tmp/.local/share/virtualenv
+            **/.venv
           key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
       # - name: Setup Gradle cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,5 +300,5 @@ jobs:
       #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
       #         --parallel=1"
 
-      - name: Stop the dev container
-        run: docker rm -f sage_devcontainer
+      # - name: Stop the dev container
+      #   run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,19 +189,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-renv-cache-
 
-      - name: Set up Poetry cache
-        uses: actions/cache@v3
-        with:
-          path: '/tmp/.cache/pypoetry'
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+      # - name: Set up Poetry cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: '/tmp/.cache/pypoetry'
+      #     key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Set up venv cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            /tmp/.local/share/virtualenv
-            **/.venv
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
+      # - name: Set up venv cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       /tmp/.local/share/virtualenv
+      #       **/.venv
+      #     key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
       # - name: Setup Gradle cache
       #   uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,5 +292,5 @@ jobs:
       #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
       #         --parallel=1"
 
-      # - name: Stop the dev container
-      #   run: docker rm -f sage_devcontainer
+      - name: Stop the dev container
+        run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,10 @@ jobs:
             && ls -al ~/.local/share/virtualenv \
             && ls -al apps/schematic/api/.venv"
 
+      - run: |
+        ls -al /tmp/.local/share/virtualenv
+        ls -al apps/schematic/api/.venv
+
       # - name: Lint the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \


### PR DESCRIPTION
Contributes to #1975 

## Description

TODO

Time to run `nx run-many --target=prepare-python`:

- Without any caching: 
  - 4m18s (1 run)
- When caching Poetry cache folder: 
  - 2m45s (1 run)
- When caching venvs:
  - 3m (1 run)
  - For projects that have their `.venv` folder in the project folder,  the logs show that there are no packages to install when using the venv cache. Yet the "gain" of time is not strikingly apparent.
  - It could be that the packages are cached with poetry and that installing them is relatively fast.
  - It takes 12s to run `prepare-python` for `schematic-api` when caching Poetry and venv.
  - It takes 30s to run `prepare-python` for `schematic-api` when caching only Poetry.
  - For now I will continue to cache venv though it seems that its content may overlap with the content cached with Poetry. Since `actions/cache@v3` is limited to 10GB (total or for one cache?), no longer caching venv may be a way to save space without increasing the time it takes to run `prepare-python` too much.

## Notes

Single quotes should not be used when specifying multiple paths of cached folders.

Incorrect:

```yaml
      - name: Set up venv cache
        uses: actions/cache@v3
        with:
          path: |
            '/tmp/.local/share/virtualenv'
            '**/.venv'
          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
```

Correct:

```yaml
      - name: Set up venv cache
        uses: actions/cache@v3
        with:
          path: |
            /tmp/.local/share/virtualenv
            **/.venv
          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
```

## Preview

### Without caching (current)

### When caching (this PR)