### PR TITLE
fix(sage-monorepo): build and publish the images of all the affected projects in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
     # env:
     #   NX_BRANCH: main
     steps:
-      - name: Show storage space usage
-        run: df -h
-
       - uses: actions/checkout@v3
         name: Checkout [${{ github.ref_name }}]
         with:
@@ -132,21 +129,11 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx affected --target=sonar"
 
-      - name: Show storage space usage
-        run: df -h
-
-      # - name: Publish the images of the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=publish-and-remove-image --parallel=1"
-
       - name: Publishing the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ghcr.io \
-            && nx run-many --target=publish-and-remove-image \
-              --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,openchallenges-api-gateway,schematic-api \
-              --parallel=1"
+            && nx affected --target=publish-image"
 
       - name: Remove the dev container
         run: docker rm -f sage_devcontainer
@@ -165,9 +152,6 @@ jobs:
           || !startsWith(github.head_ref, 'renovate/')
         )
     steps:
-      - name: Show storage space usage
-        run: df -h
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -270,20 +254,10 @@ jobs:
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
             && nx run-many --target=integration-test"
 
-      # - name: Build the images of the affected projects
-      #   run: |
-      #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-      #       && nx affected --target=build-and-remove-image --parallel=1"
-
-      - name: Show storage space usage
-        run: df -h
-
       - name: Building the images of the SELECTED projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=build-and-remove-image \
-            --projects=openchallenges-app,openchallenges-challenge-service,openchallenges-organization-service,openchallenges-image-service,openchallenges-api-gateway,schematic-api \
-              --parallel=1"
+            && nx affected --target=build-image"
 
       - name: Remove the dev container
         run: docker rm -f sage_devcontainer

--- a/apps/agora/mongo/project.json
+++ b/apps/agora/mongo/project.json
@@ -41,20 +41,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -40,20 +40,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-apex:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-apex:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/api-docs/project.json
+++ b/apps/openchallenges/api-docs/project.json
@@ -54,20 +54,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-api-docs:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-api-docs:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -85,20 +85,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-api-gateway:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-api-gateway:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -164,20 +164,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-app:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-app:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -106,20 +106,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -97,20 +97,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-config-server:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-config-server:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/elasticsearch/project.json
+++ b/apps/openchallenges/elasticsearch/project.json
@@ -41,20 +41,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-elasticsearch:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-elasticsearch:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/grafana/project.json
+++ b/apps/openchallenges/grafana/project.json
@@ -44,20 +44,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-grafana:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-grafana:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -109,20 +109,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-image-service:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-image-service:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/mariadb/project.json
+++ b/apps/openchallenges/mariadb/project.json
@@ -39,20 +39,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-mariadb:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-mariadb:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/mysqld-exporter/project.json
+++ b/apps/openchallenges/mysqld-exporter/project.json
@@ -41,20 +41,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-mysqld-exporter:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -109,20 +109,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/{projectName}:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/prometheus/project.json
+++ b/apps/openchallenges/prometheus/project.json
@@ -41,20 +41,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-prometheus:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-prometheus:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/rstudio/project.json
+++ b/apps/openchallenges/rstudio/project.json
@@ -41,20 +41,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-rstudio:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-rstudio:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -85,20 +85,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-service-registry:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-service-registry:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -40,20 +40,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-thumbor:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-thumbor:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/vault/project.json
+++ b/apps/openchallenges/vault/project.json
@@ -40,20 +40,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-vault:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-vault:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/zipkin/project.json
+++ b/apps/openchallenges/zipkin/project.json
@@ -40,20 +40,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-zipkin:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/openchallenges-zipkin:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/schematic/api-docs/project.json
+++ b/apps/schematic/api-docs/project.json
@@ -54,20 +54,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/schematic-api-docs:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/schematic-api-docs:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/schematic/api/project.json
+++ b/apps/schematic/api/project.json
@@ -54,20 +54,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/schematic-api:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/schematic-api:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/synapse/rstudio/project.json
+++ b/apps/synapse/rstudio/project.json
@@ -34,20 +34,6 @@
       },
       "dependsOn": ["build-image"]
     },
-    "publish-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/synapse-rstudio:* --quiet) --force"
-      },
-      "dependsOn": ["publish-image"]
-    },
-    "build-and-remove-image": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "docker rmi $(docker images --filter=reference=ghcr.io/sage-bionetworks/synapse-rstudio:* --quiet) --force"
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Closes #2271

## Description

The CI workflow now builds - and publishes when pushing to `main` - all the Docker images of the affected projects. This set of images had to be reduced to a small, static number because of limited storage space available on the default GH-hosted runner. We recently upgraded Sage Monorepo to use a larger runner, which allows us to build the images of all the affected projects.