### PR TITLE
feat: Update API to get N random challenges

### DIFF
--- a/apps/openchallenges/challenge-service/config/application-local.yml
+++ b/apps/openchallenges/challenge-service/config/application-local.yml
@@ -1,4 +1,2 @@
 openchallenges-challenge-service:
   welcome-message: 'Welcome to the challenge service (local config).'
-
-spring.cache.type: NONE

--- a/apps/openchallenges/challenge-service/config/application-local.yml
+++ b/apps/openchallenges/challenge-service/config/application-local.yml
@@ -1,2 +1,4 @@
 openchallenges-challenge-service:
   welcome-message: 'Welcome to the challenge service (local config).'
+
+spring.cache.type: NONE

--- a/apps/openchallenges/challenge-service/requests.http
+++ b/apps/openchallenges/challenge-service/requests.http
@@ -77,6 +77,10 @@ GET {{basePath}}/challenges?sort=recently_started
 
 GET {{basePath}}/challenges?sort=recently_ended
 
+### Get 5 random challenges
+
+GET {{basePath}}/challenges?sort=random&pageSize=5
+
 ### List the challenge platforms.
 
 GET {{basePath}}/challengePlatforms

--- a/apps/openchallenges/challenge-service/requests.http
+++ b/apps/openchallenges/challenge-service/requests.http
@@ -77,9 +77,13 @@ GET {{basePath}}/challenges?sort=recently_started
 
 GET {{basePath}}/challenges?sort=recently_ended
 
-### Get 5 random challenges
+### Get one random challenge
 
