### PR TITLE
feat(openchallenges): cap challenges to 2023 on timeline plot

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
@@ -14,11 +14,14 @@ public class ChallengeAnalyticsService {
     List<String> years =
         Arrays.asList(
             "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017",
-            "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025");
+            "2018", "2019", "2020", "2021", "2022", "2023");
     List<Integer> challengeCounts =
-        Arrays.asList(
-            6, 9, 13, 17, 23, 29, 34, 41, 49, 59, 86, 97, 116, 135, 183, 242, 302, 304, 305);
+        Arrays.asList(6, 9, 13, 17, 23, 29, 34, 41, 49, 59, 86, 97, 116, 135, 183, 242, 302);
     Integer undatedChallengeCount = 160;
+
+    // int currentYear = Year.now().getValue();
+    // years.removeIf(year -> Integer.parseInt(year) > currentYear);
+    // challengeCounts = challengeCounts.subList(0, years.size());
 
     return ChallengesPerYearDto.builder()
         .years(years)

--- a/libs/openchallenges/home/src/_lib-theme.scss
+++ b/libs/openchallenges/home/src/_lib-theme.scss
@@ -3,6 +3,7 @@
 @use './lib/challenge-registration/challenge-registration-theme' as challenge-registration;
 @use './lib/featured-challenge-list/featured-challenge-list-theme' as featured-challenge-list;
 @use './lib/challenge-search/challenge-search-theme' as challenge-search;
+@use './lib/statistics-viewer/statistics-viewer-theme' as statistics-viewer;
 
 @mixin theme($theme) {
   @include home.theme($theme);
@@ -10,4 +11,5 @@
   @include challenge-registration.theme($theme);
   @include featured-challenge-list.theme($theme);
   @include challenge-search.theme($theme);
+  @include statistics-viewer.theme($theme);
 }

--- a/libs/openchallenges/home/src/lib/statistics-viewer/_statistics-viewer-theme.scss
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/_statistics-viewer-theme.scss
@@ -1,0 +1,36 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $config: mat.get-color-config($theme);
+  $primary: map.get($config, 'primary');
+  $accent: map.get($config, 'accent');
+  $warn: map.get($config, 'warn');
+  $figma: map.get($config, 'figma');
+
+  #statistics {
+    .caption {
+      font-size: #888;
+    }
+  }
+}
+
+@mixin typography($theme) {
+  #statistics {
+    .caption {
+      font-size: 1em;
+    }
+  }
+}
+
+@mixin theme($theme) {
+  $color-config: mat.get-color-config($theme);
+  @if $color-config != null {
+    @include color($theme);
+  }
+
+  $typography-config: mat.get-typography-config($theme);
+  @if $typography-config != null {
+    @include typography($theme);
+  }
+}

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -3,7 +3,8 @@
   <div class="col container">
     <div echarts [options]="chartOptions"></div>
     <span class="caption">
-      *The plot excludes future challenges and/or challenges with no known start date.
+      *The plot does not include challenges that are planned beyond this year, or those with
+      unspecified start dates.
     </span>
   </div>
 </section>

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -1,7 +1,7 @@
 <section id="statistics" class="mat-typography">
   <h3 class="section-title">Total Challenges Tracked</h3>
   <div class="col container">
-    <div echarts [options]="chartOptions"></div>
+    <div id="timeline-plot" echarts [options]="chartOptions"></div>
     <span class="caption">
       *The plot does not include challenges that are planned beyond this year, or those with
       unspecified start dates.

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -2,5 +2,8 @@
   <h3 class="section-title">Total Challenges Tracked</h3>
   <div class="col container">
     <div echarts [options]="chartOptions"></div>
+    <span class="caption">
+      *The plot excludes future challenges and/or challenges with no known start date.
+    </span>
   </div>
 </section>

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
@@ -14,7 +14,7 @@ $xxl-breakpoint: 1400px;
   margin: 0 auto;
   padding-left: 24px;
   padding-right: 24px;
