### PR TITLE
feat: Cache Gradle in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,5 +313,5 @@ jobs:
               --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 
-      - name: Stop the dev container
-        run: docker rm -f sage_devcontainer
+      # - name: Stop the dev container
+      #   run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,15 @@ jobs:
             **/.venv
           key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
-      # - name: Setup Gradle cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       /root/.gradle/caches
-      #       /root/.gradle/wrapper
-      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-gradle-
+      - name: Set up Gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /tmp/.gradle/caches
+            /tmp/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v2
@@ -101,13 +101,17 @@ jobs:
           mkdir -p \
             /tmp/.cache/R/renv/cache \
             /tmp/.cache/pypoetry \
-            /tmp/.local/share/virtualenv
+            /tmp/.local/share/virtualenv \
+            /tmp/.gradle/caches \
+            /tmp/.gradle/wrapper
 
           devcontainer up \
             --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \
             --mount type=bind,source=/tmp/.local/share/virtualenv,target=/home/vscode/.local/share/virtualenv \
+            --mount type=bind,source=/tmp/.gradle/caches,target=/home/vscode/.gradle/caches \
+            --mount type=bind,source=/tmp/.gradle/wrapper,target=/home/vscode/.gradle/wrapper \
             --workspace-folder ../sage-monorepo
 
       - name: Prepare the workspace
@@ -116,6 +120,7 @@ jobs:
             sudo chown -R vscode:vscode \
               /home/vscode/.cache \
               /home/vscode/.local \
+              /home/vscode/.gradle \
             && . ./dev-env.sh \
             && workspace-install"
 
@@ -217,15 +222,15 @@ jobs:
             **/.venv
           key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
-      # - name: Set up Gradle cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       /tmp/.gradle/caches
-      #       /tmp/.gradle/wrapper
-      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-gradle-
+      - name: Set up Gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /tmp/.gradle/caches
+            /tmp/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v2
@@ -258,6 +263,7 @@ jobs:
             /tmp/.gradle/wrapper
 
           devcontainer up \
+            --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \
             --mount type=bind,source=/tmp/.local/share/virtualenv,target=/home/vscode/.local/share/virtualenv \
@@ -273,44 +279,39 @@ jobs:
               /home/vscode/.local \
               /home/vscode/.gradle \
             && . ./dev-env.sh \
-            && yarn install --immutable"
+            && workspace-install"
 
-      - name: Install Gradle packages
+      - name: Lint the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=prepare-java --parallel=1"
+            && nx affected --target=lint"
 
-      # - name: Lint the affected projects
+      - name: Build the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=build"
+
+      - name: Test the affected projects (unit)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=test"
+
+      - name: Test the affected projects (integration)
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=integration-test"
+
+      # - name: Build the images of the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=lint"
+      #       && nx affected --target=build-and-remove-image --parallel=1"
 
-      # - name: Build the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build"
+      - name: Build the images of the SELECTED projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx run-many --target=build-and-remove-image \
+              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+              --parallel=1"
 
-      # - name: Test the affected projects (unit)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=test"
-
-      # - name: Test the affected projects (integration)
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=integration-test"
-
-      # # - name: Build the images of the affected projects
-      # #   run: |
-      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      # #       && nx affected --target=build-and-remove-image --parallel=1"
-
-      # - name: Build the images of the SELECTED projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx run-many --target=build-and-remove-image \
-      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-      #         --parallel=1"
-
-      # - name: Stop the dev container
-      #   run: docker rm -f sage_devcontainer
+      - name: Stop the dev container
+        run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,5 +313,5 @@ jobs:
               --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 
-      # - name: Stop the dev container
-      #   run: docker rm -f sage_devcontainer
+      - name: Stop the dev container
+        run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Install Gradle packages
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            nx run-many --target=prepare-java --parallel=1"
+            && nx run-many --target=prepare-java --parallel=1"
 
       # - name: Lint the affected projects
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,12 +216,12 @@ jobs:
             **/.venv
           key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
 
