### PR TITLE
refactor: Move client hydration provider to the server config

### DIFF
--- a/apps/openchallenges/app/src/app/app.config.server.ts
+++ b/apps/openchallenges/app/src/app/app.config.server.ts
@@ -1,9 +1,10 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';
 import { appConfig, APP_BASE_URL_PROVIDER_INDEX } from './app.config';
+import { provideClientHydration } from '@angular/platform-browser';
 
 const serverConfig: ApplicationConfig = {
-  providers: [provideServerRendering()],
+  providers: [provideServerRendering(), provideClientHydration()],
 };
 
 // The file server.ts defines a provider that specifies 'APP_BASE_URL' based on the request protocol

--- a/apps/openchallenges/app/src/app/app.config.ts
+++ b/apps/openchallenges/app/src/app/app.config.ts
@@ -9,7 +9,6 @@ import {
   provideHttpClient,
 } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { provideClientHydration } from '@angular/platform-browser';
 import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/openchallenges/api-client-angular';
 import {
   configFactory,
@@ -53,6 +52,5 @@ export const appConfig: ApplicationConfig = {
         // scrollPositionRestoration: 'top',
       })
     ),
-    provideClientHydration(),
   ],
 };


### PR DESCRIPTION
## Description

This is to address a warning message shown in the browser console when start the app without SSR (hydration is only useful for SSR, not CSR). This PR implements this change.