### PR TITLE
ci: Enable Dev Container in CI workflow to push to GHCR

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,9 @@
     "NX_CLOUD_ENV_NAME": "${localEnv:NX_CLOUD_ENV_NAME}",
     "NX_HEAD": "${localEnv:NX_HEAD}",
     "NX_RUN_GROUP": "${localEnv:NX_RUN_GROUP}",
-    "SONAR_TOKEN": "${localEnv:SONAR_TOKEN}"
+    "SONAR_TOKEN": "${localEnv:SONAR_TOKEN}",
+    "DOCKER_USERNAME": "${localEnv:DOCKER_USERNAME}",
+    "DOCKER_PASSWORD": "${localEnv:DOCKER_PASSWORD}"
   },
 
   "features": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,11 +296,11 @@ jobs:
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
       #       && nx affected --target=build-and-remove-image --parallel=1"
 
-      - name: Build the images of the SELECTED projects
+      - name: PUBLISH the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image \
-              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
+            && nx run-many --target=publish-and-remove-image \
+              --projects=openchallenges-app \
               --parallel=1"
 
       - name: Stop the dev container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,10 +266,10 @@ jobs:
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
       #       && nx affected --target=build-and-remove-image --parallel=1"
 
-      - name: PUBLISH the images of the SELECTED projects
+      - name: Building the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=publish-and-remove-image \
+            && nx run-many --target=build-and-remove-image \
             --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,8 @@ jobs:
             --mount type=bind,source=/tmp/.gradle/wrapper,target=/home/vscode/.gradle/wrapper \
             --workspace-folder ../sage-monorepo
 
-      - name: Login to GitHub Container Registry (inside dev container)
-        run: echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io
+      # - name: Login to GitHub Container Registry (inside dev container)
+      #   run: echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io
 
       - name: Prepare the workspace
         run: |
@@ -311,6 +311,7 @@ jobs:
       - name: PUBLISH the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io \
             && nx run-many --target=publish-and-remove-image \
               --projects=openchallenges-app \
               --parallel=1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
               --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 
-      - name: Stop the dev container
+      - name: Remove the dev container
         run: docker rm -f sage_devcontainer
 
   pr:
@@ -273,5 +273,5 @@ jobs:
             --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 
-      - name: Stop the dev container
+      - name: Remove the dev container
         run: docker rm -f sage_devcontainer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,7 @@ jobs:
             /tmp/.gradle/wrapper
 
           devcontainer up \
+            --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker \
             --mount type=bind,source=/tmp/.yarn/cache,target=/workspaces/sage-monorepo/.yarn/cache \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,10 +270,7 @@ jobs:
             --workspace-folder ../sage-monorepo
 
       - name: Login to GitHub Container Registry (inside dev container)
-        run: echo $DOCKER_PASSWORD | docker login \
-          --username $DOCKER_USERNAME \
-          --password-stdin \
-          ghcr.io
+        run: echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io
 
       - name: Prepare the workspace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,13 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-single-buildx
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,12 +240,12 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-single-buildx
 
-      # - name: Login to GitHub Container Registry
-      #   uses: docker/login-action@v2
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,9 @@ jobs:
       - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0
 
+      - name: Show docker creds helper
+        run: ls -al /usr/local/bin/docker*
+
       - name: Start the dev container
         run: |
           mkdir -p \
@@ -311,7 +314,6 @@ jobs:
       - name: PUBLISH the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io \
             && nx run-many --target=publish-and-remove-image \
               --projects=openchallenges-app \
               --parallel=1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ env:
   NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
   NX_CLOUD_ENV_NAME: 'linux'
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  DOCKER_USERNAME: ${{ github.actor }}
+  DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   push:
@@ -238,12 +240,12 @@ jobs:
       #     restore-keys: |
       #       ${{ runner.os }}-single-buildx
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v2
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0
@@ -259,7 +261,6 @@ jobs:
             /tmp/.gradle/wrapper
 
           devcontainer up \
-            --mount type=bind,source=$HOME/.docker,target=/home/vscode/.docker \
             --mount type=bind,source=/tmp/.yarn/cache,target=/workspaces/sage-monorepo/.yarn/cache \
             --mount type=bind,source=/tmp/.cache/R/renv/cache,target=/home/vscode/.cache/R/renv/cache \
             --mount type=bind,source=/tmp/.cache/pypoetry,target=/home/vscode/.cache/pypoetry \
@@ -267,6 +268,9 @@ jobs:
             --mount type=bind,source=/tmp/.gradle/caches,target=/home/vscode/.gradle/caches \
             --mount type=bind,source=/tmp/.gradle/wrapper,target=/home/vscode/.gradle/wrapper \
             --workspace-folder ../sage-monorepo
