### PR TITLE
docs: Annotate projects with `language` and `package-manager` tags

### DIFF
--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -107,6 +107,6 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": ["openchallenges-app-config-data"]
 }

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -253,7 +253,7 @@
       }
     }
   },
-  "tags": ["type:app", "scope:client"],
+  "tags": ["type:app", "scope:client", "language:typescript"],
   "implicitDependencies": [
     "openchallenges-styles",
     "openchallenges-themes",

--- a/apps/openchallenges/auth-service/project.json
+++ b/apps/openchallenges/auth-service/project.json
@@ -63,7 +63,7 @@
       "dependsOn": ["^install"]
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-api-gateway",
     "openchallenges-keycloak",

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -125,6 +125,6 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": ["openchallenges-app-config-data", "shared-java-util"]
 }

--- a/apps/openchallenges/challenge-to-elasticsearch-service/project.json
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/project.json
@@ -81,7 +81,7 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-app-config-data",
     "openchallenges-kafka-admin",

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -119,6 +119,6 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": ["openchallenges-app-config-data"]
 }

--- a/apps/openchallenges/core-service/project.json
+++ b/apps/openchallenges/core-service/project.json
@@ -57,7 +57,7 @@
       "dependsOn": ["^install"]
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-api-gateway",
     "openchallenges-keycloak",

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -135,6 +135,6 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": ["openchallenges-app-config-data", "shared-java-util"]
 }

--- a/apps/openchallenges/kaggle-to-kafka-service/project.json
+++ b/apps/openchallenges/kaggle-to-kafka-service/project.json
@@ -81,7 +81,7 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-app-config-data",
     "openchallenges-kafka-admin",

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -128,6 +128,6 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": ["openchallenges-app-config-data", "shared-java-util"]
 }

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -107,6 +107,6 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": ["openchallenges-app-config-data"]
 }

--- a/apps/openchallenges/user-service/project.json
+++ b/apps/openchallenges/user-service/project.json
@@ -81,7 +81,7 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-api-gateway",
     "openchallenges-keycloak",

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -123,6 +123,6 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"],
+  "tags": ["type:service", "scope:backend", "language:python", "package-manager:poetry"],
   "implicitDependencies": ["schematic-api-description"]
 }

--- a/libs/openchallenges/about/project.json
+++ b/libs/openchallenges/about/project.json
@@ -31,6 +31,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/api-client-angular/project.json
+++ b/libs/openchallenges/api-client-angular/project.json
@@ -52,6 +52,6 @@
       }
     }
   },
-  "tags": [],
+  "tags": ["language:typescript"],
   "implicitDependencies": ["openchallenges-api-description"]
 }

--- a/libs/openchallenges/api-client-r/project.json
+++ b/libs/openchallenges/api-client-r/project.json
@@ -53,7 +53,7 @@
       }
     }
   },
-  "tags": [],
+  "tags": ["language:r", "package-manager:renv"],
   "implicitDependencies": [
     "openchallenges-api-description"
   ]

--- a/libs/openchallenges/app-config-data/project.json
+++ b/libs/openchallenges/app-config-data/project.json
@@ -51,5 +51,5 @@
       }
     }
   },
-  "tags": ["type:library", "scope:openchallenges"]
+  "tags": ["type:library", "scope:openchallenges", "language:java", "package-manager:gradle"]
 }

--- a/libs/openchallenges/assets/project.json
+++ b/libs/openchallenges/assets/project.json
@@ -5,6 +5,6 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:assets", "scope:openchallenges"],
+  "tags": ["type:assets", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/challenge-search/project.json
+++ b/libs/openchallenges/challenge-search/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/challenge/project.json
+++ b/libs/openchallenges/challenge/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/config/project.json
+++ b/libs/openchallenges/config/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/home/project.json
+++ b/libs/openchallenges/home/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/kafka-admin/project.json
+++ b/libs/openchallenges/kafka-admin/project.json
@@ -52,6 +52,6 @@
       }
     }
   },
-  "tags": ["type:library", "scope:openchallenges"],
+  "tags": ["type:library", "scope:openchallenges", "language:java", "package-manager:gradle"],
   "implicitDependencies": ["openchallenges-app-config-data"]
 }

--- a/libs/openchallenges/kafka-consumer/project.json
+++ b/libs/openchallenges/kafka-consumer/project.json
@@ -52,7 +52,7 @@
       }
     }
   },
-  "tags": ["type:library", "scope:openchallenges"],
+  "tags": ["type:library", "scope:openchallenges", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-app-config-data",
     "openchallenges-kafka-admin",

--- a/libs/openchallenges/kafka-model/project.json
+++ b/libs/openchallenges/kafka-model/project.json
@@ -51,5 +51,5 @@
       }
     }
   },
-  "tags": ["type:library", "scope:openchallenges"]
+  "tags": ["type:library", "scope:openchallenges", "language:java", "package-manager:gradle"]
 }

--- a/libs/openchallenges/kafka-producer/project.json
+++ b/libs/openchallenges/kafka-producer/project.json
@@ -52,7 +52,7 @@
       }
     }
   },
