### PR TITLE
refactor: Remove last module from OC app

### DIFF
--- a/apps/openchallenges/app/src/app/app.config.ts
+++ b/apps/openchallenges/app/src/app/app.config.ts
@@ -1,0 +1,79 @@
+import {
+  ApplicationConfig,
+  APP_INITIALIZER,
+  importProvidersFrom,
+} from '@angular/core';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+  withInMemoryScrolling,
+} from '@angular/router';
+
+import { SharedUtilModule } from '@sagebionetworks/shared/util';
+import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
+import { KeycloakAngularModule } from 'keycloak-angular';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import {
+  withInterceptorsFromDi,
+  provideHttpClient,
+} from '@angular/common/http';
+import { CountUpModule } from 'ngx-countup';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+  BASE_PATH as API_CLIENT_BASE_PATH,
+  ApiModule,
+} from '@sagebionetworks/openchallenges/api-client-angular';
+import {
+  configFactory,
+  ConfigService,
+} from '@sagebionetworks/openchallenges/config';
+
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    importProvidersFrom(
+      BrowserModule.withServerTransition({ appId: 'openchallenges' }),
+      ApiModule,
+      CountUpModule,
+      MatButtonModule,
+      KeycloakAngularModule,
+      // AuthModule.forRoot(),
+      MatProgressSpinnerModule,
+      SharedUtilModule
+    ),
+    {
+      provide: 'APP_BASE_URL',
+      useFactory: () => `.`,
+      deps: [],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: configFactory,
+      deps: [ConfigService],
+      multi: true,
+    },
+    // {
+    //   provide: APP_INITIALIZER,
+    //   useFactory: initializeKeycloakFactory,
+    //   multi: true,
+    //   deps: [ConfigService, KeycloakService, PLATFORM_ID],
+    // },
+    {
+      provide: API_CLIENT_BASE_PATH,
+      useFactory: (configService: ConfigService) => configService.config.apiUrl,
+      deps: [ConfigService],
+    },
+    { provide: 'googleTagManagerId', useValue: 'GTM-NBR5XD8C' },
+    provideAnimations(),
+    provideHttpClient(withInterceptorsFromDi()),
+    provideRouter(
+      routes,
+      withEnabledBlockingInitialNavigation(),
+      withInMemoryScrolling({
+        scrollPositionRestoration: 'top',
+      })
+    ),
+  ],
+};

--- a/apps/openchallenges/app/src/app/app.routes.ts
+++ b/apps/openchallenges/app/src/app/app.routes.ts
@@ -1,5 +1,4 @@
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
+import { Routes } from '@angular/router';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -71,18 +70,3 @@ export const routes: Routes = [
     redirectTo: '/not-found',
   },
 ];
-
-@NgModule({
-  imports: [
-    RouterModule.forRoot(routes, {
-      initialNavigation: 'enabledBlocking',
-      // this is important to use "data:title" from any level
-      // paramsInheritanceStrategy: 'always',
-      scrollPositionRestoration: 'top', // reset scroll position
-    }),
-  ],
-  declarations: [],
-  providers: [],
-  exports: [RouterModule],
-})
-export class AppRoutingModule {}

--- a/apps/openchallenges/app/src/main.ts
+++ b/apps/openchallenges/app/src/main.ts
@@ -1,31 +1,9 @@
-import {
-  enableProdMode,
-  APP_INITIALIZER,
-  importProvidersFrom,
-} from '@angular/core';
+import { enableProdMode } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
 
 import { environment } from './environments/environment';
+import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
-import { SharedUtilModule } from '@sagebionetworks/shared/util';
-import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
-import { KeycloakAngularModule } from 'keycloak-angular';
-import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import {
-  withInterceptorsFromDi,
-  provideHttpClient,
-} from '@angular/common/http';
-import { CountUpModule } from 'ngx-countup';
-import { provideAnimations } from '@angular/platform-browser/animations';
-import { AppRoutingModule } from './app/app-routing.module';
-import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
-import {
-  BASE_PATH as API_CLIENT_BASE_PATH,
-  ApiModule,
-} from '@sagebionetworks/openchallenges/api-client-angular';
-import {
-  configFactory,
-  ConfigService,
-} from '@sagebionetworks/openchallenges/config';
 
 function bootstrap() {
   // TODO: Consider getting read of environment files, which have been replaced by config/*.json. It
@@ -35,47 +13,9 @@ function bootstrap() {
     enableProdMode();
   }
 
-  bootstrapApplication(AppComponent, {
-    providers: [
-      importProvidersFrom(
-        BrowserModule.withServerTransition({ appId: 'openchallenges' }),
-        ApiModule,
-        AppRoutingModule,
-        CountUpModule,
-        MatButtonModule,
-        KeycloakAngularModule,
-        // AuthModule.forRoot(),
-        MatProgressSpinnerModule,
-        SharedUtilModule
-      ),
-      {
-        provide: 'APP_BASE_URL',
-        useFactory: () => `.`,
-        deps: [],
-      },
-      {
-        provide: APP_INITIALIZER,
-        useFactory: configFactory,
-        deps: [ConfigService],
-        multi: true,
-      },
-      // {
-      //   provide: APP_INITIALIZER,
-      //   useFactory: initializeKeycloakFactory,
-      //   multi: true,
-      //   deps: [ConfigService, KeycloakService, PLATFORM_ID],
-      // },
-      {
-        provide: API_CLIENT_BASE_PATH,
-        useFactory: (configService: ConfigService) =>
-          configService.config.apiUrl,
-        deps: [ConfigService],
-      },
-      { provide: 'googleTagManagerId', useValue: 'GTM-NBR5XD8C' },
-      provideAnimations(),
-      provideHttpClient(withInterceptorsFromDi()),
-    ],
-  }).catch((err) => console.error(err));
+  bootstrapApplication(AppComponent, appConfig).catch((err) =>
+    console.error(err)
+  );
 }
 
 if (document.readyState === 'complete') {


### PR DESCRIPTION
Closes #2096

## Changelog

- Migrate the content of `app-routing.module.ts` to `app.routes.ts`
- Create the file `app.config.ts` introduced with Angular v16 which includes code for routes.

> **Note**
> The PR opened by @sagely1 adds a fresh new Angular project generated with the Angular generator. I used it as a reference for the implementation of `app.config.ts`.

## Cc

@sagely1 This PR may interest you since it is related to a new concept/design introduced in Angular v16.