### PR TITLE
chore(openchallenges): make it easier to update the OC API docs image

### DIFF
--- a/apps/openchallenges/api-docs/project.json
+++ b/apps/openchallenges/api-docs/project.json
@@ -36,23 +36,39 @@
       "options": {
         "context": "apps/openchallenges/api-docs",
         "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/openchallenges-api-docs"],
-          "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
+          "images": [
+            "ghcr.io/sage-bionetworks/openchallenges-api-docs"
+          ],
+          "tags": [
+            "type=edge,branch=main",
+            "type=raw,value=local",
+            "type=sha"
+          ]
         },
         "push": false
-      }
+      },
+      "dependsOn": [
+        "build"
+      ]
     },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
         "context": "apps/openchallenges/api-docs",
         "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/openchallenges-api-docs"],
-          "tags": ["type=edge,branch=main", "type=sha"]
+          "images": [
+            "ghcr.io/sage-bionetworks/openchallenges-api-docs"
+          ],
+          "tags": [
+            "type=edge,branch=main",
+            "type=sha"
+          ]
         },
         "push": true
       },
-      "dependsOn": ["build-image"]
+      "dependsOn": [
+        "build-image"
+      ]
     },
     "scan-image": {
       "executor": "nx:run-commands",
@@ -62,6 +78,11 @@
       }
     }
   },
-  "tags": ["type:docs", "scope:backend"],
-  "implicitDependencies": ["openchallenges-api-description"]
+  "tags": [
+    "type:docs",
+    "scope:backend"
+  ],
+  "implicitDependencies": [
+    "openchallenges-api-description"
+  ]
 }


### PR DESCRIPTION
Closes #2366

## Changelog

- Make the task `build-image` of the OC API docs depend on `build` 