-  gap: 32px;
+  align-items: center;
 }
 .section-title {
   text-align: center;
@@ -27,6 +27,10 @@ $xxl-breakpoint: 1400px;
   .row {
     flex-wrap: nowrap;
     width: unset;
+  }
+
+  .caption {
+    margin-top: -14px;
   }
 }
 .metrics-container {

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
@@ -16,6 +16,9 @@ $xxl-breakpoint: 1400px;
   padding-right: 24px;
   align-items: center;
 }
+#timeline-plot {
+  width: 100%;
+}
 .section-title {
   text-align: center;
   margin-bottom: 42px;

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -70,24 +70,24 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
                 animationDelay: (dataIndex: number) => dataIndex * 100,
               },
             ],
-            graphic: res.undatedChallengeCount
-              ? {
-                  elements: [
-                    {
-                      type: 'text',
-                      style: {
-                        text:
-                          `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
-                          `without known start dates.`,
-                        fill: '#888',
-                        fontSize: '1em',
-                      },
-                      left: '25%',
-                      bottom: 5,
-                    },
-                  ],
-                }
-              : undefined,
+            // graphic: res.undatedChallengeCount
+            //   ? {
+            //       elements: [
+            //         {
+            //           type: 'text',
+            //           style: {
+            //             text:
+            //               `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
+            //               `without known start dates.`,
+            //             fill: '#888',
+            //             fontSize: '1em',
+            //           },
+            //           left: '25%',
+            //           bottom: 5,
+            //         },
+            //       ],
+            //     }
+            //   : undefined,
           })
       );
   }

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -70,24 +70,6 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
                 animationDelay: (dataIndex: number) => dataIndex * 100,
               },
             ],
-            // graphic: res.undatedChallengeCount
-            //   ? {
-            //       elements: [
-            //         {
-            //           type: 'text',
-            //           style: {
-            //             text:
-            //               `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
-            //               `without known start dates.`,
-            //             fill: '#888',
-            //             fontSize: '1em',
-            //           },
-            //           left: '25%',
-            //           bottom: 5,
-            //         },
-            //       ],
-            //     }
-            //   : undefined,
           })
       );
   }

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { HomeDataService } from '../home-data-service';
 import { NgxEchartsModule, NGX_ECHARTS_CONFIG } from 'ngx-echarts';
-import { EChartsOption, SeriesOption } from 'echarts';
+import { EChartsOption } from 'echarts';
 import { CountUpModule } from 'ngx-countup';
 import { Subscription } from 'rxjs';
 import { RouterModule } from '@angular/router';
@@ -31,124 +31,75 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
     // update plot's data
     this.chartDataSubscription = this.homeDataService
       .getChallengesPerYear()