+
+      - name: Login to GitHub Container Registry (inside dev container)
+        run: echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
 
       - name: Prepare the workspace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,10 @@ jobs:
             --workspace-folder ../sage-monorepo
 
       - name: Login to GitHub Container Registry (inside dev container)
-        run: echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+        run: echo $DOCKER_PASSWORD | docker login \
+          --username $DOCKER_USERNAME \
+          --password-stdin \
+          ghcr.io
 
       - name: Prepare the workspace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io \
-            && nx run-many --target=build-and-remove-image \
+            && nx run-many --target=publish-and-remove-image \
               --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,21 +71,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-single-buildx-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-single-buildx
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0
 
@@ -149,25 +134,16 @@ jobs:
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
       #       && nx affected --target=publish-and-remove-image --parallel=1"
 
-      - name: BUILDING the images of the SELECTED projects
+      - name: Publishing the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io \
             && nx run-many --target=build-and-remove-image \
               --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 
       - name: Stop the dev container
         run: docker rm -f sage_devcontainer
-
-      # - run: yarn nx run-many --all --target=test --parallel --max-parallel=2
-      # TODO: Fix coverage error when no projects are affected
-      # - name: Merge coverage reports
-      #   run: yarn coverage:merge
-      # - name: Push coverage report to Coveralls
-      #   uses: coverallsapp/github-action@master
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     path-to-lcov: coverage/lcov.info
 
   pr:
     runs-on: ubuntu-latest
@@ -232,26 +208,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-single-buildx-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-single-buildx
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install the Dev Container CLI
         run: npm install -g @devcontainers/cli@0.49.0
-
-      - name: Show docker creds helper
-        run: ls -al /usr/local/bin/docker*
 
       - name: Start the dev container
         run: |
@@ -271,9 +229,6 @@ jobs:
             --mount type=bind,source=/tmp/.gradle/caches,target=/home/vscode/.gradle/caches \
             --mount type=bind,source=/tmp/.gradle/wrapper,target=/home/vscode/.gradle/wrapper \
             --workspace-folder ../sage-monorepo
-
-      # - name: Login to GitHub Container Registry (inside dev container)
-      #   run: echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io
 
       - name: Prepare the workspace
         run: |
@@ -315,7 +270,7 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx run-many --target=publish-and-remove-image \
-              --projects=openchallenges-app \
+            --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,schematic-api \
               --parallel=1"
 
       - name: Stop the dev container


### PR DESCRIPTION
Closes #2105

## Description

Enable the dev container used in the CI workflow to authenticate to GHCR and push images.

## Notes

Until now the dev container in the CI workflow didn't have access to docker auth credentials to push to GHCR. This is because the login happens outside of the dev container and the container does not have access to the credentials.

Trying to push an image to GHCR inside the dev container results in this error:

```console
NX   buildx failed with: ERROR: unauthorized: unauthenticated: User cannot be authenticated with the token provided.
```


## Attempt 1: Mount `$HOME/.docker` to the dev container

After mounting the `$HOME/.docker` folder from the home to the dev container, a new error appears:

```console
Docker buildx is required. See https://github.com/gperdomor/nx-tools to set up nx-container executor with buildx.
```

The reason is that buildx is not installed on the GH runner, so it's then no longer available to the dev container because buildx config/files live in `~/.docker/buildx`.

Another reason why this wouldn't work is that the property `credsStore` in `~/.docker/config.json` specifies the location of a binary that docker can use to login, but this binary lives outside of `~/.docker` and so it not accessible to the dev container.

Mounting this binary is not trivial because it usually includes a unique UUID, as in `/usr/local/bin/docker-credential-dev-containers-<UUID>`. As there may be multiple `/usr/local/bin/docker-credential-dev-containers-<UUID>` files, mounting the right one would require to parse the content of `~/.docker/config.json` on the GH runner.

## Attempt 2: Run `docker login` inside the dev container

Here the idea is to pass the docker username and password to the dev container and then run the command:

```console
echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io
```

The CI workflow then successfully login!

```console
Run echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io
WARNING! Your password will be stored unencrypted in /home/runner/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```

However, this step that push image still fails with the error:

```console
ERROR: unauthorized: unauthenticated: User cannot be authenticated with the token provided.
```

The solution is to login in the same "session" as the command that push the images.

> **Warning**
> Ideally we should address the WARNING about the password being stored unencrypted. Note that the action `docker/login-action@v2` does not seem to do better as they [hide](https://github.com/docker/login-action/blob/a5609cb39f57be157c39b77359abfaa43aeaeb8f/src/docker.ts#L39) the warning.