### PR TITLE
fix(openchallenges): make homepage more mobile-friendly

### DIFF
--- a/libs/openchallenges/home/src/lib/home.component.html
+++ b/libs/openchallenges/home/src/lib/home.component.html
@@ -1,4 +1,4 @@
-<main class="base mat-typography">
+<div class="base mat-typography">
   <div id="announcement">
     <h4>Welcome to OpenChallenges!</h4>
     <h3>This website uses a preview snapshot of the OpenChallenges (OC) Database</h3>
@@ -21,7 +21,7 @@
   <openchallenges-challenge-host-list *sageAppShellNoRender />
   <openchallenges-platforms *sageAppShellNoRender />
   <openchallenges-sponsor-list *sageAppShellNoRender />
-</main>
+</div>
 
 <openchallenges-footer
   [appVersion]="appVersion"

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.html
@@ -11,7 +11,6 @@
         >
           <img
             [src]="(itcrImage$ | async)?.url"
-            height="70px"
             alt="Informatics Technology for Cancer Research (ITCR)"
             title="Informatics Technology for Cancer Research"
           />

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.scss
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.scss
@@ -1,3 +1,5 @@
+@use 'libs/openchallenges/styles/src/lib/constants';
+
 .container {
   max-width: 1128px;
   width: 100%;
@@ -17,9 +19,23 @@
   padding: 24px;
   justify-content: center;
   align-items: center;
+
+  img {
+    width: 70%;
+    max-width: 70%;
+  }
 }
 #acknowledgements {
   background: #f8f8f8;
   margin-top: 12px;
   padding: 88px 0;
+}
+
+@media only screen and (max-width: constants.$md-breakpoint) {
+  .sponsor-item {
+    img {
+      width: 100%;
+      max-width: 100%;
+    }
+  }
 }

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -2,6 +2,7 @@
   <h3 class="section-title">Total Challenges Tracked</h3>
   <div class="col container">
     <div id="timeline-plot" echarts [options]="chartOptions"></div>
+    <!-- <div id="timeline-plot" echarts [options]="flippedChartOptions"></div> -->
     <span class="caption">
       *The plot does not include challenges that are planned beyond this year, or those with
       unspecified start dates.

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.scss
@@ -1,11 +1,5 @@
-// $screen-sm: 481px;
-// $screen-lg: 641px;
 @use 'libs/openchallenges/styles/src/lib/constants';
