### PR TITLE
test(openchallenges): add e2e tests to OC web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .nx-container/
 .pnpm-store/
 .scannerwork/
+playwright-report/
 
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 .coveralls.yml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,3 @@
 {
-  // Extensions should be defined in `.devcontainer/devcontainer.json` instead of here.
-  "recommendations": []
+  "recommendations": ["ms-playwright.playwright"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,4 @@
 {
-  "recommendations": ["ms-playwright.playwright"]
+  // Extensions should be defined in `.devcontainer/devcontainer.json` instead of here.
+  "recommendations": []
 }

--- a/apps/openchallenges/app/.eslintrc.json
+++ b/apps/openchallenges/app/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../../.eslintrc.json"],
+  "extends": ["plugin:playwright/recommended", "../../../.eslintrc.json"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
@@ -27,6 +27,10 @@
     {
       "files": ["*.html"],
       "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    },
+    {
+      "files": ["e2e/**/*.{ts,js,tsx,jsx}"],
       "rules": {}
     }
   ]

--- a/apps/openchallenges/app/e2e/challenge-search-paginator.spec.ts
+++ b/apps/openchallenges/app/e2e/challenge-search-paginator.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('reset page number when query input changes', async ({ page }) => {
+  await page.goto('/challenge');
+
+  // dummy assertion
+  await expect(page.locator('h2')).toHaveText('Challenges');
+});

--- a/apps/openchallenges/app/e2e/example.spec.ts
+++ b/apps/openchallenges/app/e2e/example.spec.ts
@@ -1,8 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('has title', async ({ page }) => {
-  await page.goto('/');
-
-  // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
-});

--- a/apps/openchallenges/app/e2e/example.spec.ts
+++ b/apps/openchallenges/app/e2e/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('/');
+
+  // Expect h1 to contain a substring.
+  expect(await page.locator('h1').innerText()).toContain('Welcome');
+});

--- a/apps/openchallenges/app/e2e/home.spec.ts
+++ b/apps/openchallenges/app/e2e/home.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('has banner', async ({ page }) => {
+  await page.goto('/');
+
+  // Expect first h4 to contain a substring.
+  await expect(page.locator('h4').first()).toHaveText(
+    'Welcome to OpenChallenges!'
+  );
+});

--- a/apps/openchallenges/app/jest.config.ts
+++ b/apps/openchallenges/app/jest.config.ts
@@ -14,7 +14,7 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)', 'e2e/'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/apps/openchallenges/app/jest.config.ts
+++ b/apps/openchallenges/app/jest.config.ts
@@ -14,7 +14,8 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)', 'e2e/'],
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  testPathIgnorePatterns: ['<rootDir>/e2e'],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/apps/openchallenges/app/playwright.config.ts
+++ b/apps/openchallenges/app/playwright.config.ts
@@ -25,9 +25,32 @@ export default defineConfig({
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
     },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    /* Test against mobile viewports. */
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+    /* Test against branded browsers. */
+    // When Google Chrome and/or Microsoft Edge are installed in the dev container, Playwright will
+    // use one of them to open the HTML report. These browsers are slow to open and respond because
+    // they are emulated. It is recommended to now use them in combination with the HTML report. By
+    // default, when Chrome and Edge are not installed, the HTML report opens in the native browser
+    // of the developer, which is much faster.
     // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
+    //   name: 'Google Chrome', use: { ...devices['Desktop Chrome'], channel: 'chrome' }, // or
+    //   'chrome-beta'
+    // },
+    // {
+    //   name: 'Microsoft Edge', use: { ...devices['Desktop Edge'], channel: 'msedge' }, // or
+    //   'msedge-dev'
     // },
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/apps/openchallenges/app/playwright.config.ts
+++ b/apps/openchallenges/app/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// import { workspaceRoot } from '@nx/devkit';
+
+// For CI, you may want to set BASE_URL to the deployed application.
+const baseURL = process.env['BASE_URL'] || 'http://localhost:3000';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './e2e' }),
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    baseURL,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+  /* Run your local dev server before starting the tests */ // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  //   cwd: workspaceRoot,
+  // },
+});

--- a/apps/openchallenges/app/playwright.config.ts
+++ b/apps/openchallenges/app/playwright.config.ts
@@ -1,16 +1,10 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 import { nxE2EPreset } from '@nx/playwright/preset';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
-
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -21,6 +15,21 @@ export default defineConfig({
     // includeMobileBrowsers: true, // includes mobile Chrome and Safari
     // includeBrandedBrowsers: true, // includes Google Chrome and Microsoft Edge
   }),
