### PR TITLE
ci: Scan Schematic API with Sonar

### DIFF
--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -16,7 +16,7 @@
     "sonar": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "bash $WORKSPACE_DIR/tools/sonar-scanner.sh {projectName} src/",
+        "command": "bash $WORKSPACE_DIR/tools/sonar-scanner.sh {projectName}",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -121,6 +121,13 @@
         "command": "poetry run tox",
         "cwd": "apps/schematic/api"
       }
+    },
+    "sonar": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "bash $WORKSPACE_DIR/tools/sonar-scanner.sh {projectName}",
+        "cwd": "{projectRoot}"
+      }
     }
   },
   "tags": ["type:service", "scope:backend", "language:python", "package-manager:poetry"],

--- a/tools/sonar-scanner.sh
+++ b/tools/sonar-scanner.sh
@@ -2,7 +2,7 @@
 
 if [ $# -lt 1 ]
 then
-  echo "The argument <project_key> and <sources> (optional) must be provided."
+  echo "The argument <project_key> must be specified."
   exit 1
 fi
 

--- a/tools/sonar-scanner.sh
+++ b/tools/sonar-scanner.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-if [ $# -lt 2 ]
+if [ $# -lt 1 ]
 then
-  echo "The arguments <project_key> and <sources> must be provided."
+  echo "The argument <project_key> and <sources> (optional) must be provided."
   exit 1
 fi
 
 PROJECT_KEY="$1"
-SOURCES="$2"
+SOURCES="${2:-$PWD}"
 
 echo "Project key: $PROJECT_KEY"
 echo "Sources: $SOURCES"


### PR DESCRIPTION
Closes #2053

## Description

Scan the project `schematic-api` and push the report to SonarCloud when pushing to the branch `main`.

## Changelog

- Add the task `sonar` to the project `schematic-api`
- Simplify the syntax of the task `sonar`
- Update the task `sonar` for the project `openchallenges-app`

## Preview

See the [scan report](https://sonarcloud.io/summary/overall?id=schematic-api) for `schematic-api` on SonarCloud.