-$sm-breakpoint: 576px;
-$md-breakpoint: 768px;
-$lg-breakpoint: 992px;
-$xl-breakpoint: 1200px;
-$xxl-breakpoint: 1400px;
+
 // GENERAL CLASSES
 .container {
   max-width: 1128px;
@@ -52,7 +46,8 @@ $xxl-breakpoint: 1400px;
 .clickable {
   cursor: pointer;
 }
-@media (max-width: constants.$lg-breakpoint) {
+
+@media screen and (max-width: constants.$lg-breakpoint) {
   .metrics-container {
     gap: 40px;
 
@@ -62,7 +57,7 @@ $xxl-breakpoint: 1400px;
     }
   }
 }
-@media (max-width: constants.$md-breakpoint) {
+@media screen and (max-width: constants.$md-breakpoint) {
   .metrics-container {
     gap: 20px;
 

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -26,6 +26,7 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
   private chartDataSubscription: Subscription | undefined;
 
   chartOptions!: EChartsOption;
+  // flippedChartOptions!: EChartsOption;
 
   ngOnInit() {
     // update plot's data
@@ -37,24 +38,26 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
             textStyle: {
               fontWeight: 'normal',
               fontFamily: 'Lato, sans-serif',
+              fontSize: '15px',
               color: '#000',
             },
             xAxis: {
               type: 'category',
               data: res.years,
-              axisLabel: { fontSize: '1em' },
+              axisLabel: { rotate: 45 },
             },
             yAxis: [
               {
                 type: 'value',
                 name: '',
-                axisLabel: { fontSize: '1em' },
                 nameTextStyle: {
-                  fontSize: '1.1em',
                   lineHeight: 56,
                 },
               },
             ],
+            grid: {
+              containLabel: true,
+            },
             series: [
               {
                 name: 'Total challenges',
@@ -70,6 +73,47 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
                 animationDelay: (dataIndex: number) => dataIndex * 100,
               },
             ],
+            // }),
+            // (this.flippedChartOptions = {
+            //   textStyle: {
+            //     fontWeight: 'normal',
+            //     fontFamily: 'Lato, sans-serif',
+            //     fontSize: '14px',
+            //     color: '#000',
+            //   },
+            //   xAxis: [
+            //     {
+            //       type: 'value',
+            //       name: '',
+            //       nameTextStyle: {
+            //         fontSize: '15px',
+            //         lineHeight: 56,
+            //       },
+            //     },
+            //   ],
+            //   yAxis: {
+            //     type: 'category',
+            //     data: res.years,
+            //     inverse: true,
+            //   },
+            //   grid: {
+            //     containLabel: true,
+            //   },
+            //   series: [
+            //     {
+            //       name: 'Total challenges',
+            //       data: res.challengeCounts,
+            //       type: 'bar',
+            //       itemStyle: {
+            //         color: '#afa0fe',
+            //       },
+            //       // disable default clicking
+            //       silent: true,
+            //       // make bar plot rise from left to right
+            //       // instead of rising all together in the same time
+            //       animationDelay: (dataIndex: number) => dataIndex * 100,
+            //     },
+            //   ],
           })
       );
   }

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -26,7 +26,6 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
   private chartDataSubscription: Subscription | undefined;
 
   chartOptions!: EChartsOption;
-  // flippedChartOptions!: EChartsOption;
 
   ngOnInit() {
     // update plot's data
@@ -38,13 +37,12 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
             textStyle: {
               fontWeight: 'normal',
               fontFamily: 'Lato, sans-serif',
-              fontSize: '15px',
               color: '#000',
             },
             xAxis: {
               type: 'category',
               data: res.years,
-              axisLabel: { rotate: 45 },
+              axisLabel: { rotate: 45, fontSize: '15px' },
             },
             yAxis: [
               {
@@ -73,47 +71,6 @@ export class StatisticsViewerComponent implements OnInit, OnDestroy {
                 animationDelay: (dataIndex: number) => dataIndex * 100,
               },
             ],
-            // }),
-            // (this.flippedChartOptions = {
-            //   textStyle: {
-            //     fontWeight: 'normal',
-            //     fontFamily: 'Lato, sans-serif',
-            //     fontSize: '14px',
-            //     color: '#000',
-            //   },
-            //   xAxis: [
-            //     {
-            //       type: 'value',
-            //       name: '',
-            //       nameTextStyle: {
-            //         fontSize: '15px',
-            //         lineHeight: 56,
-            //       },
-            //     },
-            //   ],
-            //   yAxis: {
-            //     type: 'category',
-            //     data: res.years,
-            //     inverse: true,
-            //   },
-            //   grid: {
-            //     containLabel: true,
-            //   },
-            //   series: [
-            //     {
-            //       name: 'Total challenges',
-            //       data: res.challengeCounts,
-            //       type: 'bar',
-            //       itemStyle: {
-            //         color: '#afa0fe',
-            //       },
-            //       // disable default clicking
-            //       silent: true,
-            //       // make bar plot rise from left to right
-            //       // instead of rising all together in the same time
-            //       animationDelay: (dataIndex: number) => dataIndex * 100,
-            //     },
-            //   ],
           })
       );
   }


### PR DESCRIPTION
Fixes #2378 

Note: this PR contains a subset of changes proposed in #2402 (now closed)

## Changelog

* adjust logo size of ITCR image when screen is smaller - this is what caused the black margin in the bug report
* adjust text size and label rotation in timeline plot

## TODO

Once orientation of plot is determined (see screenshots below), remove the unneeded code

## Preview

* **ITCR logo**
![290030938-0c8c8f42-8eac-417c-9e54-9a1d1e164d3c](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/bce8d866-63b1-47b1-b8d1-9351e7b3356d)

* **Timeline plot**
![Screenshot 2024-02-01 at 4 35 01 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/c12622a1-0786-4228-b6b0-cba865fe3169)

![Screenshot 2024-02-01 at 4 34 42 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/8e1d113c-4318-4ac1-ad4f-6d9e1b5ef0c9)

Alternatively, we can flip the plot so that the y-axis is the category (year) and the x-axis is the data:

![Screenshot 2024-02-01 at 4 24 08 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/7e61066b-c804-4c0f-929e-ba0687a33c65)

![Screenshot 2024-02-01 at 4 25 31 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/aa243f3a-e3c2-4ae8-8084-08d0c8679a46)
