### PR TITLE
feat: Update the devcontainer to access SonarScanner CLI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Sage Dev Container",
-  "image": "ghcr.io/sage-bionetworks/sage-devcontainer:55645b0",
+  "image": "ghcr.io/sage-bionetworks/sage-devcontainer:15ec53e",
 
   "containerEnv": {
     "NX_BASE": "${localEnv:NX_BASE}",

--- a/apps/schematic/api/.gitignore
+++ b/apps/schematic/api/.gitignore
@@ -1,3 +1,5 @@
+.scannerwork
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Closes #1998

## Changelog

- Update the devcontainer to get access to the SonarScanner CLI

## Notes

- The scans shown below are run manually.
- Project folders would be scanned by a GH workflow if we decide to adopt Sonar tools.

## Preview

### SonarScanner CLI

```console
$ sonar-scanner --version
INFO: Scanner configuration file: /opt/sonar-scanner/conf/sonar-scanner.properties
INFO: Project root configuration file: NONE
INFO: SonarScanner 5.0.1.3006
INFO: Java 17.0.8 Private Build (64-bit)
INFO: Linux 4.14.320-243.544.amzn2.x86_64 amd64
```

### Manual scanning

Create a project on SonarCloud and follow the instructions. For a project of type "Other", which include Python projects, the SonarScanner CLI must be used. E.g.

```console
sonar-scanner \
   -Dsonar.organization=tschaffter \
   -Dsonar.projectKey=schematic-api \
   -Dsonar.sources=. \
   -Dsonar.host.url=https://sonarcloud.io
```

### Scanning the project `schematic-api`

The results are available [here](https://sonarcloud.io/project/overview?id=schematic-api).

![Screen Shot 2023-08-21 at 13 18 04](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/410383da-5878-4305-9cc4-70f783eb3649)

### Scanning the official Schematic repo

Here I scan my fork of the repo [Sage-Bionetworks/schematic](https://github.com/Sage-Bionetworks/schematic) that I last updated around the time I joined the Tiger Team (Dec. 2022).

The results are available [here](https://sonarcloud.io/summary/overall?id=tschaffter_schematic).

![Screen Shot 2023-08-21 at 13 21 45](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/15c5c3d5-462e-40d0-ae3e-f600025a1bf6)

cc: @rrchai @vpchung @andrewelamb @linglp @milen-sage @thomasyu888 