### PR TITLE
ci: Add the command `workspace-install-affected`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
               /home/vscode/.local \
               /home/vscode/.gradle \
             && . ./dev-env.sh \
-            && workspace-install"
+            && workspace-install-affected"
 
       - name: Lint the affected projects
         run: |
@@ -269,7 +269,7 @@ jobs:
               /home/vscode/.local \
               /home/vscode/.gradle \
             && . ./dev-env.sh \
-            && workspace-install"
+            && workspace-install-affected"
 
       - name: Lint the affected projects
         run: |

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -26,6 +26,13 @@ function workspace-install {
   nx run-many --target=prepare --projects=tag:language:python --projects=tag:language:r
 }
 
+function workspace-install-affected {
+  yarn install --immutable
+  nx affected --target=create-config
+  nx affected --target=prepare --tag=language:java --parallel=1
+  nx affected --target=prepare --tag=language:python --tag=language:r
+}
+
 # Setup Python virtualenvs
 # function challenge-python {
 #   nx run-many --parallel --target=python


### PR DESCRIPTION
Closes #2087 

## How does this PR affect the caching of packages in the CI workflow?

I asked this question in the main ticket. This PR makes the cache less relevant because they may include less packages now that we are only installing the packages for affected projects. Using only the affected projects to generate the cache key would over complicate the system and saturate the storage space available.

By default, caches are replaced when their key changes instead of updating the existing cache. Updating existing cache would be more storage space efficient but would increase the risks of cache poisoning. This is something that we could explore in the future for each type of cache (Yarn, Gradle, etc.).

## Preview

### Current Behavior: Preparing all projects when no projects are affected

This PR does not affect any projects, yet all the projects are prepared, which takes between 2-4 minutes depending on the status of the cache.

<img width="1033" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/318349f9-3595-4545-b23c-3af80cd93c56">

### New Behavior: Preparing only the affected project

This PR does not affect any projects so zero projects are prepared.

<img width="1038" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/1a801f59-d301-4396-a315-22a354e53be1">

> **Note**
> Npm packages are always installed, which could be further optimized in the future. In particular, the cache makes the download phase complete almost instantaneously. However, the linking phase takes about 1 minutes. This will be greatly reduced once #2003 is merged.
