### PR TITLE
fix(sage-monorepo): update prettier to fix self-closing HTML tags introduced in Angular v16

### DIFF
--- a/libs/openchallenges/home/src/lib/home.component.html
+++ b/libs/openchallenges/home/src/lib/home.component.html
@@ -8,18 +8,19 @@
       <a
         href="https://docs.google.com/forms/d/e/1FAIpQLSdLZ6C5ZIzLZS147bmvNm2eJ3kq_88ecHS7ADjD4KaapGhO8g/viewform"
         target="_blank"
-        >submit new challenges</a>
-        and update existing ones. This will ensure that organization profiles are complete and OC
-        users have access to accurate and up-to-date resources.
+        >submit new challenges</a
+      >
+      and update existing ones. This will ensure that organization profiles are complete and OC
+      users have access to accurate and up-to-date resources.
     </h4>
   </div>
-  <openchallenges-challenge-search/>
-  <openchallenges-statistics-viewer *sageAppShellNoRender/>
-  <openchallenges-random-challenge-list *sageAppShellNoRender/>
-  <openchallenges-challenge-registration *sageAppShellNoRender/>
-  <openchallenges-challenge-host-list *sageAppShellNoRender/>
-  <openchallenges-platforms *sageAppShellNoRender/>
-  <openchallenges-sponsor-list *sageAppShellNoRender/>
+  <openchallenges-challenge-search />
+  <openchallenges-statistics-viewer *sageAppShellNoRender />
+  <openchallenges-random-challenge-list *sageAppShellNoRender />
+  <openchallenges-challenge-registration *sageAppShellNoRender />
+  <openchallenges-challenge-host-list *sageAppShellNoRender />
+  <openchallenges-platforms *sageAppShellNoRender />
+  <openchallenges-sponsor-list *sageAppShellNoRender />
 </main>
 
 <openchallenges-footer

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "openapi-merge-cli": "^1.3.1",
     "postcss-preset-env": "^7.8.3",
     "postcss-url": "^10.1.3",
-    "prettier": "2.7.1",
+    "prettier": "2.8.8",
     "primeicons": "6.0.1",
     "primeng": "16.1.0",
     "serverless": "3.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22881,12 +22881,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.7.1":
-  version: 2.7.1
-  resolution: "prettier@npm:2.7.1"
+"prettier@npm:2.8.8, prettier@npm:^2.8.6":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
   bin:
     prettier: bin-prettier.js
-  checksum: 55a4409182260866ab31284d929b3cb961e5fdb91fe0d2e099dac92eaecec890f36e524b4c19e6ceae839c99c6d7195817579cdffc8e2c80da0cb794463a748b
+  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
   languageName: node
   linkType: hard
 
@@ -22896,15 +22896,6 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.8.6":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
-  bin:
-    prettier: bin-prettier.js
-  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
   languageName: node
   linkType: hard
 
@@ -24312,7 +24303,7 @@ __metadata:
     openapi-merge-cli: ^1.3.1
     postcss-preset-env: ^7.8.3
     postcss-url: ^10.1.3
-    prettier: 2.7.1
+    prettier: 2.8.8
     primeicons: 6.0.1
     primeng: 16.1.0
     probot: 12.2.8


### PR DESCRIPTION
Fixes #2187

## Description

HTML files that include self-closing tags for Angular component can now be saved without Prettier throwing an exception.

## Notes

- Prettier received a major version released 5 months ago. To stay on the safe side, I decided to go with the latest `2.x.x` release. We can try upgrading to the next major version as part of the next bi-annual dependency update.