### PR TITLE
feat(openchallenges): hide page size options on search pages

### DIFF
--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -161,7 +161,6 @@
         [pageNumber]="selectedPageNumber || defaultPageNumber"
         [pageSize]="selectedPageSize || defaultPageSize"
         [totalRecords]="searchResultsCount"
-        [itemsPerPage]="[12, 24, 36, 48]"
         (pageChange)="onParamChange({ pageNumber: $event.page, pageSize: $event.rows,})"
       />
     </div>

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -71,7 +71,6 @@
         [pageNumber]="selectedPageNumber || defaultPageNumber"
         [pageSize]="selectedPageSize || defaultPageSize"
         [totalRecords]="searchResultsCount"
-        [itemsPerPage]="[12, 24, 36, 48]"
         (pageChange)="onParamChange({ pageNumber: $event.page, pageSize: $event.rows,})"
       />
     </div>

--- a/libs/openchallenges/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/openchallenges/ui/src/lib/paginator/paginator.component.ts
@@ -14,7 +14,8 @@ export class PaginatorComponent implements OnInit {
   @Input({ required: false }) pageLinkSize = 5;
   @Input({ required: true }) pageSize = 0; // number of rows to display in new page
   @Input({ required: true }) totalRecords = 0;
-  @Input({ required: true }) itemsPerPage!: number[];
+  @Input({ required: false }) itemsPerPage!: number[];
+
   @Output() pageChange = new EventEmitter();
 
   itemIndex = 0; // index of the first item in the new page


### PR DESCRIPTION
- closes #2094 

## Changelog

- hide the pageSize options (dropdown) on search pages

## Preview

<img width="1161" alt="Screen Shot 2023-11-01 at 1 51 50 AM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/a5d2a500-7df2-4612-a3f7-cc07de4d752a">