-  "tags": ["type:library", "scope:openchallenges"],
+  "tags": ["type:library", "scope:openchallenges", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-app-config-data",
     "openchallenges-kafka-admin",

--- a/libs/openchallenges/not-found/project.json
+++ b/libs/openchallenges/not-found/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/org-profile/project.json
+++ b/libs/openchallenges/org-profile/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/org-search/project.json
+++ b/libs/openchallenges/org-search/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/signup/project.json
+++ b/libs/openchallenges/signup/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/styles/project.json
+++ b/libs/openchallenges/styles/project.json
@@ -5,6 +5,6 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:styles", "scope:openchallenges"],
+  "tags": ["type:styles", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/team/project.json
+++ b/libs/openchallenges/team/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/themes/project.json
+++ b/libs/openchallenges/themes/project.json
@@ -5,6 +5,6 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:themes", "scope:openchallenges"],
+  "tags": ["type:themes", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/ui/project.json
+++ b/libs/openchallenges/ui/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/user-profile/project.json
+++ b/libs/openchallenges/user-profile/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:openchallenges"],
+  "tags": ["type:feature", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/openchallenges/util/project.json
+++ b/libs/openchallenges/util/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:util", "scope:openchallenges"],
+  "tags": ["type:util", "scope:openchallenges", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/schematic/api-client-angular/project.json
+++ b/libs/schematic/api-client-angular/project.json
@@ -56,6 +56,6 @@
       }
     }
   },
-  "tags": [],
+  "tags": ["language:typescript"],
   "implicitDependencies": ["schematic-api-description"]
 }

--- a/libs/schematic/api-client-python/project.json
+++ b/libs/schematic/api-client-python/project.json
@@ -25,7 +25,7 @@
       }
     }
   },
-  "tags": [],
+  "tags": ["language:python", "package-manager:poetry"],
   "implicitDependencies": [
     "schematic-api-description"
   ]

--- a/libs/shared/java/util/project.json
+++ b/libs/shared/java/util/project.json
@@ -39,5 +39,5 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:shared"]
+  "tags": ["type:feature", "scope:shared", "language:java", "package-manager:gradle"]
 }

--- a/libs/shared/typescript/assets/project.json
+++ b/libs/shared/typescript/assets/project.json
@@ -5,5 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:assets", "scope:shared"]
+  "tags": ["type:assets", "scope:shared", "language:typescript"]
 }

--- a/libs/shared/typescript/styles/project.json
+++ b/libs/shared/typescript/styles/project.json
@@ -5,5 +5,5 @@
   "projectType": "library",
   "generators": {},
   "targets": {},
-  "tags": ["type:styles", "scope:shared"]
+  "tags": ["type:styles", "scope:shared", "language:typescript"]
 }

--- a/libs/shared/typescript/themes/project.json
+++ b/libs/shared/typescript/themes/project.json
@@ -5,6 +5,6 @@
   "sourceRoot": "libs/shared/typescript/themes/src",
   "prefix": "shared",
   "targets": {},
-  "tags": ["type:themes", "scope:shared"],
+  "tags": ["type:themes", "scope:shared", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/shared/typescript/util/project.json
+++ b/libs/shared/typescript/util/project.json
@@ -23,6 +23,6 @@
       }
     }
   },
-  "tags": ["type:util", "scope:shared"],
+  "tags": ["type:util", "scope:shared", "language:typescript"],
   "implicitDependencies": []
 }

--- a/libs/shared/typescript/web-components/project.json
+++ b/libs/shared/typescript/web-components/project.json
@@ -20,5 +20,5 @@
       }
     }
   },
-  "tags": ["type:feature", "scope:shared"]
+  "tags": ["type:feature", "scope:shared", "language:typescript"]
 }


### PR DESCRIPTION
Closes #1989

## Description

The goal of this PR is to start annotating projects with the following tags:

- `language`: Programming language used by the project. Valid values are `python`, `java`, `typescript`, `r`.
- `package-manager`: Tool used to track the dependencies of the project. Valid values are `poetry`, `gradle`, `renv`.

Ultimately, we will add a workflow that checks that every projects are properly annotated.

## Why not specify the tag `package-manager` for TypeScript projects?

The package manager is currently Yarn, though we will migrate to pnpm in the near future (see #2003).

npm packages are centralized at the workspace root level (see `package.json`) and are installed outside of the scope of the projects. Because TypeScript projects are not expected to run the package manager - unlike Python, Java and R projects - I decided to not specify the tag `package-manager` for these TypeScript projects.

## How can these tags be useful?

Currently, the command `workspace-install` defined in `dev-env.sh` runs the following tasks:

```console
  nx run-many --target=prepare-java --parallel=1
  nx run-many --target=prepare-python
  nx run-many --target=prepare-r
```

The issue with this approach is that we have to document that

- if you have a Java project, you need to implement the task `prepare-java`
- if you have a Python project, you need to implement the task `prepare-python`
- etc.

Using annotation, we can simply say that the task `prepare` should install the dependencies and enable any other tasks that the project may implement.

The commands run as part of `workspace-install` could then be replaced by

```console
  nx run-many --target=prepare --tags=language:java --parallel=1
  nx run-many --target=prepare --tags=language:python
  nx run-many --target=prepare --tags=language:r
```

or shorter and potentially faster:

```console
  nx run-many --target=prepare --tags=language:java --parallel=1
  nx run-many --target=prepare --tags=language:python,language:r
```

> **warning**
> Installing the Gradle wrappers in parallel sometimes lead to issues due to concurrent downloads and writing to disk of the wrapper. This is why Java projects need to be prepared one at a time (`--parallel=1`). The preparation of Java projects takes currently less than 1s each because only the Gradle wrapper is downloaded. With Gradle, Java dependencies are downloaded when needed.