### PR TITLE
feat(openchallenges): fetch total number of platforms from backend on Home page

### DIFF
--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.html
@@ -62,8 +62,8 @@
       >
         0
       </h2>
-      <p class="mat-body-strong">organizations & hosting<br/>societies</p>
-  </div>
+      <p class="mat-body-strong">organizations & hosting<br />societies</p>
+    </div>
   </div>
   <div class="col text-center">
     <img
@@ -73,8 +73,8 @@
     />
     <div class="metrics-text-box">
       <h2
-        *ngIf="orgCount$ | async as orgCount"
-        [countUp]="13"
+        *ngIf="platformCount$ | async as platformCount"
+        [countUp]="platformCount"
         [reanimateOnClick]="reanimateOnClick"
       >
         0

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.ts
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
 import {
+  ChallengePlatformService,
   ChallengeService,
   Image,
   ImageHeight,
@@ -36,6 +37,7 @@ export class ChallengeSearchComponent implements OnInit {
   searchTerms!: string | undefined;
   challengeCount$: Observable<number> | undefined;
   orgCount$: Observable<number> | undefined;
+  platformCount$: Observable<number> | undefined;
   reanimateOnClick = false;
   challengeImg$: Observable<Image> | undefined;
   orgImg$: Observable<Image> | undefined;
@@ -46,6 +48,7 @@ export class ChallengeSearchComponent implements OnInit {
     private router: Router,
     private imageService: ImageService,
     private challengeService: ChallengeService,
+    private challengePlatformService: ChallengePlatformService,
     private organizationService: OrganizationService,
     @Inject(PLATFORM_ID) private platformId: string
   ) {
@@ -77,6 +80,12 @@ export class ChallengeSearchComponent implements OnInit {
       .pipe(map((page) => page.totalElements));
     this.orgCount$ = this.organizationService
       .listOrganizations({
+        pageNumber: 1,
+        pageSize: 1,
+      })
+      .pipe(map((page) => page.totalElements));
+    this.platformCount$ = this.challengePlatformService
+      .listChallengePlatforms({
         pageNumber: 1,
         pageSize: 1,
       })


### PR DESCRIPTION
- closes #2241 

## Changelog

- use `challengePlatformService` to get the total number of platforms in database

## Preview

<img width="956" alt="Screen Shot 2023-10-19 at 3 47 54 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/100d11cc-900c-43ab-b635-77289c843bf7">