-GET {{basePath}}/challenges?sort=random&pageSize=5
+GET {{basePath}}/challenges?sort=random&pageSize=1
+
+### Get one random challenge with the seed value 10
+
+GET {{basePath}}/challenges?sort=random&sortSeed=10&pageSize=1
 
 ### List the challenge platforms.
 

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSearchQueryDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSearchQueryDto.java
@@ -29,6 +29,9 @@ public class ChallengeSearchQueryDto {
   @JsonProperty("sort")
   private ChallengeSortDto sort = ChallengeSortDto.RELEVANCE;
 
+  @JsonProperty("sortSeed")
+  private Integer sortSeed = null;
+
   @JsonProperty("direction")
   private ChallengeDirectionDto direction = null;
 
@@ -136,6 +139,29 @@ public class ChallengeSearchQueryDto {
 
   public void setSort(ChallengeSortDto sort) {
     this.sort = sort;
+  }
+
+  public ChallengeSearchQueryDto sortSeed(Integer sortSeed) {
+    this.sortSeed = sortSeed;
+    return this;
+  }
+
+  /**
+   * The seed that initializes the random sorter. minimum: 0
+   *
+   * @return sortSeed
+   */
+  @Min(0)
+  @Schema(
+      name = "sortSeed",
+      description = "The seed that initializes the random sorter.",
+      required = false)
+  public Integer getSortSeed() {
+    return sortSeed;
+  }
+
+  public void setSortSeed(Integer sortSeed) {
+    this.sortSeed = sortSeed;
   }
 
   public ChallengeSearchQueryDto direction(ChallengeDirectionDto direction) {
@@ -487,6 +513,7 @@ public class ChallengeSearchQueryDto {
     return Objects.equals(this.pageNumber, challengeSearchQuery.pageNumber)
         && Objects.equals(this.pageSize, challengeSearchQuery.pageSize)
         && Objects.equals(this.sort, challengeSearchQuery.sort)
+        && Objects.equals(this.sortSeed, challengeSearchQuery.sortSeed)
         && Objects.equals(this.direction, challengeSearchQuery.direction)
         && Objects.equals(this.difficulties, challengeSearchQuery.difficulties)
         && Objects.equals(this.incentives, challengeSearchQuery.incentives)
@@ -507,6 +534,7 @@ public class ChallengeSearchQueryDto {
         pageNumber,
         pageSize,
         sort,
+        sortSeed,
         direction,
         difficulties,
         incentives,
@@ -528,6 +556,7 @@ public class ChallengeSearchQueryDto {
     sb.append("    pageNumber: ").append(toIndentedString(pageNumber)).append("\n");
     sb.append("    pageSize: ").append(toIndentedString(pageSize)).append("\n");
     sb.append("    sort: ").append(toIndentedString(sort)).append("\n");
+    sb.append("    sortSeed: ").append(toIndentedString(sortSeed)).append("\n");
     sb.append("    direction: ").append(toIndentedString(direction)).append("\n");
     sb.append("    difficulties: ").append(toIndentedString(difficulties)).append("\n");
     sb.append("    incentives: ").append(toIndentedString(incentives)).append("\n");

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSearchQueryDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSearchQueryDto.java
@@ -147,11 +147,12 @@ public class ChallengeSearchQueryDto {
   }
 
   /**
-   * The seed that initializes the random sorter. minimum: 0
+   * The seed that initializes the random sorter. minimum: 0 maximum: 2147483647
    *
    * @return sortSeed
    */
   @Min(0)
+  @Max(2147483647)
   @Schema(
       name = "sortSeed",
       description = "The seed that initializes the random sorter.",

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSortDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSortDto.java
@@ -13,6 +13,8 @@ public enum ChallengeSortDto {
 
   ENDING_SOON("ending_soon"),
 
+  RANDOM("random"),
+
   RECENTLY_ENDED("recently_ended"),
 
   RECENTLY_STARTED("recently_started"),

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeRepositoryImpl.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/CustomChallengeRepositoryImpl.java
@@ -324,6 +324,9 @@ public class CustomChallengeRepositoryImpl implements CustomChallengeRepository 
       case ENDING_SOON -> {
         return sf.field("end_date").order(orderWithDefaultAsc).toSort();
       }
+      case RANDOM -> {
+        return scoreSort;
+      }
       case RECENTLY_ENDED -> {
         return sf.field("end_date").order(orderWithDefaultDesc).toSort();
       }

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -443,6 +443,12 @@ components:
           type: integer
         sort:
           $ref: '#/components/schemas/ChallengeSort'
+        sortSeed:
+          description: The seed that initializes the random sorter.
+          format: int32
+          minimum: 0
+          nullable: true
+          type: integer
         direction:
           $ref: '#/components/schemas/ChallengeDirection'
         difficulties:

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -353,6 +353,7 @@ components:
       enum:
       - created
       - ending_soon
+      - random
       - recently_ended
       - recently_started
       - relevance

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -446,6 +446,7 @@ components:
         sortSeed:
           description: The seed that initializes the random sorter.
           format: int32
+          maximum: 2147483647
           minimum: 0
           nullable: true
           type: integer

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -167,6 +167,7 @@ components:
       enum:
         - created
         - ending_soon
+        - random
         - recently_ended
         - recently_started
         - relevance

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -262,6 +262,7 @@ components:
           type: integer
           format: int32
           minimum: 0
+          maximum: 2147483647
           nullable: true
         direction:
           $ref: '#/components/schemas/ChallengeDirection'

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -257,6 +257,12 @@ components:
           minimum: 1
         sort:
           $ref: '#/components/schemas/ChallengeSort'
+        sortSeed:
+          description: The seed that initializes the random sorter.
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: true
         direction:
           $ref: '#/components/schemas/ChallengeDirection'
         difficulties:

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -412,6 +412,7 @@ components:
           type: integer
           format: int32
           minimum: 0
+          maximum: 2147483647
           nullable: true
         direction:
           $ref: '#/components/schemas/ChallengeDirection'

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -407,6 +407,12 @@ components:
           minimum: 1
         sort:
           $ref: '#/components/schemas/ChallengeSort'
+        sortSeed:
+          description: The seed that initializes the random sorter.
+          type: integer
+          format: int32
+          minimum: 0
+          nullable: true
         direction:
           $ref: '#/components/schemas/ChallengeDirection'
         difficulties:

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -317,6 +317,7 @@ components:
       enum:
         - created
         - ending_soon
+        - random
         - recently_ended
         - recently_started
         - relevance

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSearchQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSearchQuery.yaml
@@ -20,6 +20,7 @@ properties:
     type: integer
     format: int32
     minimum: 0
+    maximum: 2147483647
     nullable: true
   direction:
     $ref: ChallengeDirection.yaml

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSearchQuery.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSearchQuery.yaml
@@ -15,6 +15,12 @@ properties:
     minimum: 1
   sort:
     $ref: ChallengeSort.yaml
+  sortSeed:
+    description: The seed that initializes the random sorter.
+    type: integer
+    format: int32
+    minimum: 0
+    nullable: true
   direction:
     $ref: ChallengeDirection.yaml
   difficulties:

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSort.yaml
@@ -4,6 +4,7 @@ default: relevance
 enum:
   - created
   - ending_soon
+  - random
   - recently_ended
   - recently_started
   - relevance


### PR DESCRIPTION
Closes #2133

## Description

Update the challenge service to fetch N random challenges with support for pagination. The random results are controlled by the new query parameters `sortSeed`. If the parameter is not specified, then a random seed is used.

## Changelog

- Add the challenge sorter `random`
- Add the challenge search query parameter `sortSeed`

## Notes

Hibernate Search DSL does not allow to define the function score of a query. The solution adopted in this PR consists in implementing the query as a native JSON string.

## Preview

![Recording 2023-09-18 at 21 23 23](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/47a72c05-abf6-44aa-be1e-85deb2b2895f)