### PR TITLE
refactor: Rename the task `prepare` to `create-config`

### DIFF
--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -4,19 +4,18 @@
   "sourceRoot": "apps/openchallenges-apex/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/apex"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {
       "executor": "nx:run-commands",
       "options": {
         "command": "docker/openchallenges/serve-detach.sh openchallenges-apex"
-      },
-      "dependsOn": []
+      }
     },
     "build-image": {
       "executor": "@nx-tools/nx-container:build",

--- a/apps/openchallenges/api-docs/project.json
+++ b/apps/openchallenges/api-docs/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/api-docs/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/api-docs"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/api-gateway/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/api-gateway"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -5,12 +5,11 @@
   "sourceRoot": "apps/openchallenges/app/src",
   "prefix": "openchallenges",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/app",
-        "parallel": false
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "sonar": {

--- a/apps/openchallenges/auth-service/project.json
+++ b/apps/openchallenges/auth-service/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/auth-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/auth-service"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -4,10 +4,10 @@
   "sourceRoot": "apps/openchallenges/challenge-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
+        "command": "cp -n .env.example .env",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/openchallenges/challenge-to-elasticsearch-service/project.json
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/challenge-to-elasticsearch-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/challenge-to-elasticsearch-service"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/config-server/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["shx cp -n .env.example .env"],
-        "cwd": "apps/openchallenges/config-server"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/core-service/project.json
+++ b/apps/openchallenges/core-service/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/core-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/core-service"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/elasticsearch/project.json
+++ b/apps/openchallenges/elasticsearch/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges-elasticsearch/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/elasticsearch"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/grafana/README.md
+++ b/apps/openchallenges/grafana/README.md
@@ -19,7 +19,7 @@ OpenChallenges supports these data sources:
 Create the config files with:
 
 ```console
-nx prepare openchallenges-grafana
+nx create-config openchallenges-grafana
 ```
 
 The default config file (`.env` located in this project folder) can be used as-is.

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -4,14 +4,14 @@
   "sourceRoot": "apps/openchallenges-grafana/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "shx cp -n .env.example .env",
-          "shx cp -n tools/grafana-backup-tool/.env.example tools/grafana-backup-tool/.env"
+          "cp -n .env.example .env",
+          "cp -n tools/grafana-backup-tool/.env.example tools/grafana-backup-tool/.env"
         ],
-        "cwd": "apps/openchallenges/grafana"
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/image-service/README.md
+++ b/apps/openchallenges/image-service/README.md
@@ -31,7 +31,7 @@ This service manages images for the OpenChallenges app.
 Run this command to prepare this project, including creating the config file `.env`.
 
 ```console
-nx prepare openchallenges-image-service
+nx create-config openchallenges-image-service
 ```
 
 > **Note** The task `prepare` does not overwrites the config file `.env` if it already exists.

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -4,10 +4,10 @@
   "sourceRoot": "apps/openchallenges/image-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
+        "command": "cp -n .env.example .env",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/openchallenges/kafka/project.json
+++ b/apps/openchallenges/kafka/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges-kafka/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/kafka"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/kaggle-to-kafka-service/project.json
+++ b/apps/openchallenges/kaggle-to-kafka-service/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/kaggle-to-kafka-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/kaggle-to-kafka-service"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/keycloak/README.md
+++ b/apps/openchallenges/keycloak/README.md
@@ -7,7 +7,7 @@ TODO
 ## Preparing
 
 ```console
-nx prepare openchallenges-keycloak
+nx create-config openchallenges-keycloak
 nx docker openchallenges-keycloak
 ```
 

--- a/apps/openchallenges/keycloak/project.json
+++ b/apps/openchallenges/keycloak/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/keycloak/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/keycloak"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/mariadb/project.json
+++ b/apps/openchallenges/mariadb/project.json
@@ -3,11 +3,11 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/mariadb"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/mongo/project.json
+++ b/apps/openchallenges/mongo/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/mongo/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/mongo"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/mysqld-exporter/project.json
+++ b/apps/openchallenges/mysqld-exporter/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges-mysqld-exporter/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/mysqld-exporter"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/notebook/project.json
+++ b/apps/openchallenges/notebook/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/notebook/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/notebook"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-python": {

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -4,10 +4,10 @@
   "sourceRoot": "apps/openchallenges/organization-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
+        "command": "cp -n .env.example .env",
         "cwd": "{projectRoot}"
       }
     },

