### PR TITLE
feat(openchallenges): add link to OC API docs

### DIFF
--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -19,7 +19,7 @@
         <li>
           <a 
             href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose"
-            title="Share feedback about the OC app!"
+            title="Share feedback about the OC app"
             rel="noopener noreferrer"
             target="_blank"
             >Submit a Feature/Bug</a

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -19,6 +19,8 @@
         <li>
           <a
             href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose"
+            title="OC source code on GitHub"
+            rel="noopener noreferrer"
             target="_blank"
             >Submit a Feature/Bug</a
           >

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -9,7 +9,13 @@
       <ul class="footer-link-group">
         <li><a href="/about">About</a></li>
         <li><a href="/team">Meet Our Team</a></li>
-        <!-- <li><a href="#">API</a></li> -->
+        <li>
+          <a 
+            href="https://openchallenges.io/api-docs"
+            title="Interactive documentation for OC API"
+            rel="noopener noreferrer"
+            target="_blank"
+            >API Docs</a></li>
         <li>
           <a
             href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose"

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -17,9 +17,9 @@
             target="_blank"
             >API Docs</a></li>
         <li>
-          <a
+          <a 
             href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose"
-            title="OC source code on GitHub"
+            title="Share feedback about the OC app!"
             rel="noopener noreferrer"
             target="_blank"
             >Submit a Feature/Bug</a


### PR DESCRIPTION
Fixes #2208 

## Changelog
* re-add link to API docs in footer
* add `title` and `rel="noopenner noreferer"` attributes to external links (per best practice recommendations)

## Preview
You can't see it in the screenshot, but my mouse is hovering over the **API Docs** link:
![Screenshot 2023-10-06 at 4 10 16 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/2df3e5ae-c8cc-46c1-af54-44cbdc58fbb8)
