### PR TITLE
ci(sage-monorepo): try sonar scan again for PRs originating from forks

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,14 +1,15 @@
 name: Scan affected projects with Sonar
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   HEAD_REF: ${{ github.event.pull_request.head.ref }}
   HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
 
 jobs:
-  push:
+  sonar:
+    if: contains(github.event.pull_request.labels.*.name, 'sonar-scan-approved')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/apps/openchallenges/app/src/app/app.component.html
+++ b/apps/openchallenges/app/src/app/app.component.html
@@ -1,4 +1,5 @@
 <openchallenges-google-tag-manager *ngIf="useGoogleTagManager" />
+<!-- XXX -->
 <openchallenges-navbar
   class="mat-elevation-z6"
   [title]="title"

--- a/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/OrganizationServiceApplication.java
+++ b/apps/openchallenges/organization-service/src/main/java/org/sagebionetworks/openchallenges/organization/service/OrganizationServiceApplication.java
@@ -10,7 +10,6 @@ import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
 
-// XXX to trigger Sonar scan
 @ComponentScan(basePackages = {"org.sagebionetworks.openchallenges"})
 @EnableEurekaClient
 @EnableFeignClients

--- a/tools/sonar-scanner.sh
+++ b/tools/sonar-scanner.sh
@@ -103,8 +103,6 @@ args=(
   -Dsonar.python.coverage.reportPaths=${project_dir}/coverage.xml
 )
 
-pull_request_number=2458
-
 # Include the PR key if specified
 if [[ ! -z ${pull_request_number+z} ]];
 then


### PR DESCRIPTION
Contributes to #2450

## Changelog

- Require the PR to have the label `sonar-scan-approved` to run Sonar
- Remove hard-coded PR number

## Update

This PR confirms that we can scan multiple projects with Sonar for given commit and have all the results 1) publishing in the PR thread and 2) added to the list of checks (screenshot).

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/c050ba48-779a-44e2-8967-9e1209048bf2)
