### PR TITLE
fix(openchallenges): fix flickering on search pages after clicking "see more"

### DIFF
--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -149,8 +149,10 @@
         />
       </p-panel>
     </div>
-    <div *ngIf="challenges" class="main col">
-      <h3>Results ({{ searchResultsCount }})</h3>
+    <div class="main col">
+      <h3>
+        Results <span *ngIf="challenges.length > 0">({{ searchResultsCount }})</span>
+      </h3>
       <div class="card-group">
         <openchallenges-challenge-card
           *ngFor="let challenge of challenges"
@@ -158,6 +160,7 @@
         />
       </div>
       <openchallenges-paginator
+        *ngIf="challenges.length > 0"
         #paginator
         [pageNumber]="selectedPageNumber || defaultPageNumber"
         [pageSize]="selectedPageSize || defaultPageSize"

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -149,7 +149,7 @@
         />
       </p-panel>
     </div>
-    <div class="main col">
+    <div *ngIf="challenges" class="main col">
       <h3>Results ({{ searchResultsCount }})</h3>
       <div class="card-group">
         <openchallenges-challenge-card

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.html
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.html
@@ -14,7 +14,7 @@
       />
     </div>
     <div class="text-center">
-      <a mat-raised-button class="see-more" href="/org">See More</a>
+      <a mat-raised-button class="see-more" routerLink="/org">See More</a>
     </div>
   </div>
 </section>

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.spec.ts
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 
 import { ChallengeHostListComponent } from './challenge-host-list.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ChallengeHostListComponent', () => {
   let component: ChallengeHostListComponent;
@@ -9,7 +10,11 @@ describe('ChallengeHostListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientModule, ChallengeHostListComponent],
+      imports: [
+        HttpClientModule,
+        ChallengeHostListComponent,
+        RouterTestingModule,
+      ],
     }).compileComponents();
   });
 

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { RouterModule } from '@angular/router';
 import {
   ImageAspectRatio,
   ImageHeight,
@@ -24,7 +25,12 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 @Component({
   selector: 'openchallenges-challenge-host-list',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, OrganizationCardComponent],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    OrganizationCardComponent,
+    RouterModule,
+  ],
   templateUrl: './challenge-host-list.component.html',
   styleUrls: ['./challenge-host-list.component.scss'],
 })

--- a/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.html
+++ b/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.html
@@ -5,10 +5,13 @@
       Not sure where to start? Try one of our randomly selected daily challenges!
     </div>
     <div class="card-group">
-      <openchallenges-challenge-card *ngFor="let challenge of (challenges$ | async)" [challenge]="challenge"/>
+      <openchallenges-challenge-card
+        *ngFor="let challenge of challenges$ | async"
+        [challenge]="challenge"
+      />
     </div>
     <div class="text-center">
-      <a mat-raised-button class="see-more" href="/challenge">See More</a>
+      <a mat-raised-button class="see-more" routerLink="/challenge">See More</a>
     </div>
   </div>
 </section>

--- a/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.spec.ts
+++ b/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
 
 import { RandomChallengeListComponent } from './random-challenge-list.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('RandomChallengeListComponent', () => {
   let component: RandomChallengeListComponent;
@@ -9,7 +10,11 @@ describe('RandomChallengeListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientModule, RandomChallengeListComponent],
+      imports: [
+        HttpClientModule,
+        RandomChallengeListComponent,
+        RouterTestingModule,
+      ],
     }).compileComponents();
   });
 

--- a/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.ts
+++ b/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.ts
@@ -9,11 +9,17 @@ import {
   ChallengeSort,
 } from '@sagebionetworks/openchallenges/api-client-angular';
 import { ChallengeCardComponent } from '@sagebionetworks/openchallenges/ui';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'openchallenges-random-challenge-list',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, ChallengeCardComponent],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    ChallengeCardComponent,
+    RouterModule,
+  ],
   templateUrl: './random-challenge-list.component.html',
   styleUrls: ['./random-challenge-list.component.scss'],
 })

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -59,7 +59,7 @@
         />
       </p-panel>
     </div>
-    <div class="main col">
+    <div *ngIf="organizationCards" class="main col">
       <h3>Results ({{ searchResultsCount }})</h3>
       <div class="card-group">
         <openchallenges-organization-card

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -59,8 +59,10 @@
         />
       </p-panel>
     </div>
-    <div *ngIf="organizationCards" class="main col">
-      <h3>Results ({{ searchResultsCount }})</h3>
+    <div class="main col">
+      <h3>
+        Results <span *ngIf="organizationCards.length > 0">({{ searchResultsCount }})</span>
+      </h3>
       <div class="card-group">
         <openchallenges-organization-card
           *ngFor="let organizationCard of organizationCards"
@@ -68,6 +70,7 @@
         />
       </div>
       <openchallenges-paginator
+        *ngIf="organizationCards.length > 0"
         #paginator
         [pageNumber]="selectedPageNumber || defaultPageNumber"
         [pageSize]="selectedPageSize || defaultPageSize"


### PR DESCRIPTION
- fixes #2363 

There are two flickerings on search pages:
1. Results (0) -> Results (N)
2. Results (N) ->  Results (0) -> Results (N) - it's only occurred on [openchallenges.io](openchallenges.io) based on my observation

    ![flickering](https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/394533e5-e9f6-4db7-8152-c556e5b155fd)



### Changelogs

- replace `href` with `routerlink` - [the difference between two](https://stackoverflow.com/questions/58081360/anchor-href-vs-angular-routerlink#:~:text=Href%20is%20the%20basic%20attribute,components%20without%20reloading%20the%20page.) 
- not rendering the number of search result and pagination (when there's no data to avoid the flickering 1)
- the reason of flickering 2 is still not identified as I am not able to reproduce locally, but I found [angular's hydration](https://angular.io/guide/hydration#why-is-hydration-important) might be associated with the flickering using SSR

### Preview 
sorry for the poor resolution
![](https://github.com/Sage-Bionetworks/sage-monorepo/assets/73901500/cc129581-0a31-413d-91f3-8755c3395f38)
