### PR TITLE
feat(sage-monorepo): standardize PR title scope

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -18,3 +18,15 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which scopes are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
+          scopes: |
+            agora
+            common
+            openchallenges
+            sage-monorepo
+            schematic
+            synapse
+          # Configure that a scope must always be provided.
+          requireScope: false

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -30,3 +30,6 @@ jobs:
             synapse
           # Configure that a scope must always be provided.
           requireScope: false
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$


### PR DESCRIPTION
Closes #2226

## Changelog

- Configure values that the PR title scope can take
- Ensures the subject doesn't start with an uppercase character

## Preview

The GH workflow updated in this PR is not affecting the title of this PR. The updated workflow should start taking effect once it's merged to `main`.