### PR TITLE
fix(openchallenges): implement responsive width for `mullti-select` filter on search pages

### DIFF
--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.scss
@@ -45,9 +45,12 @@
   padding-top: 0;
   padding-bottom: 0;
 }
+::ng-deep .p-multiselect.p-component {
+  max-width: 200px;
+}
 
-@media screen and (min-width: constants.$md-breakpoint) {
+@media screen and (max-width: constants.$md-breakpoint) {
   ::ng-deep .p-multiselect.p-component {
-    max-width: 200px;
+    max-width: none;
   }
 }

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.scss
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.scss
@@ -1,3 +1,5 @@
+@use 'libs/openchallenges/styles/src/lib/constants';
+
 #title {
   padding: 70px 0 32px;
   align-items: center;
@@ -42,4 +44,10 @@
 ::ng-deep .p-panel.p-panel-toggleable .p-panel-header {
   padding-top: 0;
   padding-bottom: 0;
+}
+
+@media screen and (min-width: constants.$md-breakpoint) {
+  ::ng-deep .p-multiselect.p-component {
+    max-width: 200px;
+  }
 }

--- a/libs/openchallenges/org-search/src/lib/org-search.component.scss
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.scss
@@ -1,3 +1,5 @@
+@use 'libs/openchallenges/styles/src/lib/constants';
+
 #title {
   padding: 70px 0 32px;
   align-items: center;
@@ -38,4 +40,10 @@
 ::ng-deep .p-panel.p-panel-toggleable .p-panel-header {
   padding-top: 0;
   padding-bottom: 0;
+}
+
+@media screen and (min-width: constants.$md-breakpoint) {
+  ::ng-deep .p-multiselect.p-component {
+    max-width: 200px;
+  }
 }

--- a/libs/openchallenges/org-search/src/lib/org-search.component.scss
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.scss
@@ -41,9 +41,12 @@
   padding-top: 0;
   padding-bottom: 0;
 }
+::ng-deep .p-multiselect.p-component {
+  max-width: 200px;
+}
 
-@media screen and (min-width: constants.$md-breakpoint) {
+@media screen and (max-width: constants.$md-breakpoint) {
   ::ng-deep .p-multiselect.p-component {
-    max-width: 200px;
+    max-width: none;
   }
 }

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -50,7 +50,7 @@ em {
 .text-right {
   text-align: right;
 }
-.text-grey, 
+.text-grey,
 span.text-grey a {
   color: rgba(black, 0.38);
 }
@@ -262,7 +262,7 @@ table {
   font-style: italic !important;
 }
 .read-more {
-  text-underline-offset: 3px
+  text-underline-offset: 3px;
 }
 
 // CARDS


### PR DESCRIPTION
- fixes #2349 

## Changelog
- Add a responsive max-width for the multi-select dropdown filter to avoid unexpected expansion of the filter panel

## Preview

Laptop screen:
<img width="596" alt="Screen Shot 2023-11-16 at 3 06 31 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/fc051109-5799-48ab-80ca-99385562d309">

Mobile screen:
<img width="464" alt="Screen Shot 2023-11-16 at 2 55 04 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/710686f7-15d2-4646-add0-e2375a20dcbe">