### PR TITLE
refactor: update org-service files using field injection

### DIFF
--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegateImpl.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegateImpl.java
@@ -4,14 +4,19 @@ import org.sagebionetworks.openchallenges.organization.service.model.dto.Organiz
 import org.sagebionetworks.openchallenges.organization.service.model.dto.OrganizationSearchQueryDto;
 import org.sagebionetworks.openchallenges.organization.service.model.dto.OrganizationsPageDto;
 import org.sagebionetworks.openchallenges.organization.service.service.OrganizationService;
-import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrganizationApiDelegateImpl implements OrganizationApiDelegate {
 
-  @Autowired OrganizationService organizationService;
+  //@Autowired OrganizationService organizationService;
+  private final OrganizationService organizationService;
+
+  public OrganizationApiDelegateImpl(OrganizationService organizationService) {
+    this.organizationService = organizationService;
+  }
 
   @Override
   public ResponseEntity<OrganizationsPageDto> listOrganizations(OrganizationSearchQueryDto query) {

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegateImpl.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/api/OrganizationApiDelegateImpl.java
@@ -4,14 +4,12 @@ import org.sagebionetworks.openchallenges.organization.service.model.dto.Organiz
 import org.sagebionetworks.openchallenges.organization.service.model.dto.OrganizationSearchQueryDto;
 import org.sagebionetworks.openchallenges.organization.service.model.dto.OrganizationsPageDto;
 import org.sagebionetworks.openchallenges.organization.service.service.OrganizationService;
-//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrganizationApiDelegateImpl implements OrganizationApiDelegate {
 
-  //@Autowired OrganizationService organizationService;
   private final OrganizationService organizationService;
 
   public OrganizationApiDelegateImpl(OrganizationService organizationService) {

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/configuration/HibernateSearchIndexBuild.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/configuration/HibernateSearchIndexBuild.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +15,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class HibernateSearchIndexBuild implements ApplicationListener<ApplicationReadyEvent> {
 
-  @Autowired private EntityManager entityManager;
+  //@Autowired private EntityManager entityManager;
+  private final EntityManager entityManager;
+
+  public HibernateSearchIndexBuild(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
 
   @Override
   @Transactional

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/configuration/HibernateSearchIndexBuild.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/configuration/HibernateSearchIndexBuild.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +14,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class HibernateSearchIndexBuild implements ApplicationListener<ApplicationReadyEvent> {
 
-  //@Autowired private EntityManager entityManager;
   private final EntityManager entityManager;
 
   public HibernateSearchIndexBuild(EntityManager entityManager) {

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
@@ -11,7 +11,6 @@ import org.sagebionetworks.openchallenges.organization.service.model.mapper.Orga
 import org.sagebionetworks.openchallenges.organization.service.model.repository.OrganizationRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +22,6 @@ public class OrganizationService {
 
   private static final Logger LOG = LoggerFactory.getLogger(OrganizationService.class);
 
-  //@Autowired private OrganizationRepository organizationRepository;
   private final OrganizationRepository organizationRepository;
 
   public OrganizationService(OrganizationRepository organizationRepository) {

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/service/OrganizationService.java
@@ -11,7 +11,7 @@ import org.sagebionetworks.openchallenges.organization.service.model.mapper.Orga
 import org.sagebionetworks.openchallenges.organization.service.model.repository.OrganizationRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +23,12 @@ public class OrganizationService {
 
   private static final Logger LOG = LoggerFactory.getLogger(OrganizationService.class);
 
-  @Autowired private OrganizationRepository organizationRepository;
+  //@Autowired private OrganizationRepository organizationRepository;
+  private final OrganizationRepository organizationRepository;
+
+  public OrganizationService(OrganizationRepository organizationRepository) {
+    this.organizationRepository = organizationRepository;
+  }
 
   private OrganizationMapper organizationMapper = new OrganizationMapper();
 


### PR DESCRIPTION
## Description
This pull request modifies the following organization-service files to include constructor, rather than field, injection:
- [x] HibernateSearchIndexBuild.java
- [x] OrganizationService.java
- [x] OrganizationApiDelegateImpl.java
<!-- Please include a brief summary of the changes and the related issue. Itemize 
the changes in the section Changelog (see below). -->

## Related Issue
Issue 1392: https://github.com/Sage-Bionetworks/sage-monorepo/issues/1392
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #(issue)
1392 organization-service only
## Changelog

<!-- Itemize the changes made in this PR. -->

- Add constructor injections see example below:
```
private final OrganizationRepository organizationRepository;

  public OrganizationService(OrganizationRepository organizationRepository) {
    this.organizationRepository = organizationRepository;
  }
```
- Remove field injections i.e. `@Autowired OrganizationRepository organizationRepository`

## Preview

<!-- Demonstrate the feature or bug fix implemented in this PR. For example, -->
<!-- - a screencast that illustrates a new UI feature (e.g. using https://gifcap.dev) -->
<!-- - a request example and its response from a new/updated REST API endpoint -->