### PR TITLE
fix: Undo vertical scrolling reset in OC app

### DIFF
--- a/apps/openchallenges/app/src/app/app.config.ts
+++ b/apps/openchallenges/app/src/app/app.config.ts
@@ -48,7 +48,7 @@ export const appConfig: ApplicationConfig = {
       routes,
       withEnabledBlockingInitialNavigation(),
       withInMemoryScrolling({
-        scrollPositionRestoration: 'top',
+        // scrollPositionRestoration: 'top',
       })
     ),
     provideClientHydration(),


### PR DESCRIPTION
Closes #2151 

## Description

Go back to using the default value for `scrollPositionRestoration`.

## Notes

- The issue of search pages seems to be that modifying the filters triggers a page redirection (same page), which is why the scroll position is reset when using `scrollPositionRestoration: top` and `scrollPositionRestoration: enabled`.