### PR TITLE
feat(openchallenges): add strict eslint rule on null checks 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
         "dot-notation": "off",
         "no-useless-constructor": "off",
         "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-non-null-assertion": "error",
         "prettier/prettier": [
           "error",
           {


### PR DESCRIPTION
- closes #1544

Currently, we can use "bang" operator (!) in TypeScript to bypass the null checks, but it has the potential risk, like actual null or undefined values at runtime leading to unforeseen errors.

## Changelog
- Instead of relying on the "bang" operator, use TypeScript's strict mode to deal with null and undefined values, so that the developers can be informed initially

## Preview

Now using "bang" operator (!) will not bypass the null checks, instead we can use (?) and (??) to handle nulls.
<img width="738" alt="Screen Shot 2023-11-01 at 2 10 41 AM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/b22359d2-db46-4f43-9b88-fa8a965ad9a0">

➡️ see more details about [no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion)