### PR TITLE
fix: Disable docker push in CI workflow on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,10 +141,10 @@ jobs:
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
       #       && nx affected --target=publish-and-remove-image --parallel=1"
 
-      - name: Publish the images of the SELECTED projects
+      - name: BUILDING the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-and-remove-image \
+            && nx run-many --target=build-and-remove-image \
               --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 


### PR DESCRIPTION
## Description

Disable the push of images to GHCR in CI workflow. This is a temporary measure to enable other contributors to merge to `main`. This quick fix will be permanently solved in #2013.