### PR TITLE
feat(openchallenges): add temporal information to challenge card

### DIFF
--- a/libs/openchallenges/challenge/src/lib/_challenge-theme.scss
+++ b/libs/openchallenges/challenge/src/lib/_challenge-theme.scss
@@ -45,18 +45,18 @@
     color: #000;
 
     &.active {
-      border-color: #71c663;
-      background-color: #d0fedd;
+      color: #1C5E2A;
+      background-color: #D0FEDD;
     }
 
     &.completed {
-      border-color: #ffb6c1;
-      background-color: #ffdde2;
+      color: map.get($figma, dl-color-default-navbardark);
+      background-color: map.get($primary, 100);
     }
 
     &.upcoming {
-      border-color: #ffc56d;
-      background-color: #fff1bf;
+      color: #E1861F;
+      background-color: #FFF5D1;
     }
   }
 

--- a/libs/openchallenges/challenge/src/lib/challenge.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.html
@@ -7,13 +7,13 @@
           {{ challenge.name }}
           <!-- <mat-icon aria-hidden="true" class="verified">verified_outline</mat-icon> -->
         </h2>
-        <p class="username">@{{ challenge.slug }}</p>
+        <p class="mat-body-strong username">@{{ challenge.slug }}</p>
         <div
           class="profile-type"
           *ngIf="challenge.status"
           [ngClass]="['status', challenge.status ? challenge.status : '']"
         >
-          {{ challenge.status }}
+          {{ challenge.status | titlecase }}
         </div>
       </div>
     </section>

--- a/libs/openchallenges/themes/src/_palettes.scss
+++ b/libs/openchallenges/themes/src/_palettes.scss
@@ -126,7 +126,7 @@ $figma-collection: (
   dl-color-default-navbardark: map.get($dark-blue-palette, 800),
   dl-color-default-secondary1: map.get($light-blue-palette, 300),
   dl-color-default-secondary2: map.get($accent-purple-palette, 300),
-  dl-color-default-darkaccent1: map.get($accent-green-palette, 600),
+  dl-color-default-darkaccent1: map.get($accent-green-palette, 700),
   dl-color-default-darkaccent2: map.get($accent-purple-palette, 200),
   dl-color-gray-black: #000000,
   dl-color-gray-white: #ffffff,

--- a/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
@@ -21,19 +21,15 @@
     border-color: transparent;
     color: map.get($figma, dl-color-default-primary1);
   }
-  .card-icon-alt {
-    border-color: transparent;
-    color: map.get($figma, dl-color-default-darkaccent1);
-  }
   .card-status{
     .active {
-      color: #71c663;
+      color: #24A658;
     }
     .completed {
-      color: #ffb6c1;
+      color: #FA6D6D;
     }
     .upcoming {
-      color: #ffc56d;
+      color: #F8B146;
     }
   }
 }

--- a/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
@@ -24,24 +24,15 @@
     border-color: transparent;
     color: map.get($figma, dl-color-default-primary1);
   }