--- a/apps/openchallenges/postgres/project.json
+++ b/apps/openchallenges/postgres/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/postgres/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/postgres"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/prometheus/project.json
+++ b/apps/openchallenges/prometheus/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges-prometheus/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/prometheus"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/rstudio/project.json
+++ b/apps/openchallenges/rstudio/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/rstudio/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/rstudio"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/service-registry/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["shx cp -n .env.example .env"],
-        "cwd": "apps/openchallenges/service-registry"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/thumbor/README.md
+++ b/apps/openchallenges/thumbor/README.md
@@ -11,7 +11,7 @@ This component is based on [Thumbor S3 Docker].
 Run this command to prepare this project, including creating the config file `.env`.
 
 ```console
-nx prepare openchallenges-thumbor
+nx create-config openchallenges-thumbor
 ```
 
 > **Note** The task `prepare` does not overwrites the config file `.env` if it already exists.

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges-thumbor/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/thumbor"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/user-service/project.json
+++ b/apps/openchallenges/user-service/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges/user-service/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/user-service"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-java": {

--- a/apps/openchallenges/vault/project.json
+++ b/apps/openchallenges/vault/project.json
@@ -3,11 +3,11 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/vault"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/openchallenges-zipkin/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/openchallenges/zipkin"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "serve-detach": {

--- a/apps/schematic/api-docs/project.json
+++ b/apps/schematic/api-docs/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/schematic/api-docs/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/schematic/api-docs"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/schematic/api/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/schematic/api"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-python": {

--- a/apps/schematic/notebook/project.json
+++ b/apps/schematic/notebook/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/schematic/notebook/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/schematic/notebook"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "prepare-python": {

--- a/apps/synapse/rstudio/project.json
+++ b/apps/synapse/rstudio/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "apps/synapse/rstudio/src",
   "projectType": "application",
   "targets": {
-    "prepare": {
+    "create-config": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "shx cp -n .env.example .env",
-        "cwd": "apps/synapse/rstudio"
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
       }
     },
     "build-image": {

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -23,14 +23,10 @@ function workspace-install {
   yarn install --immutable
   # TODO: Find a more efficient way than looping through all the Java project to execute the same
   # task (download gradle), enough though caching already helps.
-  nx run-many --target=prepare
+  nx run-many --target=create-config
   nx run-many --target=prepare-java --parallel=1
   nx run-many --target=prepare-python
   nx run-many --target=prepare-r
-}
-
-function workspace-prepare {
-  nx run-many --parallel --target=prepare
 }
 
 # Setup Python virtualenvs

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "primeng": "16.1.0",
     "serverless": "3.22.0",
     "serverless-plugin-typescript": "2.1.4",
-    "shx": "0.3.4",
     "smee-client": "1.2.3",
     "supertest": "^6.3.0",
     "ts-jest": "29.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24304,7 +24304,6 @@ __metadata:
     rxjs: 7.8.1
     serverless: 3.22.0
     serverless-plugin-typescript: 2.1.4
-    shx: 0.3.4
     smee-client: 1.2.3
     supertest: ^6.3.0
     ts-jest: 29.1.1
@@ -24821,7 +24820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shelljs@npm:^0.8.3, shelljs@npm:^0.8.5":
+"shelljs@npm:^0.8.3":
   version: 0.8.5
   resolution: "shelljs@npm:0.8.5"
   dependencies:
@@ -24887,18 +24886,6 @@ __metadata:
     should-type-adaptors: ^1.0.1
     should-util: ^1.0.0
   checksum: 74bcc0eb85e0a63a88e501ff9ca3b53dbc6d1ee47823c029a18a4b14b3ef4e2561733e161033df720599d2153283470e9647fdcb1bbc78903960ffb0363239c4
-  languageName: node
-  linkType: hard
-
-"shx@npm:0.3.4":
-  version: 0.3.4
-  resolution: "shx@npm:0.3.4"
-  dependencies:
-    minimist: ^1.2.3
-    shelljs: ^0.8.5
-  bin:
-    shx: lib/cli.js
-  checksum: 0aa168bfddc11e3fe8943cce2e0d2d8514a560bd58cf2b835b4351ba03f46068f7d88286c2627f4b85604e81952154c43746369fb3f0d60df0e3b511f465e5b8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes to #2075 

## Description

Use a more descriptive name for the task responsible for creating the configuration of a project based on an example config file. Also free up the task name `prepare` that may be used in #2075 .

> **Note**
> This change is mostly invisible to Developers because this task is rarely run manually.

## Changelog

- Remove `shx`
- Rename the task `prepare` to `create-config`