### PR TITLE
test(openchallenges): update dev container image for better TypeScript testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Sage Dev Container",
-  "image": "ghcr.io/sage-bionetworks/sage-devcontainer:0d98658",
+  "image": "ghcr.io/sage-bionetworks/sage-devcontainer:be08406",
 
   "containerEnv": {
     "NX_BASE": "${localEnv:NX_BASE}",
@@ -24,9 +24,7 @@
 
   "customizations": {
     "codespaces": {
-      "openFiles": [
-        "README.md"
-      ]
+      "openFiles": ["README.md"]
     },
     "vscode": {
       "extensions": [
@@ -36,7 +34,6 @@
         "eamodio.gitlens",
         "emeraldwalk.RunOnSave",
         "esbenp.prettier-vscode",
-        "firsttris.vscode-jest-runner",
         "formulahendry.auto-rename-tag",
         "github.vscode-github-actions",
         "GitHub.vscode-pull-request-github",
@@ -53,6 +50,7 @@
         "mtxr.sqltools",
         "njpwerner.autodocstring",
         "nrwl.angular-console",
+        "Orta.vscode-jest",
         "pranaygp.vscode-css-peek",
         "ritwickdey.LiveServer",
         "shengchen.vscode-checkstyle",
@@ -70,40 +68,9 @@
   },
 
   "forwardPorts": [
-    3000,
-    3306,
-    4200,
-    4211,
-    5017,
-    5200,
-    5432,
-    5601,
-    7010,
-    7080,
-    7200,
-    7888,
-    8010,
-    8071,
-    8000,
-    8080,
-    8081,
-    8082,
-    8083,
-    8084,
-    8085,
-    8086,
-    8090,
-    8091,
-    8092,
-    8200,
-    8787,
-    8888,
-    8889,
-    9090,
-    9104,
-    9200,
-    9411,
-    27017
+    3000, 3306, 4200, 4211, 5017, 5200, 5432, 5601, 7010, 7080, 7200, 7888, 8010, 8071, 8000, 8080,
+    8081, 8082, 8083, 8084, 8085, 8086, 8090, 8091, 8092, 8200, 8787, 8888, 8889, 9090, 9104, 9200,
+    9411, 27017
   ],
 
   "portsAttributes": {
@@ -249,7 +216,7 @@
     }
   },
 
-	"remoteUser": "vscode",
+  "remoteUser": "vscode",
   "shutdownAction": "stopContainer",
   "runArgs": ["--name", "sage_devcontainer"]
 }

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -102,7 +102,7 @@ function workspace-nx-cloud-help {
 function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 function check-vscode-version {
-  expected="1.81.1"
+  expected="1.84.2"
   actual="$(code --version | head -n 1)"
   if [ $(version $actual) -lt $(version $expected) ]; then
     echo "📦 Please update VS Code (${actual}) to version ${expected} or above."


### PR DESCRIPTION
- Closes #2390
- Contributes to #2387

## Changelog

- Switch to a different Jest extension for VS Code
- Update the recommended version of VS Code

## Notes

- I expected the browsers themselves (FF, Chromium, Webkit) to be already installed as part of the dev container, but running `nx e2e openchallenges-app` the first time still installed them again (same location as when installed in the dev container, i.e. in the home folder of the user `vscode`).

## Preview

### Running tests with the previous Jest extension

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/096e659e-2f3e-46bb-a9b9-c3827ee63c71)

### Running tests with the new extension

> **Note**
> Individual tests are run by clicking on a green arrow. E2e with Playwright will also be run with the same green arrow.

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/cedf8b0a-0b92-499c-890f-942b35340979)

Cc: @rrchai @vpchung @sagely1 

