### PR TITLE
fix(openchallenges): fix the OC image service issue `READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`

### DIFF
--- a/apps/openchallenges/image-service/gradle.properties
+++ b/apps/openchallenges/image-service/gradle.properties
@@ -1,4 +1,4 @@
-fasterxmlVersion=2.15.3
+fasterxmlVersion=2.13.4
 flywaydbVersion=9.4.0
 hibernateSearchVersion=6.1.7.Final
 keycloakVersion=19.0.3

--- a/apps/openchallenges/image-service/gradle.properties
+++ b/apps/openchallenges/image-service/gradle.properties
@@ -1,4 +1,4 @@
-# Updating fasterxml to v2.15.3 resulted in an error (see #2373)
+# Updating fasterxml to v2.15.3 results in an error (see #2373)
 fasterxmlVersion=2.13.4
 flywaydbVersion=9.4.0
 hibernateSearchVersion=6.1.7.Final

--- a/apps/openchallenges/image-service/gradle.properties
+++ b/apps/openchallenges/image-service/gradle.properties
@@ -1,3 +1,4 @@
+# Updating fasterxml to v2.15.3 resulted in an error (see #2373)
 fasterxmlVersion=2.13.4
 flywaydbVersion=9.4.0
 hibernateSearchVersion=6.1.7.Final


### PR DESCRIPTION
Closes #2373

## Changelog

- Downgrade fasterxml package to fix `READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` issue in the image service