### PR TITLE
feat: Task `openapi-generate` now builds the API description

### DIFF
--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -137,9 +137,14 @@
         ],
         "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
-  "implicitDependencies": ["openchallenges-app-config-data", "shared-java-util"]
+  "implicitDependencies": [
+    "openchallenges-api-description",
+    "openchallenges-app-config-data", 
+    "shared-java-util"
+  ]
 }

--- a/apps/openchallenges/challenge-to-elasticsearch-service/project.json
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/project.json
@@ -76,13 +76,15 @@
           "openapi-generator-cli generate",
           "./gradlew spotlessApply"
         ],
-        "cwd": "apps/openchallenges/challenge-to-elasticsearch-service",
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
+    "openchallenges-api-description",
     "openchallenges-app-config-data",
     "openchallenges-kafka-admin",
     "openchallenges-kafka-consumer",

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -140,9 +140,14 @@
         ],
         "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
-  "implicitDependencies": ["openchallenges-app-config-data", "shared-java-util"]
+  "implicitDependencies": [
+    "openchallenges-api-description",
+    "openchallenges-app-config-data", 
+    "shared-java-util"
+  ]
 }

--- a/apps/openchallenges/kaggle-to-kafka-service/project.json
+++ b/apps/openchallenges/kaggle-to-kafka-service/project.json
@@ -76,13 +76,15 @@
           "openapi-generator-cli generate",
           "./gradlew spotlessApply"
         ],
-        "cwd": "apps/openchallenges/kaggle-to-kafka-service",
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
+    "openchallenges-api-description",
     "openchallenges-app-config-data",
     "openchallenges-kafka-admin",
     "openchallenges-kafka-model",

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -140,9 +140,14 @@
         ],
         "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
-  "implicitDependencies": ["openchallenges-app-config-data", "shared-java-util"]
+  "implicitDependencies": [
+    "openchallenges-api-description",
+    "openchallenges-app-config-data", 
+    "shared-java-util"
+  ]
 }

--- a/apps/openchallenges/user-service/project.json
+++ b/apps/openchallenges/user-service/project.json
@@ -76,13 +76,15 @@
           "openapi-generator-cli generate",
           "./gradlew spotlessApply"
         ],
-        "cwd": "apps/openchallenges/user-service",
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
+    "openchallenges-api-description",
     "openchallenges-api-gateway",
     "openchallenges-keycloak",
     "openchallenges-mariadb",

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -78,10 +78,14 @@
     "openapi-generate": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["xargs rm -fr <.openapi-generator/FILES", "openapi-generator-cli generate"],
-        "cwd": "apps/schematic/api",
+        "commands": [
+          "xargs rm -fr <.openapi-generator/FILES", 
+          "openapi-generator-cli generate"
+        ],
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "nx:run-commands",

--- a/libs/openchallenges/api-client-angular/project.json
+++ b/libs/openchallenges/api-client-angular/project.json
@@ -46,10 +46,14 @@
     "openapi-generate": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["rm -fr src/lib/*", "openapi-generator-cli generate"],
-        "cwd": "libs/openchallenges/api-client-angular",
+        "commands": [
+          "rm -fr src/lib/*", 
+          "openapi-generator-cli generate"
+        ],
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["language:typescript"],

--- a/libs/openchallenges/api-client-r/project.json
+++ b/libs/openchallenges/api-client-r/project.json
@@ -22,9 +22,10 @@
           "rm -fr src/lib/*",
           "java -jar openapi-generator-cli.jar generate -i ../api-description/build/openapi.yaml -g r"
         ],
-        "cwd": "libs/openchallenges/api-client-r",
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "nx:run-commands",
@@ -54,7 +55,5 @@
     }
   },
   "tags": ["language:r", "package-manager:renv"],
-  "implicitDependencies": [
-    "openchallenges-api-description"
-  ]
+  "implicitDependencies": ["openchallenges-api-description"]
 }

--- a/libs/openchallenges/api-description/project.json
+++ b/libs/openchallenges/api-description/project.json
@@ -31,18 +31,19 @@
       "options": {
         "command": "lint-openapi --config openapi-lint-config.yaml --ruleset spectral.yaml build/openapi.yaml build/challenge.openapi.yaml build/organization.openapi.yaml build/image.openapi.yaml",
         "cwd": "{projectRoot}"
-      }
+      },
+      "dependsOn": ["build"]
     },
     "format": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "prettier --write libs/openchallenges/api-description"