+  projects: [
+    /* Test against desktop browsers */
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL,
@@ -29,11 +38,11 @@ export default defineConfig({
   },
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'nx serve',
+    command: 'nx serve openchallenges-app',
     url: 'http://127.0.0.1:4200',
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },
-  reporter: [['line'], ['html', { open: 'never' }]],
+  reporter: [['line'], ['html', { open: 'always' }]],
   // reporter: process.env.CI ? 'html' : 'line',
 });

--- a/apps/openchallenges/app/playwright.config.ts
+++ b/apps/openchallenges/app/playwright.config.ts
@@ -66,6 +66,6 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },
-  reporter: [['line'], ['html', { open: 'always' }]],
+  reporter: [['line'], ['html', { open: 'never' }]],
   // reporter: process.env.CI ? 'html' : 'line',
 });

--- a/apps/openchallenges/app/playwright.config.ts
+++ b/apps/openchallenges/app/playwright.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from '@playwright/test';
 import { nxE2EPreset } from '@nx/playwright/preset';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-// import { workspaceRoot } from '@nx/devkit';
+import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:3000';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
 
 /**
  * Read environment variables from file.
@@ -16,17 +16,24 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:3000';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  ...nxE2EPreset(__filename, { testDir: './e2e' }),
+  ...nxE2EPreset(__filename, {
+    testDir: './e2e',
+    // includeMobileBrowsers: true, // includes mobile Chrome and Safari
+    // includeBrandedBrowsers: true, // includes Google Chrome and Microsoft Edge
+  }),
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
-  /* Run your local dev server before starting the tests */ // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  //   cwd: workspaceRoot,
-  // },
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'nx serve',
+    url: 'http://127.0.0.1:4200',
+    reuseExistingServer: !process.env.CI,
+    cwd: workspaceRoot,
+  },
+  reporter: [['line'], ['html', { open: 'never' }]],
+  // reporter: process.env.CI ? 'html' : 'line',
 });

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -230,6 +230,13 @@
       "options": {
         "command": "node tools/generate-sitemap.js http://localhost:4200 apps/openchallenges/app/src/sitemap.xml"
       }
+    },
+    "e2e": {
+      "executor": "@nx/playwright:playwright",
+      "outputs": ["{workspaceRoot}/dist/.playwright/apps/openchallenges/app"],
+      "options": {
+        "config": "apps/openchallenges/app/playwright.config.ts"
+      }
     }
   },
   "tags": ["type:app", "scope:client", "language:typescript"],

--- a/apps/openchallenges/app/tsconfig.spec.json
+++ b/apps/openchallenges/app/tsconfig.spec.json
@@ -4,8 +4,18 @@
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
     "target": "es2016",
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "files": ["src/test-setup.ts"],
-  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
Closes #2377

## Description

This PR adds the task `e2e` to the project `openchallenges-app`. The e2e tests are run for different browsers with Playwright. The browsers and devices tested are defined in `playwright.config.ts`.

E2e tests with Playwright work very smoothly with our dev container. It's easy to install the browser and their dependencies (see below), even Google Chrome and Microsoft Edge.

## Changelog

- Add e2e tests with Playwright using Nx generator
- Configure Playwright to output results to the terminal
- Configure Playwright to not automatically open the HTML report (could be configured with an env var)
- Configure Jest to exclude e2e tests

## Future work

- Update the dev container to include all browser dependencies so they are available to the CI workflow and to the developers.
- Identify the devices and browser that we want to support (Done)
- Figure out how to test webkit browser in dev container (Done)
- Run e2e tests during CI

## Notes

