### PR TITLE
chore: Update Docker-in-Docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,9 @@
   },
 
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2.2.0": {
-      "version": "20.10.24"
+    "ghcr.io/devcontainers/features/docker-in-docker:2.4.0": {
+      "version": "24.0.5",
+      "moby": false
     }
   },
 


### PR DESCRIPTION
## Changelog

- Update from Docker `20.10.24` to `24.0.5`
- Update the docker-in-docker feature

## Notes

- Docker now uses SemVer instead of CalVer
- Since Docker `23.0`, Buildx must be installed separately as a plugin. Thankfully, the feature docker-in-docker takes care of that for us (see option [`installDockerBuildx`](https://github.com/devcontainers/features/tree/main/src/docker-in-docker) set to true by default)

## How was this PR tested?

1. Rebuild the dev container to get access to the new version of Docker
2. Set up the workspace: `workspace-install`
3. Build all the OC images: `openchallenges-build-images`
4. Start the OC stack: `nx serve-detach openchallenges-apex`
5. Test the web app in the browser

## Preview

```console
$ docker --version
Docker version 24.0.5, build ced0996
```