+        "command": "prettier --write {projectRoot}"
       }
     },
     "format-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "prettier --check libs/openchallenges/api-description"
+        "command": "prettier --check {projectRoot}"
       }
     }
   },

--- a/libs/openchallenges/api-description/project.json
+++ b/libs/openchallenges/api-description/project.json
@@ -22,7 +22,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "openapi-merge-cli --config openapi-merge.yaml",
-        "cwd": "{projctRoot}"
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["build-individuals"]
     },

--- a/libs/openchallenges/api-description/project.json
+++ b/libs/openchallenges/api-description/project.json
@@ -15,14 +15,14 @@
           "redocly bundle --output build/user.openapi.yaml src/user.openapi.yaml"
         ],
         "parallel": true,
-        "cwd": "libs/openchallenges/api-description"
+        "cwd": "{projectRoot}"
       }
     },
     "build": {
       "executor": "nx:run-commands",
       "options": {
         "command": "openapi-merge-cli --config openapi-merge.yaml",
-        "cwd": "libs/openchallenges/api-description"
+        "cwd": "{projctRoot}"
       },
       "dependsOn": ["build-individuals"]
     },
@@ -30,7 +30,7 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "lint-openapi --config openapi-lint-config.yaml --ruleset spectral.yaml build/openapi.yaml build/challenge.openapi.yaml build/organization.openapi.yaml build/image.openapi.yaml",
-        "cwd": "libs/openchallenges/api-description"
+        "cwd": "{projectRoot}"
       }
     },
     "format": {

--- a/libs/schematic/api-client-angular/project.json
+++ b/libs/schematic/api-client-angular/project.json
@@ -51,9 +51,10 @@
           "openapi-generator-cli generate",
           "echo 'TODO Format generated code'"
         ],
-        "cwd": "libs/schematic/api-client-angular",
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["language:typescript"],

--- a/libs/schematic/api-client-python/project.json
+++ b/libs/schematic/api-client-python/project.json
@@ -20,13 +20,12 @@
           "openapi-generator-cli generate",
           "echo 'TODO Format generated code'"
         ],
-        "cwd": "libs/schematic/api-client-python",
+        "cwd": "{projectRoot}",
         "parallel": false
-      }
+      },
+      "dependsOn": ["^build"]
     }
   },
   "tags": ["language:python", "package-manager:poetry"],
-  "implicitDependencies": [
-    "schematic-api-description"
-  ]
+  "implicitDependencies": ["schematic-api-description"]
 }

--- a/libs/schematic/api-description/project.json
+++ b/libs/schematic/api-description/project.json
@@ -9,26 +9,27 @@
       "options": {
         "commands": ["redocly bundle --output build/openapi.yaml src/openapi.yaml"],
         "parallel": true,
-        "cwd": "libs/schematic/api-description"
+        "cwd": "{projectRoot}"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
         "command": "lint-openapi --config openapi-lint-config.yaml --ruleset spectral.yaml build/openapi.yaml",
-        "cwd": "libs/schematic/api-description"
-      }
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["build"]
     },
     "format": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "prettier --write libs/schematic/api-description"
+        "command": "prettier --write {projectRoot}"
       }
     },
     "format-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "prettier --check libs/schematic/api-description"
+        "command": "prettier --check {projectRoot}"
       }
     }
   },

--- a/libs/synapse/api-description/project.json
+++ b/libs/synapse/api-description/project.json
@@ -9,26 +9,27 @@
       "options": {
         "commands": ["redocly bundle --output build/openapi.yaml src/openapi.yaml"],
         "parallel": true,
-        "cwd": "libs/synapse/api-description"
+        "cwd": "{projectRoot}"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
         "command": "lint-openapi --config openapi-lint-config.yaml --ruleset spectral.yaml build/openapi.yaml",
-        "cwd": "libs/synapse/api-description"
-      }
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["build"]
     },
     "format": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "prettier --write libs/synapse/api-description"
+        "command": "prettier --write {projectRoot}"
       }
     },
     "format-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "prettier --check libs/synapse/api-description"
+        "command": "prettier --check {projectRoot}"
       }
     }
   },


### PR DESCRIPTION
## Description

Generating a REST API server stub and client is currently perform with this workflow:

1. Build the API description: E.g. `nx build <product>-api-description`
2. Generate the code: E.g. `nx openapi-generate <product>-api-client-python`

This PR proposes to chain these two commands so that running `nx openapi-generate <project>` will automatically build the API description the API server stub/client depends on.

UPDATE: Similarly, the task `lint` of API description projects also run their `build` task first.