### PR TITLE
ci: Push Sonar scan results when pushing to `main`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
     "NX_CLOUD_ENCRYPTION_KEY": "${localEnv:NX_CLOUD_ENCRYPTION_KEY}",
     "NX_CLOUD_ENV_NAME": "${localEnv:NX_CLOUD_ENV_NAME}",
     "NX_HEAD": "${localEnv:NX_HEAD}",
-    "NX_RUN_GROUP": "${localEnv:NX_RUN_GROUP}"
+    "NX_RUN_GROUP": "${localEnv:NX_RUN_GROUP}",
+    "SONAR_TOKEN": "${localEnv:SONAR_TOKEN}"
   },
 
   "features": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,11 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=integration-test"
 
+      - name: Scan the affected projects with Sonar
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && nx affected --target=sonar"
+
       # - name: Publish the images of the affected projects
       #   run: |
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \

--- a/apps/openchallenges/image-service/build.gradle
+++ b/apps/openchallenges/image-service/build.gradle
@@ -137,7 +137,7 @@ jacocoTestReport {
 sonar {
   properties {
     property("sonar.projectKey", "openchallenges-image-service")
-    property("sonar.organization", "tschaffter")
+    property("sonar.organization", "sage-bionetworks")
     property("sonar.host.url", "https://sonarcloud.io")
   }
 }


### PR DESCRIPTION
Closes #2042 

## Description

Start pushing the results of Sonar scan for projects that implement the task `sonar` to SonarCloud.

New OC image service SonarCloud project: https://sonarcloud.io/project/overview?id=openchallenges-image-service

## Changelog

- Update the Sonar config of OC image service to push to its new project
- Add step to the CI workflow to generate and push the results of Sonar scans
- Pass the environment variables `SONAR_TOKEN` to the dev container

## Notes

> **note**
> This PR modifies `devcontainer.json`, which will prompt users to rebuild their dev container.

## How to scan a Sage Monorepo project and publish the results with Sonar?

- Ask @tschaffter to create a corresponding projects on SonarCloud.io
- Search Sage Monorepo for a project that already implement the task `sonar` and that use the same programming language as your project.
  - If you found at least one project, use it as example.
  - If no such project exists, contact @tschaffter for help to create the task `sonar`

## Preview

https://sonarcloud.io/project/overview?id=openchallenges-image-service

<img width="1438" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/3dacfbc2-585a-46d9-8906-6e599e8887ae">

### Badges

[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=coverage)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=openchallenges-image-service&metric=bugs)](https://sonarcloud.io/summary/new_code?id=openchallenges-image-service)

## Cc

- Schematic: @andrewelamb
- Agora: @sagely1 
- Synapse (API client): @thomasyu888 
