### PR TITLE
feat(fix): Reset scroll position to top

### DIFF
--- a/apps/openchallenges/app/src/app/app-routing.module.ts
+++ b/apps/openchallenges/app/src/app/app-routing.module.ts
@@ -78,6 +78,7 @@ export const routes: Routes = [
       initialNavigation: 'enabledBlocking',
       // this is important to use "data:title" from any level
       // paramsInheritanceStrategy: 'always',
+      scrollPositionRestoration: 'top', // reset scroll position
     }),
   ],
   declarations: [],


### PR DESCRIPTION
- fixes #1972 

## Preview
Now the scroll position is always reset to top by switching the pages/components

![Recording 2023-09-07 at 16 27 07](https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/ad6ab79e-31f1-4bf8-aa8e-c0ad0afb40fb)