-      .subscribe((res) => {
-        this.chartOptions = {
-          textStyle: {
-            fontWeight: 'normal',
-            fontFamily: 'Lato, sans-serif',
-            color: '#000',
-          },
-          // title: {
-          //   text: 'The Rise of Challenges',
-          //   left: 'center',
-          // },
-          // tooltip: {
-          //   trigger: 'axis',
-          //   axisPointer: {
-          //     type: 'cross',
-          //   },
-          // },
-          xAxis: {
-            type: 'category',
-            data: res.years,
-            axisLabel: { fontSize: '1em' },
-          },
-          yAxis: [
-            {
-              type: 'value',
-              name: '',
+      .subscribe(
+        (res) =>
+          (this.chartOptions = {
+            textStyle: {
+              fontWeight: 'normal',
+              fontFamily: 'Lato, sans-serif',
+              color: '#000',
+            },
+            // title: {
+            //   text: 'The Rise of Challenges',
+            //   left: 'center',
+            // },
+            // tooltip: {
+            //   trigger: 'axis',
+            //   axisPointer: {
+            //     type: 'cross',
+            //   },
+            // },
+            xAxis: {
+              type: 'category',
+              data: res.years,
               axisLabel: { fontSize: '1em' },
-              nameTextStyle: {
-                fontSize: '1.1em',
-                lineHeight: 56,
-              },
             },
-          ],
-          series: [
-            {
-              name: 'Total challenges',
-              data: res.challengeCounts.map((count, index) => ({
-                value: count,
-                itemStyle:
-                  +res.years[index] >= 2024
-                    ? {
-                        color: '#afa0fe',
-                        borderType: 'dashed',
-                        borderWidth: 2,
-                        borderColor: '#afa0fe',
-                        opacity: 0.3,
-                      }
-                    : {
-                        color: '#afa0fe',
-                      },
-              })),
-              type: 'bar',
-              itemStyle: {
-                color: '#afa0fe',
-              },
-              // disable default clicking
-              silent: true,
-              // make bar plot rise from left to right
-              // instead of rising all together in the same time
-              animationDelay: (dataIndex: number) => dataIndex * 100,
-            },
-          ],
-          graphic: res.undatedChallengeCount
-            ? {
-                elements: [
-                  {
-                    type: 'text',
-                    style: {
-                      text:
-                        `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
-                        `without known start dates.`,
-                      fill: '#888',
-                      fontSize: '1em',
-                    },
-                    left: '25%',
-                    bottom: 5,
-                  },
-                ],
-              }
-            : undefined,
-        };
-
-        const delayFor2023 = res.years.indexOf('2023') * 100;
-        setTimeout(() => {
-          const updatedSeries = (
-            Array.isArray(this.chartOptions.series)
-              ? [...this.chartOptions.series]
-              : [this.chartOptions.series || {}]
-          ) as SeriesOption[];
-
-          // Check if the first series exists and is a bar series before adding markPoint
-          if (updatedSeries[0] && updatedSeries[0].type === 'bar') {
-            updatedSeries[0].markPoint = {
-              symbol: 'pin',
-              symbolSize: 14,
-              symbolOffset: [0, '-25%'],
-              label: {
-                show: true,
-                position: 'top',
-                formatter: '{b}',
-                fontSize: '1em',
-              },
-              data: [
-                {
-                  name: 'OC launched',
-                  xAxis: '2023',
-                  yAxis: res.challengeCounts[res.years.indexOf('2023')],
+            yAxis: [
+              {
+                type: 'value',
+                name: '',
+                axisLabel: { fontSize: '1em' },
+                nameTextStyle: {
+                  fontSize: '1.1em',
+                  lineHeight: 56,
                 },
-              ],
-              itemStyle: {
-                color: 'red',
               },
-              silent: true,
-            };
-          }
-          this.chartOptions = { ...this.chartOptions, series: updatedSeries };
-        }, delayFor2023);
-      });
+            ],
+            series: [
+              {
+                name: 'Total challenges',
+                data: res.challengeCounts,
+                type: 'bar',
+                itemStyle: {
+                  color: '#afa0fe',
+                },
+                // disable default clicking
+                silent: true,
+                // make bar plot rise from left to right
+                // instead of rising all together in the same time
+                animationDelay: (dataIndex: number) => dataIndex * 100,
+              },
+            ],
+            graphic: res.undatedChallengeCount
+              ? {
+                  elements: [
+                    {
+                      type: 'text',
+                      style: {
+                        text:
+                          `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
+                          `without known start dates.`,
+                        fill: '#888',
+                        fontSize: '1em',
+                      },
+                      left: '25%',
+                      bottom: 5,
+                    },
+                  ],
+                }
+              : undefined,
+          })
+      );
   }
 
   // this.challengeService

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { HomeDataService } from '../home-data-service';
 import { NgxEchartsModule, NGX_ECHARTS_CONFIG } from 'ngx-echarts';
-import { EChartsOption } from 'echarts';
+import { EChartsOption, SeriesOption } from 'echarts';
 import { CountUpModule } from 'ngx-countup';
 import { Subscription } from 'rxjs';
 import { RouterModule } from '@angular/router';
@@ -31,75 +31,124 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
     // update plot's data
     this.chartDataSubscription = this.homeDataService
       .getChallengesPerYear()
-      .subscribe(
-        (res) =>
-          (this.chartOptions = {
-            textStyle: {
-              fontWeight: 'normal',
-              fontFamily: 'Lato, sans-serif',
-              color: '#000',
-            },
-            // title: {
-            //   text: 'The Rise of Challenges',
-            //   left: 'center',
-            // },
-            // tooltip: {
-            //   trigger: 'axis',
-            //   axisPointer: {
-            //     type: 'cross',
-            //   },
-            // },
-            xAxis: {
-              type: 'category',
-              data: res.years,
+      .subscribe((res) => {
+        this.chartOptions = {
+          textStyle: {
+            fontWeight: 'normal',
+            fontFamily: 'Lato, sans-serif',
+            color: '#000',
+          },
+          // title: {
+          //   text: 'The Rise of Challenges',
+          //   left: 'center',
+          // },
+          // tooltip: {
+          //   trigger: 'axis',
+          //   axisPointer: {
+          //     type: 'cross',
+          //   },
+          // },
+          xAxis: {
+            type: 'category',
+            data: res.years,
+            axisLabel: { fontSize: '1em' },
+          },
+          yAxis: [
+            {
+              type: 'value',
+              name: '',
               axisLabel: { fontSize: '1em' },
+              nameTextStyle: {
+                fontSize: '1.1em',
+                lineHeight: 56,
+              },
             },
-            yAxis: [
-              {
-                type: 'value',
-                name: '',
-                axisLabel: { fontSize: '1em' },
-                nameTextStyle: {
-                  fontSize: '1.1em',
-                  lineHeight: 56,
-                },
-              },
-            ],
-            series: [
-              {
-                name: 'Total challenges',
-                data: res.challengeCounts,
-                type: 'bar',
-                itemStyle: {
-                  color: '#afa0fe',
-                },
-                // disable default clicking
-                silent: true,
-                // make bar plot rise from left to right
-                // instead of rising all together in the same time
-                animationDelay: (dataIndex: number) => dataIndex * 100,
-              },
-            ],
-            graphic: res.undatedChallengeCount
-              ? {
-                  elements: [
-                    {
-                      type: 'text',
-                      style: {
-                        text:
-                          `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
-                          `without known start dates.`,
-                        fill: '#888',
-                        fontSize: '1em',
+          ],
+          series: [
+            {
+              name: 'Total challenges',
+              data: res.challengeCounts.map((count, index) => ({
+                value: count,
+                itemStyle:
+                  +res.years[index] >= 2024
+                    ? {
+                        color: '#afa0fe',
+                        borderType: 'dashed',
+                        borderWidth: 2,
+                        borderColor: '#afa0fe',
+                        opacity: 0.3,
+                      }
+                    : {
+                        color: '#afa0fe',
                       },
-                      left: '25%',
-                      bottom: 5,
+              })),
+              type: 'bar',
+              itemStyle: {
+                color: '#afa0fe',
+              },
+              // disable default clicking
+              silent: true,
+              // make bar plot rise from left to right
+              // instead of rising all together in the same time
+              animationDelay: (dataIndex: number) => dataIndex * 100,
+            },
+          ],
+          graphic: res.undatedChallengeCount
+            ? {
+                elements: [
+                  {
+                    type: 'text',
+                    style: {
+                      text:
+                        `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
+                        `without known start dates.`,
+                      fill: '#888',
+                      fontSize: '1em',
                     },
-                  ],
-                }
-              : undefined,
-          })
-      );
+                    left: '25%',
+                    bottom: 5,
+                  },
+                ],
+              }
+            : undefined,
+        };
+
+        const delayFor2023 = res.years.indexOf('2023') * 100;
+        setTimeout(() => {
+          const updatedSeries = (
+            Array.isArray(this.chartOptions.series)
+              ? [...this.chartOptions.series]
+              : [this.chartOptions.series || {}]
+          ) as SeriesOption[];
+
+          // Check if the first series exists and is a bar series before adding markPoint
+          if (updatedSeries[0] && updatedSeries[0].type === 'bar') {
+            updatedSeries[0].markPoint = {
+              symbol: 'pin',
+              symbolSize: 14,
+              symbolOffset: [0, '-25%'],
+              label: {
+                show: true,
+                position: 'top',
+                formatter: '{b}',
+                fontSize: '1em',
+              },
+              data: [
+                {
+                  name: 'OC launched',
+                  xAxis: '2023',
+                  yAxis: res.challengeCounts[res.years.indexOf('2023')],
+                },
+              ],
+              itemStyle: {
+                color: 'red',
+              },
+              silent: true,
+            };
+          }
+          this.chartOptions = { ...this.chartOptions, series: updatedSeries };
+        }, delayFor2023);
+      });
   }
 
   // this.challengeService

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -31,75 +31,71 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
     // update plot's data
     this.chartDataSubscription = this.homeDataService
       .getChallengesPerYear()
-      .subscribe(
-        (res) =>
-          (this.chartOptions = {
-            textStyle: {
-              fontWeight: 'normal',
-              fontFamily: 'Lato, sans-serif',
-              color: '#000',
-            },
-            // title: {
-            //   text: 'The Rise of Challenges',
-            //   left: 'center',
-            // },
-            // tooltip: {
-            //   trigger: 'axis',
-            //   axisPointer: {
-            //     type: 'cross',
-            //   },
-            // },
-            xAxis: {
-              type: 'category',
-              data: res.years,
+      .subscribe((res) => {
+        const currentYear = new Date().getFullYear();
+        const futureYearIndex = res.years.findIndex(
+          (year) => +year > currentYear
+        );
+        res.years.splice(futureYearIndex);
+        res.challengeCounts.splice(futureYearIndex);
+
+        this.chartOptions = {
+          textStyle: {
+            fontWeight: 'normal',
+            fontFamily: 'Lato, sans-serif',
+            color: '#000',
+          },
+          xAxis: {
+            type: 'category',
+            data: res.years,
+            axisLabel: { fontSize: '1em' },
+          },
+          yAxis: [
+            {
+              type: 'value',
+              name: '',
               axisLabel: { fontSize: '1em' },
+              nameTextStyle: {
+                fontSize: '1.1em',
+                lineHeight: 56,
+              },
             },
-            yAxis: [
-              {
-                type: 'value',
-                name: '',
-                axisLabel: { fontSize: '1em' },
-                nameTextStyle: {
-                  fontSize: '1.1em',
-                  lineHeight: 56,
-                },
+          ],
+          series: [
+            {
+              name: 'Total challenges',
+              data: res.challengeCounts,
+              type: 'bar',
+              itemStyle: {
+                color: '#afa0fe',
               },
-            ],
-            series: [
-              {
-                name: 'Total challenges',
-                data: res.challengeCounts,
-                type: 'bar',
-                itemStyle: {
-                  color: '#afa0fe',
-                },
-                // disable default clicking
-                silent: true,
-                // make bar plot rise from left to right
-                // instead of rising all together in the same time
-                animationDelay: (dataIndex: number) => dataIndex * 100,
-              },
-            ],
-            graphic: res.undatedChallengeCount
-              ? {
-                  elements: [
-                    {
-                      type: 'text',
-                      style: {
-                        text:
-                          `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
-                          `without known start dates.`,
-                        fill: '#888',
-                        fontSize: '1em',
-                      },
-                      left: '25%',
-                      bottom: 5,
+              // disable default clicking
+              silent: true,
+              // make bar plot rise from left to right
+              // instead of rising all together in the same time
+              animationDelay: (dataIndex: number) => dataIndex * 100,
+            },
+          ],
+          graphic: res.undatedChallengeCount
+            ? {
+                elements: [
+                  {
+                    type: 'text',
+                    style: {
+                      text:
+                        `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
+                        `without known start dates.`,
+                      fill: '#888',
+                      fontSize: '1em',
                     },
-                  ],
-                }
-              : undefined,
-          })
-      );
+                    left: '25%',
+                    bottom: 5,
+                  },
+                ],
+              }
+            : undefined,
+        };
+      });
   }
 
   // this.challengeService

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -31,71 +31,65 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
     // update plot's data
     this.chartDataSubscription = this.homeDataService
       .getChallengesPerYear()
-      .subscribe((res) => {
-        const currentYear = new Date().getFullYear();
-        const futureYearIndex = res.years.findIndex(
-          (year) => +year > currentYear
-        );
-        res.years.splice(futureYearIndex);
-        res.challengeCounts.splice(futureYearIndex);
-
-        this.chartOptions = {
-          textStyle: {
-            fontWeight: 'normal',
-            fontFamily: 'Lato, sans-serif',
-            color: '#000',
-          },
-          xAxis: {
-            type: 'category',
-            data: res.years,
-            axisLabel: { fontSize: '1em' },
-          },
-          yAxis: [
-            {
-              type: 'value',
-              name: '',
+      .subscribe(
+        (res) =>
+          (this.chartOptions = {
+            textStyle: {
+              fontWeight: 'normal',
+              fontFamily: 'Lato, sans-serif',
+              color: '#000',
+            },
+            xAxis: {
+              type: 'category',
+              data: res.years,
               axisLabel: { fontSize: '1em' },
-              nameTextStyle: {
-                fontSize: '1.1em',
-                lineHeight: 56,
-              },
             },
-          ],
-          series: [
-            {
-              name: 'Total challenges',
-              data: res.challengeCounts,
-              type: 'bar',
-              itemStyle: {
-                color: '#afa0fe',
+            yAxis: [
+              {
+                type: 'value',
+                name: '',
+                axisLabel: { fontSize: '1em' },
+                nameTextStyle: {
+                  fontSize: '1.1em',
+                  lineHeight: 56,
+                },
               },
-              // disable default clicking
-              silent: true,
-              // make bar plot rise from left to right
-              // instead of rising all together in the same time
-              animationDelay: (dataIndex: number) => dataIndex * 100,
-            },
-          ],
-          graphic: res.undatedChallengeCount
-            ? {
-                elements: [
-                  {
-                    type: 'text',
-                    style: {
-                      text:
-                        `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
-                        `without known start dates.`,
-                      fill: '#888',
-                      fontSize: '1em',
+            ],
+            series: [
+              {
+                name: 'Total challenges',
+                data: res.challengeCounts,
+                type: 'bar',
+                itemStyle: {
+                  color: '#afa0fe',
+                },
+                // disable default clicking
+                silent: true,
+                // make bar plot rise from left to right
+                // instead of rising all together in the same time
+                animationDelay: (dataIndex: number) => dataIndex * 100,
+              },
+            ],
+            graphic: res.undatedChallengeCount
+              ? {
+                  elements: [
+                    {
+                      type: 'text',
+                      style: {
+                        text:
+                          `*The OC database includes an additional ${res.undatedChallengeCount} challenges ` +
+                          `without known start dates.`,
+                        fill: '#888',
+                        fontSize: '1em',
+                      },
+                      left: '25%',
+                      bottom: 5,
                     },
-                    left: '25%',
-                    bottom: 5,
-                  },
-                ],
-              }
-            : undefined,
-        };
-      });
+                  ],
+                }
+              : undefined,
+          })
+      );
   }
 
   // this.challengeService


### PR DESCRIPTION
- closes #2365 

## Changelog

- change html to reflect caption
- update caption text by not specifying detailed number of missing challenges
- remove challengerPerYear data after current year

## Preview

<img width="1003" alt="Screen Shot 2023-11-17 at 6 23 40 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/fc995c51-9912-441b-8132-ac7a56af6482">
