### PR TITLE
fix: Specify the missing inputs of the footer

### DIFF
--- a/libs/openchallenges/about/src/lib/about.component.html
+++ b/libs/openchallenges/about/src/lib/about.component.html
@@ -125,4 +125,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/about/src/lib/about.component.ts
+++ b/libs/openchallenges/about/src/lib/about.component.ts
@@ -13,9 +13,13 @@ import { FooterComponent } from '@sagebionetworks/openchallenges/ui';
 export class AboutComponent {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
 
   constructor(private readonly configService: ConfigService) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 }

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -184,4 +184,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -114,6 +114,8 @@ export class ChallengeSearchComponent
 {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
   datePipe: DatePipe = new DatePipe('en-US');
 
   private query: BehaviorSubject<ChallengeSearchQuery> =
@@ -195,6 +197,8 @@ export class ChallengeSearchComponent
   ) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 
   ngOnInit() {

--- a/libs/openchallenges/challenge/src/lib/challenge.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.html
@@ -86,4 +86,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/challenge/src/lib/challenge.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.ts
@@ -61,6 +61,9 @@ import { CommonModule } from '@angular/common';
 export class ChallengeComponent implements OnInit {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
+
   challenge$!: Observable<Challenge>;
   loggedIn = false;
   // progressValue = 0;
@@ -79,6 +82,8 @@ export class ChallengeComponent implements OnInit {
   ) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 
   ngOnInit(): void {

--- a/libs/openchallenges/config/src/lib/config.service.ts
+++ b/libs/openchallenges/config/src/lib/config.service.ts
@@ -16,22 +16,21 @@ export class ConfigService {
     @Inject('APP_BASE_URL') @Optional() private readonly baseUrl: string
   ) {}
 
-  loadConfig(): Promise<void> {
+  async loadConfig(): Promise<void> {
     const appConfig$ = this.http.get<AppConfig>(
       `${this.baseUrl}/config/config.json`
     );
-    return lastValueFrom(appConfig$)
-      .then((config) => {
-        this.config = config;
-        this.config.isPlatformServer = isPlatformServer(this.platformId);
-        this.config.privacyPolicyUrl =
-          'https://sagebionetworks.jira.com/wiki/spaces/OA/pages/2948530178/OpenChallenges+Privacy+Policy';
-        this.config.termsOfUseUrl =
-          'https://sagebionetworks.jira.com/wiki/spaces/OA/pages/2948333575/OpenChallenges+Terms+of+Use';
-      })
-      .catch((err) => {
-        console.error('Unable to load the config file: ', err);
-        return Promise.resolve();
-      });
+    try {
+      const config = await lastValueFrom(appConfig$);
+      this.config = config;
+      this.config.isPlatformServer = isPlatformServer(this.platformId);
+      this.config.privacyPolicyUrl =
+        'https://sagebionetworks.jira.com/wiki/spaces/OA/pages/2948530178/OpenChallenges+Privacy+Policy';
+      this.config.termsOfUseUrl =
+        'https://sagebionetworks.jira.com/wiki/spaces/OA/pages/2948333575/OpenChallenges+Terms+of+Use';
+    } catch (err) {
+      console.error('Unable to load the config file: ', err);
+      return await Promise.resolve();
+    }
   }
 }

--- a/libs/openchallenges/home/src/lib/home.component.html
+++ b/libs/openchallenges/home/src/lib/home.component.html
@@ -27,4 +27,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/home/src/lib/home.component.ts
+++ b/libs/openchallenges/home/src/lib/home.component.ts
@@ -32,9 +32,13 @@ import { TopicsViewerComponent } from './topics-viewer/topics-viewer.component';
 export class HomeComponent {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
 
   constructor(private readonly configService: ConfigService) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 }

--- a/libs/openchallenges/not-found/src/lib/not-found.component.html
+++ b/libs/openchallenges/not-found/src/lib/not-found.component.html
@@ -18,4 +18,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/not-found/src/lib/not-found.component.ts
+++ b/libs/openchallenges/not-found/src/lib/not-found.component.ts
@@ -22,9 +22,13 @@ import { FooterComponent } from '@sagebionetworks/openchallenges/ui';
 export class NotFoundComponent {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
 
   constructor(private readonly configService: ConfigService) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 }

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.html
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.html
@@ -69,4 +69,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
@@ -68,6 +68,8 @@ import { OrgProfileStatsComponent } from './org-profile-stats/org-profile-stats.
 export class OrgProfileComponent implements OnInit {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
   account$!: Observable<Account | undefined>;
   organization$!: Observable<Organization>;
   organizationAvatar$!: Observable<Avatar>;
@@ -87,6 +89,8 @@ export class OrgProfileComponent implements OnInit {
   ) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 
   ngOnInit(): void {

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -81,4 +81,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/org-search/src/lib/org-search.component.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.ts
@@ -82,6 +82,8 @@ import { RadioButtonModule } from 'primeng/radiobutton';
 export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
 
   private query: BehaviorSubject<OrganizationSearchQuery> =
     new BehaviorSubject<OrganizationSearchQuery>({});
@@ -128,6 +130,8 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
   ) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 
   ngOnInit() {

--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -80,4 +80,6 @@
 <openchallenges-footer
   [appVersion]="appVersion"
   [dataUpdatedOn]="dataUpdatedOn"
+  [privacyPolicyUrl]="privacyPolicyUrl"
+  [termsOfUseUrl]="termsOfUseUrl"
 />

--- a/libs/openchallenges/team/src/lib/team.component.ts
+++ b/libs/openchallenges/team/src/lib/team.component.ts
@@ -19,6 +19,8 @@ import { Observable } from 'rxjs';
 export class TeamComponent implements OnInit {
   public appVersion: string;
   public dataUpdatedOn: string;
+  public privacyPolicyUrl: string;
+  public termsOfUseUrl: string;
   public logo$: Observable<Image> | undefined;
   public thomas$: Observable<Image> | undefined;
   public rong$: Observable<Image> | undefined;
@@ -33,6 +35,8 @@ export class TeamComponent implements OnInit {
   ) {
     this.appVersion = this.configService.config.appVersion;
     this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
   }
 
   ngOnInit() {

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.ts
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.ts
@@ -9,8 +9,8 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./footer.component.scss'],
 })
 export class FooterComponent {
-  @Input() appVersion = '';
-  @Input() dataUpdatedOn = '';
-  @Input() privacyPolicyUrl = '';
-  @Input() termsOfUseUrl = '';
+  @Input({ required: true }) appVersion = '';
+  @Input({ required: true }) dataUpdatedOn = '';
+  @Input({ required: true }) privacyPolicyUrl = '';
+  @Input({ required: true }) termsOfUseUrl = '';
 }


### PR DESCRIPTION
- Closes #2027
- Contributes to #1966

## Changelog

- Pass all required input to the footer instances
- Start using `@Input({ required: true })`

## Notes

The footer is defined as a UI component in the project `openchallenges-ui`. Following a best practice from Nx and to make the components reusable, the components defined in this project should not rely on app-specific services. This is the reason why the value of the footer inputs are no longer defined in the footer component itself. Rather, the input values are specified where the footer instances are created.

Unfortunately, the current design is that each page content has its own instance of the footer instead of defining a single instance - e.g. in the `app.component.ts`. I believe that the reason is to provide pages with more flexibility, but as far as I remember, we are not using this flexibility. Hence, the current design leads to code duplication and maintenance. Note that code duplication is one of the metrics measured by SonarCloud.

Unless we really needs the flexibility mentioned above, I would be okay with creating a single footer instance in the `app.component.ts` to reduce duplicated code (in a future PR).