### PR TITLE
test: Push Schematic API coverage report to SonarCloud

### DIFF
--- a/apps/schematic/api/tox.ini
+++ b/apps/schematic/api/tox.ini
@@ -3,11 +3,7 @@ envlist = py310
 skipsdist = True
 
 [testenv:py310]
-allowlist_externals=poetry,sed
+allowlist_externals=poetry
 commands =
-    pip install "cython<3.0.0"
-    pip install --no-build-isolation pyyaml==5.4.1
     poetry install
-    pytest --cov-report html:../../../coverage/apps/schematic/api --cov=schematic_api
-    coverage lcov -o ../../../coverage/apps/schematic/api/lcov.info
-    sed -i 's/SF:/SF:apps\/api\//g' ../../../coverage/apps/schematic/api/lcov.info
+    pytest --cov-report xml --cov-report html --cov=schematic_api

--- a/tools/sonar-scanner.sh
+++ b/tools/sonar-scanner.sh
@@ -16,4 +16,5 @@ sonar-scanner \
   -Dsonar.organization=sage-bionetworks \
   -Dsonar.projectKey=$PROJECT_KEY \
   -Dsonar.sources=$SOURCES \
-  -Dsonar.host.url=https://sonarcloud.io
+  -Dsonar.host.url=https://sonarcloud.io \
+  -Dsonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
Closes #2061

## Changelog

- Configure Schematic API to generate the coverage report in XML format
- Tells Sonar where to find coverage reports in XML format generate by Python projects

## Preview

The coverage percentage of Schematic API is now published on the [Code Quality Dashboard](https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/CODE_QUALITY.md).

<img width="1050" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/3db67d76-733e-438b-b585-57edd0f3d573">

## Cc

@MiekoHash 
