### PR TITLE
feat: Navigate to search pages when clicking on the home page stats

### DIFF
--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -2,22 +2,34 @@
   <div class="container">
     <h3 class="section-title">Current Landscape</h3>
     <div class="row">
-      <div class="col text-center">
+      <div class="col text-center clickable" routerLink="/challenge">
         <img
           class="logo-icon"
           src="/openchallenges-assets/images/graphic-challenges.svg"
           alt="Number of challenges"
         />
-        <h2 *ngIf="challengeCount$ | async as challengeCount" [countUp]="challengeCount">0</h2>
+        <h2
+          *ngIf="challengeCount$ | async as challengeCount"
+          [countUp]="challengeCount"
+          [reanimateOnClick]="reanimateOnClick"
+        >
+          0
+        </h2>
         <p>annotated challenges</p>
       </div>
-      <div class="col text-center">
+      <div class="col text-center clickable" routerLink="/org">
         <img
           class="logo-icon"
           src="/openchallenges-assets/images/graphic-hosts.svg"
           alt="Number of organizations & hosting societies"
         />
-        <h2 *ngIf="orgCount$ | async as orgCount" [countUp]="orgCount">0</h2>
+        <h2
+          *ngIf="orgCount$ | async as orgCount"
+          [countUp]="orgCount"
+          [reanimateOnClick]="reanimateOnClick"
+        >
+          0
+        </h2>
         <p>organizations & hosting societies</p>
       </div>
       <!-- <div class="col text-center">

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
@@ -39,3 +39,7 @@ $screen-lg: 641px;
     }
   }
 }
+
+.clickable {
+  cursor: pointer;
+}

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -9,15 +9,17 @@ import {
 } from '@sagebionetworks/openchallenges/api-client-angular';
 import { CountUpModule } from 'ngx-countup';
 import { Observable, map } from 'rxjs';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'openchallenges-statistics-viewer',
   standalone: true,
-  imports: [CommonModule, CountUpModule],
+  imports: [CommonModule, RouterModule, CountUpModule],
   templateUrl: './statistics-viewer.component.html',
   styleUrls: ['./statistics-viewer.component.scss'],
 })
 export class StatisticsViewerComponent implements OnInit {
+  reanimateOnClick = false;
   challengeImg$: Observable<Image> | undefined;
   orgImg$: Observable<Image> | undefined;
   userImg$: Observable<Image> | undefined;


### PR DESCRIPTION
Closes #1869 

## Changelog

- Disable the count-up animation when clicking on the stats
- Redirect to the challenge and org search pages when clicking on the corresponding stats
