### PR TITLE
feat(schematic): modified docker image when running schematic APIs with uWSGI

### DIFF
--- a/apps/schematic/api/Dockerfile
+++ b/apps/schematic/api/Dockerfile
@@ -27,6 +27,23 @@ RUN pip install poetry \
   && poetry install --with prod --no-root --no-interaction --no-ansi \
   && pip cache purge
 
+
+WORKDIR /var/www/
+# create user group www-data
+# and create www-data as a user
+RUN usermod -aG www-data www-data
+# change the group ownership of /var/www, /opt/app recursively to www-data
+# /opt/apt folder is relevant for storing manifests when executing endpoints
+# such as /assetTypes/{assetTypes}/projects/{projectId}/manifests
+RUN chgrp -R www-data /var/www /opt/app
+
+# add write permission for group for folder /var/www, opt/app recursively
+RUN chmod -R g+w /var/www /opt/app
+# make sure that all folders created under /var/www are owned by /var/www, opt/app
+RUN find /var/www /opt/app -type d -exec chmod 2775 {} \;   
+# find all files in /var/www, opt/app and add read and write permission for owner and group
+RUN find /var/www /opt/app -type f -exec chmod ug+rw {} \;
+
 WORKDIR /
 COPY docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
@@ -34,8 +51,3 @@ RUN chmod +x docker-entrypoint.sh
 EXPOSE 7080
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-
-# Run server in development mode
-# CMD ["python", "-m", "openapi_server"]
-# Run server in production mode
-CMD ["uwsgi", "--ini", "uwsgi.ini", "--lazy", "--http", ":7080"]

--- a/apps/schematic/api/README.md
+++ b/apps/schematic/api/README.md
@@ -37,6 +37,10 @@ tox
 ```
 
 ## Running with Docker
+Get into the right dir
+```
+cd apps/schematic/api
+```
 
 To run the server on a Docker container, please execute the following from the root directory:
 
@@ -45,5 +49,7 @@ To run the server on a Docker container, please execute the following from the r
 docker build -t schematic_api .
 
 # starting up a container
-docker run -p 8080:8080 schematic_api
+docker run -p 7080:7080 schematic_api
 ```
+Should then be able to visit `http://localhost:7080/api/v1/ui/#/`
+

--- a/apps/schematic/api/uwsgi.ini
+++ b/apps/schematic/api/uwsgi.ini
@@ -13,3 +13,12 @@ vacuum = true
 die-on-term = true
 thunder-lock = true
 http-keepalive = true
+harakiri-verbose = true
+http-timeout = 300 # necessary for preventing time-out
+uwsgi_read_timeout = 300 # necessary for preventing time-out
+uwsgi_send_timeout = 300 # necessary for preventing time-out
+buffer-size = 32768 # for dealing with long token in DCA and DFA
+# for dealing with OSError: write error
+ignore-sigpipe=true
+ignore-write-errors=true
+disable-write-exception=true


### PR DESCRIPTION
Related to: https://sagebionetworks.jira.com/browse/FDS-1346

## Context
The goal of this PR is to make sure schematic can work well with uWSGI. 

Even though a lot of content in this docker image would need to get changed when adding nginx, I still want to make a PR to make sure that we have `schematic+uwsgi` working if there's anything wrong with nginx and we want to trouble shoot by isolating uswgi and nginx. 

## Changelog
* Thomas already have uswgi working with schematic APIs. To make sure that all the endpoints work properly, I modified permission of some folders. I previously did it like this PR: https://github.com/Sage-Bionetworks/schematic/pull/1142/files#diff-d04806eafd231d6405de22d8c29951c269796bcea02a3fc8116c48f33e96ac6d but I think the way that i have now is clearer. 
* I updated the uswgi.ini so that it looks like our current set up in schematic. 

## Test
Get into the right dir
```
cd apps/schematic/api
```
Build a docker image: 
```
docker build -t schematic_api .
```
Run docker container: 
```
docker run -p 7080:7080 schematic_api
```
Should then be able to visit `http://localhost:7080/api/v1/ui/#/`
I tested all the endpoints and make sure that they could return expected output. 