### PR TITLE
feat(fix): Display unique challenge contributions

### DIFF
--- a/libs/openchallenges/challenge/src/lib/challenge-contributors/challenge-contributors.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge-contributors/challenge-contributors.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
 import {
   Challenge,
+  ChallengeContribution,
   ChallengeContributionService,
   Image,
   ImageAspectRatio,
@@ -40,10 +41,11 @@ export class ChallengeContributorsComponent implements OnInit {
       .pipe(
         switchMap((page) =>
           forkJoinConcurrent(
-            page.challengeContributions.map((contribution) =>
-              this.organizationService.getOrganization(
-                contribution.organizationId.toString()
-              )
+            this.uniqueContributions(page.challengeContributions).map(
+              (contribution) =>
+                this.organizationService.getOrganization(
+                  contribution.organizationId.toString()
+                )
             ),
             Infinity
           )
@@ -67,6 +69,17 @@ export class ChallengeContributorsComponent implements OnInit {
         )
       )
       .subscribe((orgCards) => (this.organizationCards = orgCards));
+  }
+
+  private uniqueContributions(
+    contributions: ChallengeContribution[]
+  ): ChallengeContribution[] {
+    return contributions.filter(
+      (b, i) =>
+        contributions.findIndex(
+          (a) => a.organizationId === b.organizationId
+        ) === i
+    );
   }
 
   private sortOrgs(orgs: Organization[]): Organization[] {


### PR DESCRIPTION
- fixes #1947 

### ChangeLog
- filter unique challenge contributions regardless of roles on Challenge profile page  (this will be updated to categorize contributions into different tabs by roles in the future)

### Preview

<img width="567" alt="Screen Shot 2023-09-14 at 10 48 36 AM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/2fba784a-fbf4-4ac0-b448-fc9a3f8957e0">

