### PR TITLE
chore: Remove Cython patch from `schematic-api`

### DIFF
--- a/apps/schematic/api/prepare-python.sh
+++ b/apps/schematic/api/prepare-python.sh
@@ -10,6 +10,4 @@ eval "$(pyenv init -)"
 
 pyenv local $PYTHON_VERSION
 poetry env use $PYTHON_VERSION
-poetry run pip install "cython<3.0.0"
-poetry run pip install --no-build-isolation pyyaml==5.4.1
 poetry install --with prod,dev


### PR DESCRIPTION
Contributes to #2036 

## Changelog

- Remove the Cython patch required for `schematic-api` to work with an earlier version of Python.

## Notes

- The project `schematic-api` works now fine with Python 3.10.12 without the Cython patch.