### PR TITLE
fix: OC Apex is returning Internal Server Error

### DIFF
--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -220,6 +220,9 @@
           "serverTarget": "openchallenges-app:server:production"
         }
       },
+      "options": {
+        "port": 4201
+      },
       "defaultConfiguration": "development"
     },
     "prerender": {

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -220,9 +220,6 @@
           "serverTarget": "openchallenges-app:server:production"
         }
       },
-      "options": {
-        "port": 4201
-      },
       "defaultConfiguration": "development"
     },
     "prerender": {

--- a/apps/openchallenges/app/server.ts
+++ b/apps/openchallenges/app/server.ts
@@ -11,7 +11,7 @@ import bootstrap from './src/main.server';
 // that process port comes from the above builder utils
 // About setting a constant value: https://github.com/angular/universal/issues/1628
 const PORT = process.env['PORT'] || '4200';
-console.log(`server.ts: ${PORT}`);
+// console.log(`server.ts: ${PORT}`);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/apps/openchallenges/app/server.ts
+++ b/apps/openchallenges/app/server.ts
@@ -11,6 +11,7 @@ import bootstrap from './src/main.server';
 // that process port comes from the above builder utils
 // About setting a constant value: https://github.com/angular/universal/issues/1628
 const PORT = process.env['PORT'] || '4200';
+console.log(`server.ts: ${PORT}`);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/apps/openchallenges/app/server.ts
+++ b/apps/openchallenges/app/server.ts
@@ -11,7 +11,6 @@ import bootstrap from './src/main.server';
 // that process port comes from the above builder utils
 // About setting a constant value: https://github.com/angular/universal/issues/1628
 const PORT = process.env['PORT'] || '4200';
-// console.log(`server.ts: ${PORT}`);
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {

--- a/apps/openchallenges/app/server.ts
+++ b/apps/openchallenges/app/server.ts
@@ -8,6 +8,11 @@ import { join } from 'path';
 
 import bootstrap from './src/main.server';
 
+// that process port comes from the above builder utils
+// About setting a constant value: https://github.com/angular/universal/issues/1628
+const PORT = process.env['PORT'] || '4200';
+console.log(`server.ts: ${PORT}`);
+
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
@@ -54,7 +59,13 @@ export function app(): express.Express {
         // The base URL enables the app to load the app config file during server-side rendering.
         {
           provide: 'APP_BASE_URL',
+          // the format of ${host} is `host:port`
           useFactory: () => `${protocol}://${host}`,
+          deps: [],
+        },
+        {
+          provide: 'APP_PORT',
+          useValue: PORT,
           deps: [],
         },
       ],
@@ -65,12 +76,10 @@ export function app(): express.Express {
 }
 
 function run(): void {
-  const port = process.env['PORT'] || 4200;
-
   // Start up the Node server
   const server = app();
-  server.listen(port, () => {
-    console.log(`Node Express server listening on http://localhost:${port}`);
+  server.listen(PORT, () => {
+    console.log(`Node Express server listening on http://localhost:${PORT}`);
   });
 }
 

--- a/libs/openchallenges/config/src/lib/config.service.ts
+++ b/libs/openchallenges/config/src/lib/config.service.ts
@@ -13,18 +13,23 @@ export class ConfigService {
   constructor(
     private http: HttpClient,
     @Inject(PLATFORM_ID) private platformId: string,
-    @Inject('APP_BASE_URL') @Optional() private readonly baseUrl: string
+    @Inject('APP_PORT') @Optional() private readonly port: string
   ) {}
 
   async loadConfig(): Promise<void> {
-    let browserRoot = '.';
-    if (isPlatformServer(this.platformId)) {
-      browserRoot = 'http://localhost:4200';
-    }
+    console.log(`app port: ${this.port}`);
+    // The location of the browser folder, which includes the config folder, depends on whether the
+    // present code is run in the browser and by the node server. We could use the request received
+    // by the node server (SSR) and get the host and port, but this does not work when the port is
+    // different from the Angular or node port. Note that `localhost` works inside the container
+    // (production) as well as outside (dev server). APP_BASE_URL could be used when running the dev
+    // server and accessing it directly (e.g. APP_BASE_URL = 'http://localhost:37677') but not when
+    // accessing the production server in the container from apex (APP_BASE_URL =
+    // 'http://localhost:8000', which is invalid inside the container).
+    const browserRoot = isPlatformServer(this.platformId)
+      ? `http://localhost:${this.port}`
+      : '.';
 
-    console.log(`base URL: ${this.baseUrl}`);
-    console.log(`is server platform: ${isPlatformServer(this.platformId)}`);
-    // const configFolder = `dist/apps/openchallenges/app/browser/browser/config`;
     const appConfig$ = this.http.get<AppConfig>(
       `${browserRoot}/config/config.json`
     );

--- a/libs/openchallenges/config/src/lib/config.service.ts
+++ b/libs/openchallenges/config/src/lib/config.service.ts
@@ -17,8 +17,16 @@ export class ConfigService {
   ) {}
 
   async loadConfig(): Promise<void> {
+    let browserRoot = '.';
+    if (isPlatformServer(this.platformId)) {
+      browserRoot = 'http://localhost:4200';
+    }
+
+    console.log(`base URL: ${this.baseUrl}`);
+    console.log(`is server platform: ${isPlatformServer(this.platformId)}`);
+    // const configFolder = `dist/apps/openchallenges/app/browser/browser/config`;
     const appConfig$ = this.http.get<AppConfig>(
-      `${this.baseUrl}/config/config.json`
+      `${browserRoot}/config/config.json`
     );
     try {
       const config = await lastValueFrom(appConfig$);

--- a/libs/openchallenges/config/src/lib/config.service.ts
+++ b/libs/openchallenges/config/src/lib/config.service.ts
@@ -17,7 +17,6 @@ export class ConfigService {
   ) {}
 
   async loadConfig(): Promise<void> {
-    console.log(`app port: ${this.port}`);
     // The location of the browser folder, which includes the config folder, depends on whether the
     // present code is run in the browser and by the node server. We could use the request received
     // by the node server (SSR) and get the host and port, but this does not work when the port is


### PR DESCRIPTION
Closes #2168

## Description

This PR enables the node server (Express) to read the app config file in all situations, e.g.

- when accessing the web app directly on port `4200` or via the apex on port `8000`
- when running the app dev server
- when running the app inside its container

## Changelog

- Use different location for the config file depending on whether app is run on the server or in the browser

## Preview

App works when using

- [x] `nx serve openchallenges-app` + access to `localhost:4200`
- [x] `nx serve-ssr openchallenges-app` + access to `localhost:4200`
- [x] `nx build-image openchallenges-app` + `nx serve-detach openchallenges-apex` + access to `localhost:4200`
- [x] `nx build-image openchallenges-app` + `nx serve-detach openchallenges-apex` + access to `localhost:8000`