### PR TITLE
fix(openchallenges): change paginator variable to dynamic rendering

### DIFF
--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.html
@@ -160,7 +160,6 @@
         />
       </div>
       <openchallenges-paginator
-        *ngIf="challenges.length > 0"
         #paginator
         [pageNumber]="selectedPageNumber || defaultPageNumber"
         [pageSize]="selectedPageSize || defaultPageSize"

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -309,7 +309,6 @@ export class ChallengeSearchComponent
         // update challenges and total number of results
         this.searchResultsCount = page.totalElements;
         this.challenges = page.challenges;
-        console.log(this.paginator.pageNumber);
       });
   }
 

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -208,7 +208,7 @@ export class ChallengeSearchComponent
       );
       this.searchedTerms = params['searchTerms'];
       this.selectedPageNumber = +params['pageNumber'] || this.defaultPageNumber;
-      this.selectedPageSize = +params['pageSize'] || this.defaultPageSize;
+      this.selectedPageSize = this.defaultPageSize; // no available pageSize options for users
       this.sortedBy = params['sort'] || this.defaultSortedBy;
 
       const defaultQuery: ChallengeSearchQuery = {
@@ -309,6 +309,7 @@ export class ChallengeSearchComponent
         // update challenges and total number of results
         this.searchResultsCount = page.totalElements;
         this.challenges = page.challenges;
+        console.log(this.paginator.pageNumber);
       });
   }
 

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search.component.ts
@@ -130,7 +130,7 @@ export class ChallengeSearchComponent
   defaultSortedBy: ChallengeSort = 'relevance';
   defaultPageNumber = 0;
   defaultPageSize = 24;
-  @ViewChild('paginator', { static: true }) paginator!: PaginatorComponent;
+  @ViewChild('paginator', { static: false }) paginator!: PaginatorComponent;
 
   // define filters
   sortFilters: Filter[] = challengeSortFilter;

--- a/libs/openchallenges/org-search/src/lib/org-search.component.html
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.html
@@ -70,7 +70,6 @@
         />
       </div>
       <openchallenges-paginator
-        *ngIf="organizationCards.length > 0"
         #paginator
         [pageNumber]="selectedPageNumber || defaultPageNumber"
         [pageSize]="selectedPageSize || defaultPageSize"

--- a/libs/openchallenges/org-search/src/lib/org-search.component.ts
+++ b/libs/openchallenges/org-search/src/lib/org-search.component.ts
@@ -122,7 +122,7 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
   defaultSortedBy: OrganizationSort = 'challenge_count';
   defaultPageNumber = 0;
   defaultPageSize = 24;
-  @ViewChild('paginator', { static: true }) paginator!: PaginatorComponent;
+  @ViewChild('paginator', { static: false }) paginator!: PaginatorComponent;
 
   // define filters
   sortFilters: Filter[] = organizationSortFilter;
@@ -163,7 +163,7 @@ export class OrgSearchComponent implements OnInit, AfterContentInit, OnDestroy {
       this.selectedCategories = this.splitParam(params['categories']);
       this.searchedTerms = params['searchTerms'];
       this.selectedPageNumber = +params['pageNumber'] || this.defaultPageNumber;
-      this.selectedPageSize = +params['pageSize'] || this.defaultPageSize;
+      this.selectedPageSize = this.defaultPageSize; // no available pageSize options for users
       this.sortedBy = params['sort'] || this.defaultSortedBy;
 
       const defaultQuery: OrganizationSearchQuery = {

--- a/libs/openchallenges/ui/src/lib/paginator/paginator.component.html
+++ b/libs/openchallenges/ui/src/lib/paginator/paginator.component.html
@@ -8,4 +8,5 @@
   [showCurrentPageReport]="true"
   currentPageReportTemplate="Showing {first} to {last} of {totalRecords} results"
   (onPageChange)="onPageChange($event)"
+  [alwaysShow]="false"
 ></p-paginator>

--- a/libs/openchallenges/ui/src/lib/paginator/paginator.component.ts
+++ b/libs/openchallenges/ui/src/lib/paginator/paginator.component.ts
@@ -5,6 +5,7 @@ import {
   Output,
   EventEmitter,
   ViewChild,
+  OnInit,
 } from '@angular/core';
 import {
   Paginator,
@@ -18,7 +19,7 @@ import {
   templateUrl: './paginator.component.html',
   styleUrls: ['./paginator.component.scss'],
 })
-export class PaginatorComponent {
+export class PaginatorComponent implements OnInit {
   @Input({ required: true }) pageNumber = 0; // index of the new page
   @Input({ required: false }) pageLinkSize = 5;
   @Input({ required: true }) pageSize = 0; // number of items to display in new page
@@ -29,10 +30,9 @@ export class PaginatorComponent {
 
   itemIndex = 0; // index of the first item in the new page
 
-  // change itemIndex's value will not dynamically trigger selection updates - seems a primeng issue
-  // ngOnInit(): void {
-  //   this.itemIndex = this.pageNumber * this.pageSize;
-  // }
+  ngOnInit(): void {
+    this.itemIndex = this.pageNumber * this.pageSize;
+  }
 
   onPageChange(event: any): void {
     this.pageChange.emit(event);


### PR DESCRIPTION
- fixes #2425 

As we added a new condition to not the paginator element if no data found, the variable of `paginator` is undefined initially as it is static, which caused the error ^.

## Changelogs
- Change the `paginator` to dynamic, so its value will be set after the content is fully initialized
- Use `PrimeNG` built-in [property](https://www.primefaces.org/primeng-v14-lts/paginator) `alwaysShow=false` to hide the paginator when there is only one page
- Update page index on paginator UI once the `pageNumber` of param in a pasted url presents
- Disable the `pageSize` changes from the pasted url
