### PR TITLE
fix(openchallenges): challenge card fixes

### DIFF
--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -72,10 +72,10 @@ export class ChallengeCardComponent implements OnInit {
     }
   }
 
-  calcTimeDiff(date: string, hideFarDates = false) {
+  calcTimeDiff(date: string, hideFarDates = false): string | never {
     const pattern = /\d{4}-\d{2}-\d{2}/;
     if (!pattern.test(date)) {
-      return '';
+      throw Error(`${date} does not match the schema: ${pattern}`);
     }
     const refDate: any = new Date(date + ' 00:00:00');
     const now: any = new Date();

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -58,7 +58,7 @@ export class ChallengeCardComponent implements OnInit {
             objectKey: 'banner-default.svg',
           });
       if (this.challenge.endDate && this.status === 'completed') {
-        const timeSince = this.calcTimeDiff(this.challenge.endDate);
+        const timeSince = this.calcTimeDiff(this.challenge.endDate, true);
         if (timeSince) {
           this.time_info = `Ended ${timeSince} ago`;
         }
@@ -72,7 +72,7 @@ export class ChallengeCardComponent implements OnInit {
     }
   }
 
-  calcTimeDiff(date: string) {
+  calcTimeDiff(date: string, hideFarDates = false) {
     const pattern = /\d{4}-\d{2}-\d{2}/;
     if (!pattern.test(date)) {
       return '';
@@ -92,7 +92,7 @@ export class ChallengeCardComponent implements OnInit {
     // Find the largest unit of time and return in human-readable format.
     let timeDiffString = '';
     for (const [unit, value] of Object.entries(timeDiff)) {
-      if (unit === 'month' && value > 3) {
+      if (hideFarDates && unit === 'month' && value > 3) {
         break;
       } else if (value > 0) {
         timeDiffString = `${value} ${unit}` + (value > 1 ? 's' : '');

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -57,17 +57,23 @@ export class ChallengeCardComponent implements OnInit {
         : this.imageService.getImage({
             objectKey: 'banner-default.svg',
           });
-      if (this.challenge.endDate && this.status === 'completed') {
-        const timeSince = this.calcTimeDiff(this.challenge.endDate, true);
-        if (timeSince) {
-          this.time_info = `Ended ${timeSince} ago`;
+      try {
+        if (this.challenge.endDate && this.status === 'completed') {
+          const timeSince = this.calcTimeDiff(this.challenge.endDate, true);
+          if (timeSince) {
+            this.time_info = `Ended ${timeSince} ago`;
+          }
+        } else if (this.challenge.endDate && this.status === 'active') {
+          this.time_info = `Ends in ${this.calcTimeDiff(
+            this.challenge.endDate
+          )}`;
+        } else if (this.challenge.startDate && this.status === 'upcoming') {
+          this.time_info = `Starts in ${this.calcTimeDiff(
+            this.challenge.startDate
+          )}`;
         }
-      } else if (this.challenge.endDate && this.status === 'active') {
-        this.time_info = `Ends in ${this.calcTimeDiff(this.challenge.endDate)}`;
-      } else if (this.challenge.startDate && this.status === 'upcoming') {
-        this.time_info = `Starts in ${this.calcTimeDiff(
-          this.challenge.startDate
-        )}`;
+      } catch (e: unknown) {
+        console.log(e);
       }
     }
   }

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -73,7 +73,7 @@ export class ChallengeCardComponent implements OnInit {
           )}`;
         }
       } catch (error: unknown) {
-        console.log(e);
+        console.log(error);
       }
     }
   }

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -72,7 +72,7 @@ export class ChallengeCardComponent implements OnInit {
             this.challenge.startDate
           )}`;
         }
-      } catch (e: unknown) {
+      } catch (error: unknown) {
         console.log(e);
       }
     }


### PR DESCRIPTION
## Changelog

* add a new parameter to `calcTimeDiff`, so that hiding timeline > 3 months is optional
   * use case: for active and upcoming challenges, it is still valuable to show the temporal info, even if it's beyond 3 months away 
* add type annotation for return value ([feedback](https://github.com/Sage-Bionetworks/sage-monorepo/pull/2277#discussion_r1377770930)) 
* if an unexpected date format is given, throw an Error instead of returning an empty string ([feedback](https://github.com/Sage-Bionetworks/sage-monorepo/pull/2277#discussion_r1377792909))
   * relatedly, add a try-catch for function call

   > [!NOTE]
   > I had tried the other approach mentioned in the feedback, but I kept getting an error about not being able to do the arithmetic operation when approaching things that way


## Preview

**Before**
![Screenshot 2023-11-02 at 4 58 30 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/47ac0a65-9569-45f1-a6c5-a45e00b68233)

**After**
![Screenshot 2023-11-02 at 4 58 42 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/68638c18-2e37-4a4b-bceb-a95265ee2ff2)
