### PR TITLE
chore: Remove duplicated VS Code extension information

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,28 +1,4 @@
 {
-  "recommendations": [
-    "1000ch.svgo",
-    "Angular.ng-template",
-    "dbaeumer.vscode-eslint",
-    "emeraldwalk.RunOnSave",
-    "esbenp.prettier-vscode",
-    "firsttris.vscode-jest-runner",
-    "GitHub.vscode-pull-request-github",
-    "Gruntfuggly.todo-tree",
-    "humao.rest-client",
-    "mhutchie.git-graph",
-    "mongodb.mongodb-vscode",
-    "ms-python.python",
-    "mtxr.sqltools-driver-mysql",
-    "mtxr.sqltools-driver-pg",
-    "mtxr.sqltools",
-    "nrwl.angular-console",
-    "ritwickdey.LiveServer",
-    "shengchen.vscode-checkstyle",
-    "stkb.rewrap",
-    "vmware.vscode-boot-dev-pack",
-    "vscjava.vscode-gradle",
-    "vscjava.vscode-java-pack",
-    "webhint.vscode-webhint",
-    "ms-playwright.playwright"
-  ]
+  // Extensions should be defined in `.devcontainer/devcontainer.json` instead of here.
+  "recommendations": []
 }


### PR DESCRIPTION
## Description

VS Code extensions are already installed as part of the devcontainer so there is no need to ask recommend the user to install them.