- Good reads/watches
  - [Introducing Playwright Support for Nx](https://blog.nrwl.io/introducing-playwright-support-for-nx-d8108ee11d46)
  - [Introducing Official Support for Playwright (video)](https://www.youtube.com/watch?v=k1U3PuBrZFQ)
  - [Playwright Docs: Browsers](https://playwright.dev/docs/browsers)

## Preview

### Local workflow

Build the latest images and start the OC stack:

```console
openchallenges-build-images
nx serve-detach openchallenges-apex
```

If you want to update the web app at the same time as developing the tests, start the web app in development mode:

```console
docker rm -f openchallenges-app
nx serve openchallenges-app
```

Run the task `e2e` for the project `openchallenges-app`:

```console
nx e2e openchallenges-app
```

The results will be displayed in the terminal. A URL will also be provided to open an HTML report in your browser.

### Add e2e test to an existing project

```console
nx g @nx/playwright:configuration --project=openchallenges-app [--dry-run]
```

### List of browsers supported by Playwright

```console
$ npx playwright install --with-deps edge
Failed to install browsers
Error: Invalid installation targets: 'edge'. Expecting one of: chromium, chrome, chrome-beta, msedge, msedge-beta, msedge-dev, firefox, firefox-asan, webkit
```

### Install browser dependencies

> **Note**
> Adding these dependencies to the dev container would make them readily available to developers and CI.

```console
# Install the browser and their dependencies
npx playwright install --with-deps firefox
npx playwright install --with-deps chromium
npx playwright install --with-deps webkit

# Installing Chrome and Edge is not recommended when using the HTML report (see comment in `playwright.config.ts`).
#npx playwright install --with-deps chrome
#npx playwright install --with-deps msedge
```

OLD:

```console
# chromium (adds 28.6 MB)
sudo apt-get install libatk-bridge2.0-0 libxkbcommon0 libatspi2.0-0 libgbm1 

# firefox (adds 25.0 MB)
sudo apt-get install libgtk-3-0 libcairo-gobject2 libdbus-glib-1-2 
```

## Preview

### Run individual test with Playwrite extension for VS Code

Initially, the check mark is replaced by a green play button. Upon clicking it, the test is executed. In the example below, ignore the "Run" button (used by Jest runner).

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/b8de5a5c-cb5f-4c5b-a0e8-65393fcdd1da)

### Run individual test (with Jest; not recommended)

Consider this test:

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/e3638fdc-203b-48d5-a224-032df0ee8a9b)

Clicking on "Run" generates the following output (the commands listed in the terminal are inputted and executed by Jest). While this seems to work fine, the docs printed below recommends to not run e2e with Jest. This PR now excludes the folder `e2e` from the folders taken into account by Jest.

```console
vscode@9f210d49fa49:/workspaces/sage-monorepo$ cd '/workspaces/sage-monorepo'
vscode@9f210d49fa49:/workspaces/sage-monorepo$ node 'node_modules/.bin/jest' '/workspaces/sage-monorepo/apps/openchallenges/app/e2e/home.spec.ts' -c '/workspaces/sage-monorepo/apps/openchallenges/app/jest.config.ts' -t 'has banner'
 FAIL   openchallenges  apps/openchallenges/app/e2e/home.spec.ts
  ● Test suite failed to run

    Playwright Test needs to be invoked via 'npx playwright test' and excluded from Jest test runs.
    Creating one directory for Playwright tests and one for Jest is the recommended way of doing it.
    See https://playwright.dev/docs/intro for more information about Playwright Test.

      3 | test('has banner', async ({ page }) => {
      4 |   await page.goto('/');
    > 5 |
        | ^
      6 |   // Expect first h4 to contain a substring.
      7 |   await expect(page.locator('h4').first()).toHaveText(
      8 |     'Welcome to OpenChallenge!'

      at throwIfRunningInsideJest (../../../node_modules/@playwright/test/lib/common/testType.js:214:11)
      at TestTypeImpl._createTest (../../../node_modules/@playwright/test/lib/common/testType.js:74:5)
      at ../../../node_modules/@playwright/test/lib/transform/transform.js:235:12
      at Object.<anonymous> (e2e/home.spec.ts:5:17)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        4.247 s
Ran all test suites matching /\/workspaces\/sage-monorepo\/apps\/openchallenges\/app\/e2e\/home.spec.ts/i with tests matching "has banner".
```

### More browsers

Example of browsers that we may support. This browsers to tests are defined in `playwright.config.ts`.

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/b28caec3-359a-4f37-a3e9-f32bb44adeb6)

### Run e2e with `--ui` (+ watch mode)

This command starts the Playwright tool:

```console
nx e2e openchallenges-app --ui
```

Here on Windows:

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/6e168082-8af5-48c8-9465-35d41904d673)

Click on this icon to enable the watch mode, which will rerun the test when the code is saved:

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/543baa53-d9d2-4e1e-9e6e-26157dd07603)

