### PR TITLE
fix(openchallenges): show 'Not available' for empty submission types

### DIFF
--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
@@ -51,7 +51,7 @@
         </tr>
         <tr>
           <td class="text-right">Submission Type</td>
-          <td>
+          <td *ngIf="challenge.inputDataTypes && challenge.submissionTypes.length > 0; else na_subs">
             <span
               nowrap
               *ngFor="let submissionType of challenge.submissionTypes; let isLast = last"
@@ -59,6 +59,9 @@
               {{ prettify(submissionType) }}{{ isLast ? '' : ', ' }}</span
             >
           </td>
+          <ng-template #na_subs>
+            <td><span class="text-grey">Not available</span></td>
+          </ng-template>
         </tr>
         <tr>
           <td class="text-right">Data Type(s)</td>


### PR DESCRIPTION
Fixes #2361 

## Changelog

* add logic for displaying "Not available" if there are no submission types found for a challenge

## Preview

![Screenshot 2023-11-16 at 3 14 46 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/256868d9-2248-4053-833c-12037935d8fc)
