### PR TITLE
fix(sage-monorepo): format on save Python files with `black`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,6 +45,7 @@
         "mhutchie.git-graph",
         "mongodb.mongodb-vscode",
         "ms-playwright.playwright",
+        "ms-python.black-formatter",
         "ms-python.python",
         "mtxr.sqltools-driver-mysql",
         "mtxr.sqltools-driver-pg",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
   "java.jdt.ls.java.home": "/usr/lib/jvm/java-17-openjdk-amd64",
   "python.linting.enabled": true,
   "python.linting.pylintEnabled": false,
-  "python.linting.flake8Enabled": true,
   "python.formatting.provider": "black",
   "editor.tabSize": 2,
   "editor.formatOnSave": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
   },
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter",
+    "black-formatter.importStrategy": "fromEnvironment",
     "editor.formatOnSave": true,
     "editor.tabSize": 4
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
+  "black-formatter.importStrategy": "fromEnvironment",
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter",
-    "black-formatter.importStrategy": "fromEnvironment",
     "editor.formatOnSave": true,
     "editor.tabSize": 4
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,17 +2,13 @@
   "java.checkstyle.configuration": "checkstyle.xml",
   "java.checkstyle.version": "10.3",
   "java.jdt.ls.java.home": "/usr/lib/jvm/java-17-openjdk-amd64",
-  "python.linting.enabled": true,
-  "python.linting.pylintEnabled": false,
-  "python.formatting.provider": "black",
   "editor.tabSize": 2,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    // "source.fixAll": false,
     "source.fixAll.eslint": true
   },
-  "python.formatting.blackArgs": [],
   "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.formatOnSave": true,
     "editor.tabSize": 4
   },


### PR DESCRIPTION
Closes #2261

## Description

Configure Format On Save for Python files.

## Changelog

- Prevent `flake8` from running when saving Python files
- Add VS Code extension [`ms-python.black-formatter`](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) to the dev container
- Configure Format On Save with Black for Python files

## Notes

- See [Migration to Python Tools Extensions](https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions)
- Requires the new extension to be installed, either manually or by rebuilding the dev container.

Also, the Black extension for VS Code says:

> The bundled black is only used if there is no installed version of black found in the selected python environment.

Your Python project must still have `black` as a dev dependencies in your project poetry file. The above feature of the Black extension means that the output of formatting with `black` programmatically (e.g. in the CI workflow) and in VS Code (Format On Save) should be the same.

Here is the version of Black bundle with the extension used when a Python project does not provide black itself.

```console
2023-10-20 21:42:05.244 [info] SUPPORTED black>=22.3.0
FOUND black==23.3.0
```

After preparing the Python environment for `schematic-api` and activating it in VS Code, we can see that Format On Save use the version of Black specified by the `schematic-api` project. It is this version that will be executed by the CI workflow.

In `pyproject.toml`:

```toml
[tool.poetry.group.dev.dependencies]
black = "23.7.0"
```

```console
2023-10-20 21:57:26.170 [info] SUPPORTED black>=22.3.0
FOUND black==23.7.0
```

## Preview

### Format On Save

![Recording 2023-10-20 at 14 36 12](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/13166570-52ca-4a7d-bcd9-22d9e4819029)