### PR TITLE
fix(openchallenges): make homepage more mobile-friendly

### DIFF
--- a/libs/openchallenges/styles/src/lib/_constants.scss
+++ b/libs/openchallenges/styles/src/lib/_constants.scss
@@ -34,6 +34,6 @@ $xl-breakpoint: 1200px;
 $xxl-breakpoint: 1400px;
 
 // Dimensions of component
-$navbar-height: 68px;
+$navbar-height: 75px;
 $navbar-height-tall: 240px;
 $footer-height: 259px;

--- a/libs/openchallenges/styles/src/lib/_general.scss
+++ b/libs/openchallenges/styles/src/lib/_general.scss
@@ -422,7 +422,7 @@ table {
 }
 @media only screen and (max-width: constants.$lg-breakpoint) {
   html {
-    margin-top: constants.$navbar-height-tall;
+    margin-top: constants.$navbar-height;
   }
 
   .card-group {

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.html
@@ -1,30 +1,37 @@
-<!-- TODO: figure out if the <nav> should go inside of a <header> element. -->
-<nav class="sage-navbar" aria-label="Top Toolbar">
-  <a mat-button routerLink="/" aria-label="Home">
-    <img
-      class="logo"
-      src="/openchallenges-assets/images/openchallenges-color.svg"
-      alt="OpenChallenges"
-    />
-  </a>
-
-  <a mat-button class="navbar-item" *ngFor="let key of sectionsKeys" [routerLink]="key"
-    >{{ sections[key].name }}
-  </a>
-
-  <div class="flex-spacer"></div>
-
-  <a mat-button class="navbar-item" routerLink="/team">Meet Our Team</a>
-  <openchallenges-discord-button />
-
-  <!-- <a mat-button class="navbar-item" *ngIf="!isLoggedIn" routerLink="/login" aria-label="Log In">
-    Log In
-  </a> -->
-  <!-- *ngIf="isLoggedIn" -->
-  <!-- <openchallenges-user-button
-    class="test"
-    [avatar]="userAvatar"
-    [menuItems]="userMenuItems"
-    (menuItemSelected)="selectUserMenuItem($event)"
-  /> -->
+<nav aria-label="Navbar">
+  <mat-toolbar class="sage-navbar">
+    <a mat-button routerLink="/" aria-label="Home">
+      <img
+        class="logo"
+        src="/openchallenges-assets/images/openchallenges-color.svg"
+        alt="OpenChallenges"
+      />
+    </a>
+    <div fxFlex fxLayout fxLayoutAlign="end" fxHide.gt-sm>
+      <button mat-icon-button (click)="onToggleSidenav()">
+        <mat-icon aria-hidden="true">menu</mat-icon>
+      </button>
+    </div>
+    <div fxFlex fxLayout fxLayoutAlign="start" fxHide.lt-md>
+      <a mat-button *ngFor="let key of sectionsKeys" [routerLink]="key"
+        >{{ sections[key].name }}
+      </a>
+    </div>
+  
+    <div fxFlex fxLayout fxLayoutAlign="end" fxHide.lt-md>
+      <a mat-button class="navbar-item" routerLink="/team">Meet Our Team</a>
+      <openchallenges-discord-button />
+    </div>
+  </mat-toolbar>
 </nav>
+
+<!-- <a mat-button class="navbar-item" *ngIf="!isLoggedIn" routerLink="/login" aria-label="Log In">
+  Log In
+</a> -->
+<!-- *ngIf="isLoggedIn" -->
+<!-- <openchallenges-user-button
+  class="test"
+  [avatar]="userAvatar"
+  [menuItems]="userMenuItems"
+  (menuItemSelected)="selectUserMenuItem($event)"
+/> -->

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.scss
@@ -21,11 +21,9 @@
     }
   }
 }
-
 .flex-spacer {
   flex-grow: 1;
 }
-
 .logo {
   height: 36px;
   vertical-align: middle;
@@ -36,13 +34,7 @@
     width: 100%;
     align-self: center;
   }
-  .sage-navbar {
-    height: constants.$navbar-height-tall;
-  }
   .flex-spacer {
     flex-grow: 0;
-  }
-  .test {
-    width: 100%;
   }
 }

--- a/libs/openchallenges/ui/src/lib/navbar/navbar.component.ts
+++ b/libs/openchallenges/ui/src/lib/navbar/navbar.component.ts
@@ -4,10 +4,13 @@ import { RouterModule } from '@angular/router';
 import { Avatar } from '../avatar/avatar';
 import { EMPTY_AVATAR } from '../avatar/mock-avatars';
 import { MenuItem } from '../user-button/menu-item';
