### PR TITLE
ci: Configure Sonar for the challenge service

### DIFF
--- a/apps/openchallenges/challenge-service/build.gradle
+++ b/apps/openchallenges/challenge-service/build.gradle
@@ -9,7 +9,9 @@ buildscript {
 
 plugins {
   id 'com.diffplug.spotless' version "${spotlessVersion}"
+  id 'jacoco'
   id 'java'
+  id 'org.sonarqube' version "${sonarqubeVersion}"
   id 'org.springframework.boot' version "${springBootVersion}"
   id "io.spring.dependency-management" version "${springDependencyManagementVersion}"
   id "org.flywaydb.flyway" version "${flywaydbVersion}"
@@ -76,6 +78,36 @@ java {
 
 tasks.withType(JavaCompile) {
   options.encoding = 'UTF-8'
+}
+
+test {
+  testLogging.showStandardStreams = true
+
+  beforeTest { descriptor ->
+     logger.lifecycle("Running test: " + descriptor)
+  }
+
+  failFast = true
+
+  testLogging {
+    events("passed", "skipped", "failed")
+  }
+
+  finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+  reports {
+    xml.required = true
+  }
+}
+
+sonar {
+  properties {
+    property("sonar.projectKey", "${project.name}")
+    property("sonar.organization", "sage-bionetworks")
+    property("sonar.host.url", "https://sonarcloud.io")
+  }
 }
 
 bootBuildImage {

--- a/apps/openchallenges/challenge-service/gradle.properties
+++ b/apps/openchallenges/challenge-service/gradle.properties
@@ -4,6 +4,7 @@ hibernateSearchVersion=6.1.7.Final
 keycloakVersion=19.0.3
 lombokVersion=1.18.24
 openchallengesVersion=0.0.1-SNAPSHOT
+sonarqubeVersion=4.3.0.3225
 spotlessVersion=6.11.0
 springBootVersion=2.7.8
 springCloudVersion=3.1.4

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -8,47 +8,62 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/challenge-service"
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/challenge-service"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {
-        "root": "apps/openchallenges/challenge-service"
+        "root": "{projectRoot}"
       },
       "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
+    "test": {
+      "executor": "@nxrocks/nx-spring-boot:test",
+      "options": {
+        "root": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
+    },
+    "sonar": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./gradlew sonar",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["test"]
+    },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",
       "options": {
-        "root": "apps/openchallenges/challenge-service"
+        "root": "{projectRoot}"
       }
     },
     "format": {
       "executor": "@nxrocks/nx-spring-boot:format",
       "options": {
-        "root": "apps/openchallenges/challenge-service"
+        "root": "{projectRoot}"
       }
     },
     "format-check": {
       "executor": "@nxrocks/nx-spring-boot:check-format",
       "options": {
-        "root": "apps/openchallenges/challenge-service"
+        "root": "{projectRoot}"
       }
     },
     "serve": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew build --continuous", "./gradlew bootRun"],
-        "cwd": "apps/openchallenges/challenge-service",
+        "cwd": "{projectRoot}",
         "parallel": true
       },
       "dependsOn": ["^install"]
@@ -56,14 +71,14 @@
     "serve-detach": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker/openchallenges/serve-detach.sh openchallenges-challenge-service"
+        "command": "docker/openchallenges/serve-detach.sh {projectName}"
       },
       "dependsOn": []
     },
     "build-image-base": {
       "executor": "@nxrocks/nx-spring-boot:build-image",
       "options": {
-        "root": "apps/openchallenges/challenge-service"
+        "root": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },
@@ -72,7 +87,7 @@
       "options": {
         "context": "apps/openchallenges/challenge-service",
         "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/openchallenges-challenge-service"],
+          "images": ["ghcr.io/sage-bionetworks/{projectName}"],
           "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
         },
         "push": false
@@ -84,7 +99,7 @@
       "context": "apps/openchallenges/challenge-service",
       "options": {
         "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/openchallenges-challenge-service"],
+          "images": ["ghcr.io/sage-bionetworks/{projectName}"],
           "tags": ["type=edge,branch=main", "type=sha"]
         },
         "push": true
@@ -94,21 +109,21 @@
     "publish-and-remove-image": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-challenge-service:* --quiet) --force"
+        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
       },
       "dependsOn": ["publish-image"]
     },
     "build-and-remove-image": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-challenge-service:* --quiet) --force"
+        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
       },
       "dependsOn": ["build-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "trivy image ghcr.io/sage-bionetworks/openchallenges-challenge-service:local --quiet",
+        "command": "trivy image ghcr.io/sage-bionetworks/{projectName}:local --quiet",
         "color": true
       }
     },
@@ -120,7 +135,7 @@
           "openapi-generator-cli generate",
           "./gradlew spotlessApply"
         ],
-        "cwd": "apps/openchallenges/challenge-service",
+        "cwd": "{projectRoot}",
         "parallel": false
       }
     }


### PR DESCRIPTION
Closes #2069

## Changelog

- Add the task `sonar` to the project `openchallenges-challenge-service`
- Use Nx variables `{projectName}` and `{projectRoot}` whenever possible in `project.json`