### PR TITLE
feat(openchallenges): add Team button to OC navbar

### DIFF
--- a/libs/openchallenges/about/src/lib/about.component.spec.ts
+++ b/libs/openchallenges/about/src/lib/about.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ConfigService } from '@sagebionetworks/openchallenges/config';
 import { FooterComponent } from '@sagebionetworks/openchallenges/ui';
 import { AboutComponent } from './about.component';
@@ -11,7 +12,7 @@ describe('AboutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientModule, FooterComponent],
+      imports: [HttpClientModule, RouterTestingModule, FooterComponent],
       providers: [ConfigService],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();

--- a/libs/openchallenges/not-found/src/lib/not-found.component.spec.ts
+++ b/libs/openchallenges/not-found/src/lib/not-found.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ConfigService } from '@sagebionetworks/openchallenges/config';
 
 import { NotFoundComponent } from './not-found.component';
@@ -11,7 +12,7 @@ describe('NotFoundComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientModule, NotFoundComponent],
+      imports: [HttpClientModule, RouterTestingModule, NotFoundComponent],
       providers: [ConfigService],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -7,17 +7,19 @@
         alt="OpenChallenges"
       />
       <ul class="footer-link-group">
-        <li><a href="/about">About</a></li>
-        <li><a href="/team">Meet Our Team</a></li>
+        <li><a routerLink="/about">About</a></li>
+        <li><a routerLink="/team">Meet Our Team</a></li>
         <li>
-          <a 
+          <a
             [href]="apiDocsUrl"
             title="Interactive documentation for OC API"
             rel="noopener noreferrer"
             target="_blank"
-            >API Docs</a></li>
+            >API Docs</a
+          >
+        </li>
         <li>
-          <a 
+          <a
             href="https://github.com/Sage-Bionetworks/sage-monorepo/issues/new/choose"
             title="Share feedback about the OC app"
             rel="noopener noreferrer"

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.spec.ts
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { FooterComponent } from './footer.component';
 
 describe('FooterComponent', () => {
@@ -8,7 +9,7 @@ describe('FooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientModule],
+      imports: [HttpClientModule, RouterTestingModule],
     }).compileComponents();
   });
 

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.ts
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'openchallenges-footer',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
@@ -14,6 +14,7 @@
 
   <div class="flex-spacer"></div>
 
+  <a mat-button class="navbar-item" routerLink="/team">Team</a>
   <openchallenges-discord-button />
 
   <!-- <a mat-button class="navbar-item" *ngIf="!isLoggedIn" routerLink="/login" aria-label="Log In">

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
@@ -14,7 +14,7 @@
 
   <div class="flex-spacer"></div>
 
-  <a mat-button class="navbar-item" routerLink="/team">Team</a>
+  <a mat-button class="navbar-item" routerLink="/team">Meet Our Team</a>
   <openchallenges-discord-button />
 
   <!-- <a mat-button class="navbar-item" *ngIf="!isLoggedIn" routerLink="/login" aria-label="Log In">


### PR DESCRIPTION
Closes #2303

## Changelog

- Add the button "Team" to the right panel of the navbar
- Replace `href` by `routerLink` in the navbar and footer for links that target app pages

> **Note**
> Navigating to a page of the app with `href` destroys and reloads the app. This can be observed by looking at the navbar that flickers when navigating with `href`. Instead, navigating to pages of the app should be done with `routerLink` (requires to import the `RouterModule`). In that case, the navbar will remain and only the components that are no longer used will be destroyed, which leads to faster navigation.

## Preview

### Option 1

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/cb7328cf-08b2-455a-bfe0-5f5d6ad22044)

### Option 2

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/5e989889-a40c-473a-93e4-94f2f2014550)