+import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { UserButtonComponent } from '../user-button/user-button.component';
 import { DiscordButtonComponent } from '../discord-button/discord-button.component';
 import { NavbarSection } from './navbar-section';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { FlexLayoutModule } from '@ngbracket/ngx-layout';
 
 @Component({
   selector: 'openchallenges-navbar',
@@ -18,6 +21,9 @@ import { NavbarSection } from './navbar-section';
     MatButtonModule,
     UserButtonComponent,
     DiscordButtonComponent,
+    MatIconModule,
+    MatToolbarModule,
+    FlexLayoutModule,
   ],
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
@@ -29,6 +35,7 @@ export class NavbarComponent {
   @Input({ required: true }) userMenuItems: MenuItem[] = [];
   @Output() userMenuItemSelected = new EventEmitter<MenuItem>();
   @Output() logInClicked = new EventEmitter<boolean>();
+  @Output() sidenavToggle = new EventEmitter();
 
   private _sections: { [key: string]: NavbarSection } = {};
   sectionsKeys: string[] = [];
@@ -46,4 +53,8 @@ export class NavbarComponent {
   selectUserMenuItem(menuItem: MenuItem) {
     this.userMenuItemSelected.emit(menuItem);
   }
+
+  public onToggleSidenav = () => {
+    this.sidenavToggle.emit();
+  };
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@angular-architects/module-federation": "14.3.14",
     "@angular/animations": "16.2.1",
-    "@angular/cdk": "16.2.1",
+    "@angular/cdk": "^17.0.3",
     "@angular/common": "16.2.1",
     "@angular/compiler": "16.2.1",
     "@angular/core": "16.2.1",
@@ -27,6 +27,7 @@
     "@angular/platform-server": "16.2.1",
     "@angular/router": "16.2.1",
     "@cdktf/provider-aws": "14.0.2",
+    "@ngbracket/ngx-layout": "^17.0.0",
     "@nguniversal/express-engine": "16.2.0",
     "@swc/helpers": "0.5.1",
     "@types/commander": "^2.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,20 +342,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/cdk@npm:16.2.1":
-  version: 16.2.1
-  resolution: "@angular/cdk@npm:16.2.1"
+"@angular/cdk@npm:^17.0.3":
+  version: 17.0.3
+  resolution: "@angular/cdk@npm:17.0.3"
   dependencies:
     parse5: ^7.1.2
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/common": ^16.0.0 || ^17.0.0
-    "@angular/core": ^16.0.0 || ^17.0.0
+    "@angular/common": ^17.0.0 || ^18.0.0
+    "@angular/core": ^17.0.0 || ^18.0.0
     rxjs: ^6.5.3 || ^7.4.0
   dependenciesMeta:
     parse5:
       optional: true
-  checksum: 119184f800138ce284a0bb4af2f4ba8a71cdc78ba6090a9c5bf49e24bc60642f4929bd01b1735d3fc437b91b1bb0741d20218a8478efb2d89bff3cb55049d666
+  checksum: 616875935bd4d6119b639666bdad3c20a83da245af6a381266c246b927bbae98cce29a41752fcd4fc4d22fde05417c1f54cf2ec1c7a5dfafc363ff004afea084
   languageName: node
   linkType: hard
 
@@ -5895,6 +5895,21 @@ __metadata:
     "@nestjs/websockets":
       optional: true
   checksum: 65cc143c8e43cf009a94988a25e5c85cdab4c915990b8f840a06e7029d364e52baa381e3e0d05590f057332e0bd8c4ffce73b59f61e062ebe50ba166de156b58
+  languageName: node
+  linkType: hard
+
+"@ngbracket/ngx-layout@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@ngbracket/ngx-layout@npm:17.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  peerDependencies:
+    "@angular/cdk": ">=17.0.0"
+    "@angular/common": ">=17.0.0"
+    "@angular/core": ">=17.0.0"
+    "@angular/platform-browser": ">=17.0.0"
+    rxjs: ^6.5.3 || ^7.8.0
+  checksum: 1fd2a8c45899954ce2e55f92d90fa580ed0751e3512e0688656f0f6950f26a5dfc776c0f0873fde5647fc8686ae3d24f5659ae8ba7b8361f50ad3c4d501fd6c6
   languageName: node
   linkType: hard
 
@@ -24202,7 +24217,7 @@ __metadata:
     "@angular-eslint/eslint-plugin-template": 16.0.3
     "@angular-eslint/template-parser": 16.0.3
     "@angular/animations": 16.2.1
-    "@angular/cdk": 16.2.1
+    "@angular/cdk": ^17.0.3
     "@angular/cli": ~16.2.0
     "@angular/common": 16.2.1
     "@angular/compiler": 16.2.1
@@ -24218,6 +24233,7 @@ __metadata:
     "@cdktf/provider-aws": 14.0.2
     "@hint/configuration-web-recommended": 8.2.16
     "@hint/formatter-codeframe": 3.1.33
+    "@ngbracket/ngx-layout": ^17.0.0
     "@nguniversal/builders": 16.2.0
     "@nguniversal/express-engine": 16.2.0
     "@nrwl/js": 16.7.2


### PR DESCRIPTION
Fixes #2378 

## Changelog
* add new Angular package (`ngx-layout`) to more easily develop web pages that are responsive to various viewport sizes ([ref](https://github.com/ngbracket/ngx-layout/wiki))
   * I will most likely refactor other HTML pages to utilize `ngx-layout` as well, in another PR
* update navbar to collapse links into a toggable sidebar when the viewport is extra-small (mobile size) - this is to follow suit what other web apps are generally doing with their navbar
* adjust logo size of ITCR image - this is what caused the white margin on the right side in the bug report
* 

## Preview

**Navbar**
* browser
![Screenshot 2023-12-11 at 2 31 00 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/14cebbdc-fca4-4314-a60e-4513acca8a11)

* mobile
![Screenshot 2023-12-11 at 2 31 18 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/a0f451df-f5f1-497d-96cf-b25cd2eac3f9)

**Sponsor section**
![Screenshot 2023-12-11 at 2 31 36 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/0c8c8f42-8eac-417c-9e54-9a1d1e164d3c)