-      # - name: Setup Gradle cache
+      # - name: Set up Gradle cache
       #   uses: actions/cache@v3
       #   with:
       #     path: |
-      #       /root/.gradle/caches
-      #       /root/.gradle/wrapper
+      #       /tmp/.gradle/caches
+      #       /tmp/.gradle/wrapper
       #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
       #     restore-keys: |
       #       ${{ runner.os }}-gradle-
@@ -252,12 +252,16 @@ jobs:
           mkdir -p \
             /tmp/.cache/R/renv/cache \
             /tmp/.cache/pypoetry \
-            /tmp/.local/share/virtualenv
+            /tmp/.local/share/virtualenv \
+            /tmp/.gradle/caches \
+            /tmp/.gradle/wrapper
 
           devcontainer up \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \
             --mount type=bind,source=/tmp/.local/share/virtualenv,target=/home/vscode/.local/share/virtualenv \
+            --mount type=bind,source=/tmp/.gradle/caches,target=/home/vscode/.gradle/caches \
+            --mount type=bind,source=/tmp/.gradle/wrapper,target=/home/vscode/.gradle/wrapper \
             --workspace-folder ../sage-monorepo
 
       - name: Prepare the workspace
@@ -266,40 +270,46 @@ jobs:
             sudo chown -R vscode:vscode \
               /home/vscode/.cache \
               /home/vscode/.local \
+              /home/vscode/.gradle \
             && . ./dev-env.sh \
-            && workspace-install"
+            && yarn install --immutable"
 
-      - name: Lint the affected projects
+      - name: Install Gradle packages
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=lint"
+            nx run-many --target=prepare-java --parallel=1"
 
-      - name: Build the affected projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=build"
-
-      - name: Test the affected projects (unit)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=test"
-
-      - name: Test the affected projects (integration)
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=integration-test"
-
-      # - name: Build the images of the affected projects
+      # - name: Lint the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build-and-remove-image --parallel=1"
+      #       && nx affected --target=lint"
 
-      - name: Build the images of the SELECTED projects
-        run: |
-          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image \
-              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
-              --parallel=1"
+      # - name: Build the affected projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=build"
 
-      - name: Stop the dev container
-        run: docker rm -f sage_devcontainer
+      # - name: Test the affected projects (unit)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=test"
+
+      # - name: Test the affected projects (integration)
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx affected --target=integration-test"
+
+      # # - name: Build the images of the affected projects
+      # #   run: |
+      # #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      # #       && nx affected --target=build-and-remove-image --parallel=1"
+
+      # - name: Build the images of the SELECTED projects
+      #   run: |
+      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+      #       && nx run-many --target=build-and-remove-image \
+      #         --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+      #         --parallel=1"
+
+      # - name: Stop the dev container
+      #   run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
             /tmp/.local/share/virtualenv
 
           devcontainer up \
+            --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \
             --mount type=bind,source=/tmp/.local/share/virtualenv,target=/home/vscode/.local/share/virtualenv \


### PR DESCRIPTION
Contributes to #1975 

## Description

Cache the Gradle cache.

## Notes

It is difficult to evaluate how much time is saved with this feature because the task `prepare-java` only install the Gradle wrapper. This task does not download and install the dependencies as the tasks `prepare-python` and `prepare-r` do. Here the approach implemented for Java project is more efficient as packages are downloaded only when needed.

The content of the Gradle cache folder in my dev container is about 400MB. These is at least as much data that will not need to be downloaded again and again.

```console
$ du -h --max-depth=0 ~/.gradle/caches
391M    /home/vscode/.gradle/caches
```

This is also visible when looking at the content of the cache (post cache):

```console
Post job cleanup.
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/sage-monorepo/sage-monorepo --files-from manifest.txt --use-compress-program zstdmt
Cache Size: ~356 MB (373805837 B)
Cache saved successfully
Cache saved with key: Linux-gradle-fc352e85e08d63602693013dcdfde5c7f6b45cc5bd4adf5bacce1ee476e744da
```