### PR TITLE
refactor: Deprecate tasks `prepare-<languages>`

### DIFF
--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/api-gateway"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/auth-service/project.json
+++ b/apps/openchallenges/auth-service/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/auth-service"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -11,7 +11,7 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],

--- a/apps/openchallenges/challenge-to-elasticsearch-service/project.json
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/challenge-to-elasticsearch-service"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/config-server"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/core-service/project.json
+++ b/apps/openchallenges/core-service/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/core-service"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -11,7 +11,7 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],

--- a/apps/openchallenges/kaggle-to-kafka-service/project.json
+++ b/apps/openchallenges/kaggle-to-kafka-service/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/kaggle-to-kafka-service"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/notebook/project.json
+++ b/apps/openchallenges/notebook/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-python": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "command": "./prepare-python.sh",
-        "cwd": "apps/openchallenges/notebook"
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -11,7 +11,7 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/service-registry"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/openchallenges/user-service/project.json
+++ b/apps/openchallenges/user-service/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "apps/openchallenges/user-service"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-python": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "command": "./prepare-python.sh",
-        "cwd": "apps/schematic/api"
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/schematic/notebook/project.json
+++ b/apps/schematic/notebook/project.json
@@ -11,11 +11,11 @@
         "cwd": "{projectRoot}"
       }
     },
-    "prepare-python": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "command": "./prepare-python.sh",
-        "cwd": "apps/schematic/notebook"
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -21,12 +21,9 @@ export PATH="$PATH:$WORKSPACE_DIR/node_modules/.bin"
 
 function workspace-install {
   yarn install --immutable
-  # TODO: Find a more efficient way than looping through all the Java project to execute the same
-  # task (download gradle), enough though caching already helps.
   nx run-many --target=create-config
-  nx run-many --target=prepare-java --parallel=1
-  nx run-many --target=prepare-python
-  nx run-many --target=prepare-r
+  nx run-many --target=prepare --projects=tag:language:java --parallel=1
+  nx run-many --target=prepare --projects=tag:language:python --projects=tag:language:r
 }
 
 # Setup Python virtualenvs

--- a/libs/openchallenges/api-client-r/project.json
+++ b/libs/openchallenges/api-client-r/project.json
@@ -12,7 +12,7 @@
           "Rscript -e 'renv::restore()'",
           "wget -O openapi-generator-cli.jar https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-cli/7.0.0-SNAPSHOT/openapi-generator-cli-7.0.0-20230720.164703-191.jar"
         ],
