### PR TITLE
feat: Add option `allowLoadLocalInfile=true` to `DB_URL`

### DIFF
--- a/apps/openchallenges/challenge-service/.env.example
+++ b/apps/openchallenges/challenge-service/.env.example
@@ -1,4 +1,4 @@
 SERVER_PORT=8085
 KEYCLOAK_URL=http://openchallenges-keycloak:8080
 SERVICE_REGISTRY_URL=http://openchallenges-service-registry:8081/eureka
-DB_URL=jdbc:mysql://openchallenges-mariadb:3306/challenge_service
+DB_URL=jdbc:mysql://openchallenges-mariadb:3306/challenge_service&allowLoadLocalInfile=true

--- a/apps/openchallenges/challenge-service/.env.example
+++ b/apps/openchallenges/challenge-service/.env.example
@@ -1,4 +1,4 @@
 SERVER_PORT=8085
 KEYCLOAK_URL=http://openchallenges-keycloak:8080
 SERVICE_REGISTRY_URL=http://openchallenges-service-registry:8081/eureka
-DB_URL=jdbc:mysql://openchallenges-mariadb:3306/challenge_service&allowLoadLocalInfile=true
+DB_URL=jdbc:mysql://openchallenges-mariadb:3306/challenge_service?allowLoadLocalInfile=true

--- a/apps/openchallenges/organization-service/.env.example
+++ b/apps/openchallenges/organization-service/.env.example
@@ -1,4 +1,4 @@
 SERVER_PORT=8084
 KEYCLOAK_URL=http://openchallenges-keycloak:8080
 SERVICE_REGISTRY_URL=http://openchallenges-service-registry:8081/eureka
-DB_URL=jdbc:mysql://openchallenges-mariadb:3306/organization_service&allowLoadLocalInfile=true
+DB_URL=jdbc:mysql://openchallenges-mariadb:3306/organization_service?allowLoadLocalInfile=true

--- a/apps/openchallenges/organization-service/.env.example
+++ b/apps/openchallenges/organization-service/.env.example
@@ -1,4 +1,4 @@
 SERVER_PORT=8084
 KEYCLOAK_URL=http://openchallenges-keycloak:8080
 SERVICE_REGISTRY_URL=http://openchallenges-service-registry:8081/eureka
-DB_URL=jdbc:mysql://openchallenges-mariadb:3306/organization_service
+DB_URL=jdbc:mysql://openchallenges-mariadb:3306/organization_service&allowLoadLocalInfile=true


### PR DESCRIPTION
Contributes to #2047

## Changelog

- Update the value of the config parameter `DB_URL` in `.env.example` for the challenge and organization service

> **Note**
> The value of `DB_URL` must be manually updated in `.env`, which is not tracked.

> **Note**
> The base branch of this PR is the feature branch `load-local-infile`.

> **Warning**
> The challenge and organization services fail to start when using this parameter. I'm assuming that it's because the server (MariaDB) is not configured yet.