-  .status-tag {
-    border-color: map.get($figma, dl-color-default-primary2);
-    background-color: map.get($figma, dl-color-default-hover1);
-    color: #000;
-
-    &.active {
-      border-color: #71c663;
-      background-color: #d0fedd;
+  .card-status{
+    .active {
+      color: #71c663;
     }
-
-    &.completed {
-      border-color: #ffb6c1;
-      background-color: #ffdde2;
+    .completed {
+      color: #ffb6c1;
     }
-
-    &.upcoming {
-      border-color: #ffc56d;
-      background-color: #fff1bf;
+    .upcoming {
+      color: #ffc56d;
     }
   }
 }

--- a/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
@@ -16,13 +16,14 @@
     border-color: transparent;
     background-color: map.get($figma, dl-color-default-hover1);
   }
-  .star-icon {
-    border-color: transparent;
-    color: map.get($figma, dl-color-default-primary1);
-  }
+  .star-icon,
   .card-icon {
     border-color: transparent;
     color: map.get($figma, dl-color-default-primary1);
+  }
+  .card-icon-alt {
+    border-color: transparent;
+    color: map.get($figma, dl-color-default-darkaccent1);
   }
   .card-status{
     .active {

--- a/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/_challenge-card-theme.scss
@@ -23,18 +23,22 @@
   }
   .card-status{
     .active {
-      color: #24A658;
+      color: #71C663;
     }
     .completed {
-      color: #FA6D6D;
+      color: map.get($figma, dl-color-default-primary1)
     }
     .upcoming {
-      color: #F8B146;
+      color: #FFC56D;
     }
   }
 }
 
-@mixin typography($theme) { }
+@mixin typography($theme) {
+  .card-status span {
+    font-size: 21px;
+  }
+}
 
 @mixin theme($theme) {
   $color-config: mat.get-color-config($theme);

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -27,12 +27,13 @@
       <p class="mat-caption">{{ desc }}</p>
     </div>
     <div class="card-footer">
-      <mat-icon aria-hidden="true" class="card-icon">auto_awesome</mat-icon>
+      <mat-icon aria-hidden="true" class="card-icon">emoji_events</mat-icon>
       <div class="difficulty-tag mat-small">
         {{ incentives }}
       </div>
-      <div class="status-tag mat-small" [ngClass]="statusClass">
-        {{ status }}
+      <div class="platform-tag mat-small">
+        <mat-icon aria-hidden="true" class="card-icon">location_on</mat-icon>
+        {{ platform.name }}
       </div>
     </div>
   </div>

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -32,7 +32,7 @@
         {{ incentives }}
       </div>
       <div class="platform-tag mat-small">
-        <mat-icon aria-hidden="true" class="card-icon">location_on</mat-icon>
+        <mat-icon aria-hidden="true" class="card-icon-alt">location_on</mat-icon>
         {{ platform.name }}
       </div>
     </div>

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -18,9 +18,12 @@
       <p class="card-title">
         {{ challenge.name }}
       </p>
-      <p class="card-subtitle" *ngIf="platform">
-        {{ platform.name }}
-      </p>
+      <div class="card-status">
+        <div><span [ngClass]="statusClass">•</span> {{ status | titlecase }}</div>
+        <div class="mat-small">
+          {{ time_info }}
+        </div>
+      </div>
       <p class="mat-caption">{{ desc }}</p>
     </div>
     <div class="card-footer">

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -19,7 +19,7 @@
         {{ challenge.name }}
       </p>
       <div class="card-status">
-        <div><span [ngClass]="statusClass">{{ status | titlecase }}</span></div>
+        <div><span [ngClass]="statusClass">●</span> {{ status | titlecase }}</div>
         <div class="mat-small">
           {{ time_info }}
         </div>
@@ -30,10 +30,6 @@
       <mat-icon aria-hidden="true" class="card-icon">emoji_events</mat-icon>
       <div class="difficulty-tag mat-small">
         {{ incentives }}
-      </div>
-      <div class="platform-tag mat-small">
-        <mat-icon aria-hidden="true" class="card-icon">location_on</mat-icon>
-        {{ platform.name }}
       </div>
     </div>
   </div>

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.html
@@ -19,7 +19,7 @@
         {{ challenge.name }}
       </p>
       <div class="card-status">
-        <div><span [ngClass]="statusClass">•</span> {{ status | titlecase }}</div>
+        <div><span [ngClass]="statusClass">{{ status | titlecase }}</span></div>
         <div class="mat-small">
           {{ time_info }}
         </div>
@@ -32,7 +32,7 @@
         {{ incentives }}
       </div>
       <div class="platform-tag mat-small">
-        <mat-icon aria-hidden="true" class="card-icon-alt">location_on</mat-icon>
+        <mat-icon aria-hidden="true" class="card-icon">location_on</mat-icon>
         {{ platform.name }}
       </div>
     </div>

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -19,6 +19,9 @@
   height: 100%;
 }
 .card-status {
+  div:first-child {
+    margin-right: 5px;
+  }
   min-height: 58px;
   display: flex;
   flex-direction: column;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -19,7 +19,7 @@
   height: 100%;
 }
 .card-status {
-  margin: 8px 0 12px;
+  min-height: 58px;
   display: flex;
   flex-direction: column;
   flex-basis: 100%;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -18,6 +18,15 @@
 .card-banner {
   height: 100%;
 }
+.card-status {
+  margin: 8px 0 12px;
+  display: flex;
+  flex-direction: column;
+  flex-basis: 100%;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: flex-start;
+}
 
 // FOOTER
 .difficulty-tag {

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -35,10 +35,3 @@
   flex: 1;
   @include general.line-clamp(2);
 }
-.platform-tag {
-  max-width: 115px;
-  padding-right: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-}

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -36,7 +36,7 @@
   @include general.line-clamp(2);
 }
 .platform-tag {
-  max-width: 110px;
+  max-width: 115px;
   padding-right: 8px;
   display: flex;
   align-items: center;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -13,7 +13,7 @@
   cursor: pointer;
 }
 .card-body {
-  min-height: 160px;
+  min-height: 190px;
 }
 .card-banner {
   height: 100%;

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.scss
@@ -35,17 +35,10 @@
   flex: 1;
   @include general.line-clamp(2);
 }
-.status-tag {
+.platform-tag {
   max-width: 110px;
-  margin-left: 6px;
-  padding: 4px 0;
+  padding-right: 8px;
   display: flex;
-  flex-direction: column;
-  flex-basis: 100%;
-  box-sizing: border-box;
   align-items: center;
-  justify-content: center;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: constants.$dl-radius-radius-radius16;
+  justify-content: flex-start;
 }

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -27,6 +27,7 @@ export class ChallengeCardComponent implements OnInit {
   desc!: string;
   incentives!: string;
   statusClass!: string;
+  time_info!: string | number;
   // difficulty!: string | undefined;
 
   constructor(
@@ -63,6 +64,45 @@ export class ChallengeCardComponent implements OnInit {
         : this.imageService.getImage({
             objectKey: 'banner-default.svg',
           });
+      if (this.challenge.endDate && this.status === 'completed') {
+        this.time_info = `Ended ${this.calcTimeDiff(
+          this.challenge.endDate
+        )} ago`;
+      } else if (this.challenge.endDate && this.status === 'active') {
+        this.time_info = `Ends in ${this.calcTimeDiff(this.challenge.endDate)}`;
+      } else if (this.challenge.startDate && this.status === 'upcoming') {
+        this.time_info = `Starts in ${this.calcTimeDiff(
+          this.challenge.startDate
+        )}`;
+      }
     }
+  }
+
+  calcTimeDiff(date: string | null | undefined) {
+    if (!date) {
+      return '';
+    }
+    const refDate: any = new Date(date + ' 00:00:00');
+    const now: any = new Date();
+    const diffMs = Math.abs(refDate - now);
+
+    // Calculate the time difference in years, months, weeks, days, and hours.
+    const timeDiff = {
+      year: Math.floor(diffMs / 31_556_952_000),
+      month: Math.floor(diffMs / 2_629_746_000),
+      week: Math.floor(diffMs / 604_800_000),
+      day: Math.floor(diffMs / 86_400_000),
+      hour: Math.floor(diffMs / 3_600_000),
+    };
+
+    // Find the largest unit of time and return in human-readable format.
+    let timeDiffString = '';
+    for (const [unit, value] of Object.entries(timeDiff)) {
+      if (value > 0) {
+        timeDiffString = `${value} ${unit}` + (value > 1 ? 's' : '');
+        break;
+      }
+    }
+    return timeDiffString;
   }
 }

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -78,8 +78,9 @@ export class ChallengeCardComponent implements OnInit {
     }
   }
 
-  calcTimeDiff(date: string | null | undefined) {
-    if (!date) {
+  calcTimeDiff(date: string) {
+    const pattern = /\d{4}-\d{2}-\d{2}/;
+    if (!pattern.test(date)) {
       return '';
     }
     const refDate: any = new Date(date + ' 00:00:00');

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -4,8 +4,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
 import {
   Challenge,
-  ChallengePlatformService,
-  SimpleChallengePlatform,
   Image,
   ImageService,
 } from '@sagebionetworks/openchallenges/api-client-angular';
@@ -22,7 +20,6 @@ import { Observable } from 'rxjs';
 export class ChallengeCardComponent implements OnInit {
   @Input({ required: true }) challenge!: Challenge;
   banner$: Observable<Image> | undefined;
-  platform!: SimpleChallengePlatform;
   status!: string | undefined;
   desc!: string;
   incentives!: string;
@@ -30,10 +27,7 @@ export class ChallengeCardComponent implements OnInit {
   time_info!: string | number;
   // difficulty!: string | undefined;
 
-  constructor(
-    private challengePlatformService: ChallengePlatformService,
-    private imageService: ImageService
-  ) {}
+  constructor(private imageService: ImageService) {}
 
   ngOnInit(): void {
     if (this.challenge) {
@@ -42,7 +36,6 @@ export class ChallengeCardComponent implements OnInit {
       // this.difficulty = this.challenge.difficulty
       //   ? startCase(this.challenge.difficulty.replace('-', ''))
       //   : undefined;
-      this.platform = this.challenge.platform;
       this.desc = this.challenge.headline
         ? this.challenge.headline
         : this.challenge.description;
@@ -65,9 +58,10 @@ export class ChallengeCardComponent implements OnInit {
             objectKey: 'banner-default.svg',
           });
       if (this.challenge.endDate && this.status === 'completed') {
-        this.time_info = `Ended ${this.calcTimeDiff(
-          this.challenge.endDate
-        )} ago`;
+        const timeSince = this.calcTimeDiff(this.challenge.endDate);
+        if (timeSince) {
+          this.time_info = `Ended ${timeSince} ago`;
+        }
       } else if (this.challenge.endDate && this.status === 'active') {
         this.time_info = `Ends in ${this.calcTimeDiff(this.challenge.endDate)}`;
       } else if (this.challenge.startDate && this.status === 'upcoming') {
@@ -89,7 +83,6 @@ export class ChallengeCardComponent implements OnInit {
 
     // Calculate the time difference in years, months, weeks, days, and hours.
     const timeDiff = {
-      year: Math.floor(diffMs / 31_556_952_000),
       month: Math.floor(diffMs / 2_629_746_000),
       week: Math.floor(diffMs / 604_800_000),
       day: Math.floor(diffMs / 86_400_000),
@@ -99,7 +92,9 @@ export class ChallengeCardComponent implements OnInit {
     // Find the largest unit of time and return in human-readable format.
     let timeDiffString = '';
     for (const [unit, value] of Object.entries(timeDiff)) {
-      if (value > 0) {
+      if (unit === 'month' && value > 3) {
+        break;
+      } else if (value > 0) {
         timeDiffString = `${value} ${unit}` + (value > 1 ? 's' : '');
         break;
       }


### PR DESCRIPTION
Fixes #2240 

## Changelog
* add logic for calculating time difference in units of years, months, weeks, days, and hours
* display time until start date OR time until end date (depending on status), using the largest non-zero time unit
* due to limited space in the footer: re-arrange the card layout, switching placements of status and platform
* update "Incentives" icon to something more obvious (trophy)
* add fixed heights for status and headline divs; that way, cards stay uniformed in height no matter the contents

## Preview

Footer icons using the same color:

![Screenshot 2023-10-26 at 12 31 22 AM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/f043f851-941c-4425-9e1e-575f18e086e4)

OR one footer icon uses the blue color from our logo and one icon uses the other:

![Screenshot 2023-10-26 at 4 49 56 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/4c234063-5be0-4494-94d2-0f6273411567)



Alternatively, we can forgo displaying the platform altogether (something Addison mentioned as potentially not helpful information):

![Screenshot 2023-10-26 at 12 44 12 AM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/cb1ab5c1-4f6d-428b-ba9c-df7b90b9d86f)