-        "cwd": "libs/openchallenges/api-client-r"
+        "cwd": "{projectRoot}"
       }
     },
     "openapi-generate": {

--- a/libs/openchallenges/api-client-r/project.json
+++ b/libs/openchallenges/api-client-r/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "prefix": "openchallenges",
   "targets": {
-    "prepare-r": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [

--- a/libs/openchallenges/app-config-data/project.json
+++ b/libs/openchallenges/app-config-data/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "libs/openchallenges/app-config-data/src",
   "projectType": "library",
   "targets": {
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "libs/openchallenges/app-config-data"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/libs/openchallenges/kafka-admin/project.json
+++ b/libs/openchallenges/kafka-admin/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "libs/openchallenges/kafka-admin/src",
   "projectType": "library",
   "targets": {
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "libs/openchallenges/kafka-admin"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/libs/openchallenges/kafka-consumer/project.json
+++ b/libs/openchallenges/kafka-consumer/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "libs/openchallenges/kafka-consumer/src",
   "projectType": "library",
   "targets": {
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "libs/openchallenges/kafka-consumer"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/libs/openchallenges/kafka-model/project.json
+++ b/libs/openchallenges/kafka-model/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "libs/openchallenges/kafka-model/src",
   "projectType": "library",
   "targets": {
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "libs/openchallenges/kafka-model"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/libs/openchallenges/kafka-producer/project.json
+++ b/libs/openchallenges/kafka-producer/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "libs/openchallenges/kafka-producer/src",
   "projectType": "library",
   "targets": {
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "libs/openchallenges/kafka-producer"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/libs/schematic/api-client-python/project.json
+++ b/libs/schematic/api-client-python/project.json
@@ -5,11 +5,11 @@
   "projectType": "library",
   "prefix": "schematic",
   "targets": {
-    "prepare-python": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "command": "./prepare-python.sh",
-        "cwd": "libs/schematic/api-client-python"
+        "cwd": "{projectRoot}"
       }
     },
     "openapi-generate": {

--- a/libs/shared/java/util/project.json
+++ b/libs/shared/java/util/project.json
@@ -4,11 +4,11 @@
   "sourceRoot": "libs/shared/java/util/src",
   "projectType": "library",
   "targets": {
-    "prepare-java": {
+    "prepare": {
       "executor": "nx:run-commands",
       "options": {
         "commands": ["./gradlew --version 1> /dev/null"],
-        "cwd": "libs/shared/java/util"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {

--- a/tools/prepare-java-envs.js
+++ b/tools/prepare-java-envs.js
@@ -1,5 +1,5 @@
 // For each Java project in the workspace, this script checks if their Gradle binary, as defined in
-// has changed since the last git operation. The Nx target `prepare-java` is then run for all the
+// has changed since the last git operation. The Nx target `prepare` is then run for all the
 // projects that must be updated.
 
 'use strict';
@@ -37,7 +37,7 @@ const hasGradleProjectDefinitionChanged = (projectDir, changedFiles) => {
 
 // Installs the Python dependencies of the comma-separated list of projects.
 const prepareJavaProject = (projectNames) => {
-  spawn('nx', ['run-many', '--target=prepare-java', `--projects=${projectNames}`], {
+  spawn('nx', ['run-many', '--target=prepare', `--projects=${projectNames}`], {
     stdio: 'inherit',
   }).on('exit', function (error) {
     if (error) {

--- a/tools/prepare-python-envs.js
+++ b/tools/prepare-python-envs.js
@@ -1,6 +1,6 @@
 // For each Python project in the workspace, this script checks if their dependencies, as defined in
-// their lock files, have changed since the last git operation. The Nx target `prepare-python` is
-// then run for all the projects that had their dependencies updated.
+// their lock files, have changed since the last git operation. The Nx target `prepare` is then run
+// for all the projects that had their dependencies updated.
 
 'use strict';
 
@@ -32,7 +32,7 @@ const hasPoetryProjectDefinitionChanged = (projectDir, changedFiles) => {
 
 // Installs the Python dependencies of the comma-separated list of projects.
 const installPythonDependencies = (projectNames) => {
-  spawn('nx', ['run-many', '--target=prepare-python', `--projects=${projectNames}`], {
+  spawn('nx', ['run-many', '--target=prepare', `--projects=${projectNames}`], {
     stdio: 'inherit',
   }).on('exit', function (error) {
     if (error) {

--- a/tools/prepare-r-envs.js
+++ b/tools/prepare-r-envs.js
@@ -32,7 +32,7 @@ const hasRenvProjectDefinitionChanged = (projectDir, changedFiles) => {
 
 // Installs the R dependencies of the comma-separated list of projects.
 const prepareREnvironment = (projectNames) => {
-  spawn('nx', ['run-many', '--target=prepare-r', `--projects=${projectNames}`], {
+  spawn('nx', ['run-many', '--target=prepare', `--projects=${projectNames}`], {
     stdio: 'inherit',
   }).on('exit', function (error) {
     if (error) {


### PR DESCRIPTION
Closes #2075 

## Description

Adopt the same task name to prepare projects - mainly install dependencies - independently of the programming language and package manager used. The task `prepare-python`, `prepare-java` and `prepare-r` are renamed to `prepare`.

When preparing projects for specific languages (e.g. Java projects needs to be prepare one at a time to avoid a race condition), filtering is performed based on project tags.

## Preview

The new command `workspace-install`:

```bash
function workspace-install {
  yarn install --immutable
  nx run-many --target=create-config
  nx run-many --target=prepare --projects=tag:language:java --parallel=1
  nx run-many --target=prepare --projects=tag:language:python --projects=tag:language:r
}
```

> **Warning**
> After checking out the update, running the command `workspace-install` in the same terminal won't work because it relies on the old `prepare-<language>` tasks that are no longer available. The solution is to simply open a new terminal to redefine `workspace-install` or source `dev-env.sh` with `. ./dev-env.sh` in the existing terminals.