### PR TITLE
feat(openchallenges): add CI workflow for updating the DB dump files on a daily cadence

### DIFF
--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -7,18 +7,30 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+
     steps:
       - name: Get current date
         run: |
           echo "TODAY=$(date +"%Y-%m-%d")" >> $env:GITHUB_ENV
+
       - name: Use variable
         run: |
           echo "${{ env.TODAY }}"
+
+      # - name: Install schematic and validate files
+      #   shell: bash
+      #   run: |
+      #     python3.10 -m venv .venv
+      #     chmod 755 .venv/bin/activate
+      #     source .venv/bin/activate
+      #     pip3.10 install schematicpy
+  
       # - name: Commit files
       #   run: |
       #     git config user.name github-actions[bot]
       #     git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       #     git commit -m "add latest CSV dump files for DB update" -a
+
       # - name: Push changes
       #   uses: ad-m/github-push-action@master
       #   with:

--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -17,6 +17,12 @@ jobs:
         run: |
           echo "${{ env.TODAY }}"
 
+      # - name: Install system dependencies
+      #   run: |
+      #     sudo add-apt-repository ppa:deadsnakes/ppa
+      #     sudo apt-get update
+      #     sudo apt-get install -y pip python3.10-venv libcurl4-openssl-dev
+
       # - name: Install schematic and validate files
       #   shell: bash
       #   run: |

--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -9,19 +9,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get current date
+      - name: Install system dependencies
         run: |
-          echo "TODAY=$(date +"%Y-%m-%d")" >> $env:GITHUB_ENV
+          sudo add-apt-repository ppa:deadsnakes/ppa
+          sudo apt-get update
+          sudo apt-get install -y pip python3.10-venv libcurl4-openssl-dev
 
-      - name: Use variable
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Create Google Service credentials file
+        uses: jsdaniell/create-json@v1.2.3
+        with:
+          name: "service_account.json"
+          json: ${{ secrets.GC_JSON }}
+
+      - name: Update dump files
         run: |
-          echo "${{ env.TODAY }}"
-
-      # - name: Install system dependencies
-      #   run: |
-      #     sudo add-apt-repository ppa:deadsnakes/ppa
-      #     sudo apt-get update
-      #     sudo apt-get install -y pip python3.10-venv libcurl4-openssl-dev
+          python3 -m pip install --upgrade pip
+          pip install gspread pandas numpy
+          python3 apps/openchallenges/db-update/update_db_csv.py
 
       # - name: Install schematic and validate files
       #   shell: bash
@@ -30,15 +40,21 @@ jobs:
       #     chmod 755 .venv/bin/activate
       #     source .venv/bin/activate
       #     pip3.10 install schematicpy
-  
-      # - name: Commit files
-      #   run: |
-      #     git config user.name github-actions[bot]
-      #     git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      #     git commit -m "add latest CSV dump files for DB update" -a
 
-      # - name: Push changes
-      #   uses: ad-m/github-push-action@master
-      #   with:
-      #     github_token: ${{ secrets.GH_TOKEN }}
-      #     branch: db-update-${{ env.TODAY }}
+      - name: Commit files
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config advice.addIgnoredFile false
+          git add .
+          git commit -m "add latest CSV dump files for DB update"
+
+      - name: Get current date
+        run: |
+          echo "TODAY=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          branch: db-update-${{ env.TODAY }}

--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -1,0 +1,16 @@
+name: Update DB files
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        run: |
+          echo "TODAY=$(date +"%Y-%m-%d")" >> $env:GITHUB_ENV
+      - name: Use variable
+        run: |
+          echo "${{env.TODAY}}"

--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: db-update-${{ env.TODAY }}
 
       - name: Create pull request
@@ -65,5 +65,5 @@ jobs:
             --title 'chore(openchallenges): ${{ env.TODAY }} DB update' \
             --body 'Daily OC datebase update'
         env:
-            GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -13,4 +13,14 @@ jobs:
           echo "TODAY=$(date +"%Y-%m-%d")" >> $env:GITHUB_ENV
       - name: Use variable
         run: |
-          echo "${{env.TODAY}}"
+          echo "${{ env.TODAY }}"
+      # - name: Commit files
+      #   run: |
+      #     git config user.name github-actions[bot]
+      #     git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      #     git commit -m "add latest CSV dump files for DB update" -a
+      # - name: Push changes
+      #   uses: ad-m/github-push-action@master
+      #   with:
+      #     github_token: ${{ secrets.GH_TOKEN }}
+      #     branch: db-update-${{ env.TODAY }}

--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -63,7 +63,8 @@ jobs:
         run: |
           gh pr create -B main -H db-update-${{ env.TODAY }} \
             --title 'chore(openchallenges): ${{ env.TODAY }} DB update' \
-            --body 'Daily OC datebase update'
+            --body 'Daily OC datebase update' \
+            --label sonar-scan-approved
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.github/workflows/update-db-csv-files.yml
+++ b/.github/workflows/update-db-csv-files.yml
@@ -58,3 +58,12 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           branch: db-update-${{ env.TODAY }}
+
+      - name: Create pull request
+        run: |
+          gh pr create -B main -H db-update-${{ env.TODAY }} \
+            --title 'chore(openchallenges): ${{ env.TODAY }} DB update' \
+            --body 'Daily OC datebase update'
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    

--- a/.github/workflows/update-oc-db-csv-files.yml
+++ b/.github/workflows/update-oc-db-csv-files.yml
@@ -1,7 +1,7 @@
-name: Update DB files
+name: Update OpenChallenges DB files
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * *"  # daily at 00:00 UTC 
   workflow_dispatch:
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
         uses: jsdaniell/create-json@v1.2.3
         with:
           name: "service_account.json"
-          json: ${{ secrets.GC_JSON }}
+          json: ${{ secrets.GOOGLE_CLIENT_JSON }}
 
       - name: Update dump files
         run: |

--- a/.github/workflows/update-oc-db-csv-files.yml
+++ b/.github/workflows/update-oc-db-csv-files.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      # schematic only supports Python 3.9 and 3.10, so we will need
+      # to specifically use one of these versions.
       - name: Install system dependencies
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa
@@ -20,6 +23,30 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Find existing DB branch if available
+        run: |
+          echo "BRANCH=$(git branch -r | \
+                         grep "db-update-*" | \
+                         sed -e 's/origin\///' | \
+                         sed -e 's/^[ \t]*//')" >> $GITHUB_ENV
+
+      - name: Checkout existing DB branch if available
+        if: ${{ env.BRANCH != '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BRANCH }}
+          persist-credentials: false
+
+      - name: Get current date
+        run: |
+          echo "TODAY=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
+
+      - name: Create new branch name if needed
+        if: ${{ env.BRANCH == '' }}
+        run : |
+          echo "BRANCH=db-update-${{ env.TODAY }}" >> $GITHUB_ENV
+          echo "PR_NEEDED="true"" >> $GITHUB_ENV
 
       - name: Create Google Service credentials file
         uses: jsdaniell/create-json@v1.2.3
@@ -47,11 +74,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git config advice.addIgnoredFile false
           git add .
-          git commit -m "add latest CSV dump files for DB update"
-
-      - name: Get current date
-        run: |
-          echo "TODAY=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
+          git commit -m "${{ env.TODAY }}: add latest CSV dump files"
 
       - name: Push changes
         uses: ad-m/github-push-action@master
@@ -60,10 +83,11 @@ jobs:
           branch: db-update-${{ env.TODAY }}
 
       - name: Create pull request
+        if: ${{ env.PR_NEEDED == 'true' }}
         run: |
-          gh pr create -B main -H db-update-${{ env.TODAY }} \
+          gh pr create -B main -H ${{ env.BRANCH }} \
             --title 'chore(openchallenges): ${{ env.TODAY }} DB update' \
-            --body 'Daily OC datebase update' \
+            --body 'Daily OC datebase update(s)' \
             --label sonar-scan-approved
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-oc-db-csv-files.yml
+++ b/.github/workflows/update-oc-db-csv-files.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Create Google Service credentials file
+      - name: Create Google Client credentials file
         uses: jsdaniell/create-json@v1.2.3
         with:
           name: "service_account.json"

--- a/.github/workflows/update-oc-db-csv-files.yml
+++ b/.github/workflows/update-oc-db-csv-files.yml
@@ -24,30 +24,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Find existing DB branch if available
-        run: |
-          echo "BRANCH=$(git branch -r | \
-                         grep "db-update-*" | \
-                         sed -e 's/origin\///' | \
-                         sed -e 's/^[ \t]*//')" >> $GITHUB_ENV
-
-      - name: Checkout existing DB branch if available
-        if: ${{ env.BRANCH != '' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.BRANCH }}
-          persist-credentials: false
-
-      - name: Get current date
-        run: |
-          echo "TODAY=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
-
-      - name: Create new branch name if needed
-        if: ${{ env.BRANCH == '' }}
-        run : |
-          echo "BRANCH=db-update-${{ env.TODAY }}" >> $GITHUB_ENV
-          echo "PR_NEEDED="true"" >> $GITHUB_ENV
-
       - name: Create Google Service credentials file
         uses: jsdaniell/create-json@v1.2.3
         with:
@@ -68,27 +44,15 @@ jobs:
       #     source .venv/bin/activate
       #     pip3.10 install schematicpy
 
-      - name: Commit files
+      - name: Get current date
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git config advice.addIgnoredFile false
-          git add .
-          git commit -m "${{ env.TODAY }}: add latest CSV dump files"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: db-update-${{ env.TODAY }}
-
-      - name: Create pull request
-        if: ${{ env.PR_NEEDED == 'true' }}
-        run: |
-          gh pr create -B main -H ${{ env.BRANCH }} \
-            --title 'chore(openchallenges): ${{ env.TODAY }} DB update' \
-            --body 'Daily OC datebase update(s)' \
-            --label sonar-scan-approved
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "TODAY=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
     
+      - name: Push changes, then create or update pull request
+        uses: peter-evans/create-pull-request@v6
+        with: 
+          title: "chore(openchallenges): ${{ env.TODAY }} DB update"
+          body: Daily OC database update(s)
+          labels: sonar-scan-approved
+          commit-message: "${{ env.TODAY }}: add latest CSV dump files"
+          branch: openchallenges/db-update

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+service_account.json
 
 # System Files
 .DS_Store

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -1,0 +1,216 @@
+import os
+import csv
+import gspread
+import numpy as np
+import pandas as pd
+
+GOOGLE_SHEET_TITLE = "OpenChallenges Data"
+CHALLENGE_FOLDER = "apps/openchallenges/challenge-service/src/main/resources/db"
+ORGANIZATION_FOLDER = "apps/openchallenges/organization-service/src/main/resources/db"
+
+
+def output_csv(df, output_filename, output_folder=""):
+    """Output a dataframe into CSV file.
+
+    CSV file should not include index numbers and all values should
+    be surrounded with double-quotes.
+    """
+    df.to_csv(
+        os.path.join(output_folder, output_filename),
+        index=False,
+        quoting=csv.QUOTE_ALL,
+    )
+
+
+def get_challenge_data(wks, sheet_name="challenges"):
+    """Get challenges data and clean up as needed.
+
+    Output:
+        - challenges
+        - challenge incentives
+        - challenge submission types
+    """
+    df = pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")
+    df.loc[df._platform == "Other", "platform"] = "\\N"
+
+    challenges = df[
+        [
+            "id",
+            "slug",
+            "name",
+            "headline",
+            "description",
+            "avatar_url",
+            "website_url",
+            "status",
+            "platform",
+            "doi",
+            "start_date",
+            "end_date",
+            "created_at",
+            "updated_at",
+        ]
+    ]
+    challenges = (
+        challenges.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
+        .replace(r"\n", " ", regex=True)
+        .replace("'", "''")
+    )
+    challenges["headline"] = (
+        challenges["headline"]
+        .astype(str)
+        .apply(lambda x: x[:76] + "..." if len(x) > 80 else x)
+    )
+    challenges["description"] = (
+        challenges["description"]
+        .astype(str)
+        .apply(lambda x: x[:995] + "..." if len(x) > 1000 else x)
+    )
+    challenges.loc[challenges.start_date == "", "start_date"] = "\\N"
+    challenges.loc[challenges.end_date == "", "end_date"] = "\\N"
+
+    incentives = pd.concat(
+        [
+            df[df.monetary_incentive == "TRUE"][["id", "created_at"]].assign(
+                incentives="monetary"
+            ),
+            df[df.publication_incentive == "TRUE"][["id", "created_at"]].assign(
+                incentives="publication"
+            ),
+            df[df.speaking_incentive == "TRUE"][["id", "created_at"]].assign(
+                incentives="speaking_engagement"
+            ),
+            df[df.other_incentive == "TRUE"][["id", "created_at"]].assign(
+                incentives="other"
+            ),
+        ]
+    ).rename(columns={"id": "challenge_id"})
+    incentives["incentives"] = pd.Categorical(
+        incentives["incentives"],
+        categories=["monetary", "publication", "speaking_engagement", "other"],
+    )
+    incentives = incentives.sort_values(["challenge_id", "incentives"])
+    incentives.index = np.arange(1, len(incentives) + 1)
+
+    sub_types = pd.concat(
+        [
+            df[df.file_submission == "TRUE"][["id", "created_at"]].assign(
+                submission_types="prediction_file"
+            ),
+            df[df.container_submission == "TRUE"][["id", "created_at"]].assign(
+                submission_types="container_image"
+            ),
+            df[df.notebook_submission == "TRUE"][["id", "created_at"]].assign(
+                submission_types="notebook"
+            ),
+            df[df.other_submission == "TRUE"][["id", "created_at"]].assign(
+                submission_types="other"
+            ),
+        ]
+    ).rename(columns={"id": "challenge_id"})
+    sub_types["submission_types"] = pd.Categorical(
+        sub_types["submission_types"],
+        categories=["prediction_file", "container_image", "notebook", "other"],
+    )
+    sub_types = sub_types.sort_values(["challenge_id", "submission_types"])
+    sub_types.index = np.arange(1, len(sub_types) + 1)
+
+    return challenges, incentives, sub_types
+
+
+def get_challenge_categories(wks, sheet_name="challenge_category"):
+    """Get challenge categories."""
+    return pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")[
+        ["id", "challenge_id", "category"]
+    ]
+
+
+def get_platform_data(wks, sheet_name="platforms"):
+    """Get platform data and clean up as needed."""
+    platforms = pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")
+    return platforms[platforms._public == "TRUE"][
+        ["id", "slug", "name", "avatar_url", "website_url", "created_at", "updated_at"]
+    ]
+
+
+def get_organization_data(wks, sheet_name="organizations"):
+    """Get organization data and clean up as needed."""
+    organizations = pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")
+    organizations = organizations[organizations._public == "TRUE"][
+        [
+            "id",
+            "name",
+            "login",
+            "avatar_url",
+            "website_url",
+            "description",
+            "challenge_count",
+            "created_at",
+            "updated_at",
+            "acronym",
+        ]
+    ]
+    organizations = (
+        organizations.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
+        .replace(r"\n", " ", regex=True)
+        .replace("'", "''")
+    )
+    organizations["description"] = (
+        organizations["description"]
+        .astype(str)
+        .apply(lambda x: x[:995] + "..." if len(x) > 1000 else x)
+    )
+    return organizations
+
+
+def get_roles(wks, sheet_name="contribution_role"):
+    """Get data on organization's role(s) in challenges."""
+    return (
+        pd.DataFrame(wks.worksheet(sheet_name).get_all_records())
+        .fillna("")
+        .drop(["_challenge", "_organization"], axis=1)
+    )
+
+
+def get_edam_terms(wks, sheet_name="edam_terms"):
+    """Get list of EDAM terms currently used in the DB."""
+    return pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")[
+        ["id", "edam_id", "name", "subclass_of", "created_at", "updated_at"]
+    ]
+
+
+def get_edam_annotations(wks, sheet_name="challenge_data"):
+    """Get data on challenge's EDAM annotations."""
+    return (
+        pd.DataFrame(wks.worksheet(sheet_name).get_all_records())
+        .fillna("")
+        .drop(["_challenge", "_edam_name"], axis=1)
+    )
+
+
+def main(gc):
+    """Main function."""
+    wks = gc.open(GOOGLE_SHEET_TITLE)
+
+    platforms = get_platform_data(wks)
+    output_csv(platforms, "platforms.csv", CHALLENGE_FOLDER)
+
+    roles = get_roles(wks)
+    output_csv(roles, "contribution_roles.csv", CHALLENGE_FOLDER)
+    output_csv(roles, "contribution_roles.csv", ORGANIZATION_FOLDER)
+
+    categories = get_challenge_categories(wks)
+    output_csv(categories, "categories.csv", CHALLENGE_FOLDER)
+
+    organizations = get_organization_data(wks)
+    output_csv(organizations, "organizations.csv", ORGANIZATION_FOLDER)
+
+    challenges, incentives, sub_types = get_challenge_data(wks)
+    output_csv(challenges, "challenges.csv", CHALLENGE_FOLDER)
+    output_csv(incentives, "incentives.csv", CHALLENGE_FOLDER)
+    output_csv(sub_types, "submission_types.csv", CHALLENGE_FOLDER)
+
+
+if __name__ == "__main__":
+    google_client = gspread.service_account(filename="service_account.json")
+    main(google_client)

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -9,7 +9,7 @@ CHALLENGE_FOLDER = "apps/openchallenges/challenge-service/src/main/resources/db"
 ORGANIZATION_FOLDER = "apps/openchallenges/organization-service/src/main/resources/db"
 
 
-def output_csv(df, output_filename, output_folder=""):
+def output_csv(df, output_filename, output_folder="", print_row=False):
     """Output a dataframe into CSV file.
 
     CSV file should not include index numbers and all values should
@@ -17,7 +17,7 @@ def output_csv(df, output_filename, output_folder=""):
     """
     df.to_csv(
         os.path.join(output_folder, output_filename),
-        index=False,
+        index=print_row,
         quoting=csv.QUOTE_ALL,
     )
 
@@ -115,7 +115,11 @@ def get_challenge_data(wks, sheet_name="challenges"):
     sub_types = sub_types.sort_values(["challenge_id", "submission_types"])
     sub_types.index = np.arange(1, len(sub_types) + 1)
 
-    return challenges, incentives, sub_types
+    return (
+        challenges,
+        incentives[["incentives", "challenge_id", "created_at"]],
+        sub_types[["submission_types", "challenge_id", "created_at"]],
+    )
 
 
 def get_challenge_categories(wks, sheet_name="challenge_category"):
@@ -193,22 +197,24 @@ def main(gc):
     wks = gc.open(GOOGLE_SHEET_TITLE)
 
     platforms = get_platform_data(wks)
-    output_csv(platforms, "platforms.csv", CHALLENGE_FOLDER)
+    output_csv(platforms, "platforms.csv", output_folder=CHALLENGE_FOLDER)
 
     roles = get_roles(wks)
-    output_csv(roles, "contribution_roles.csv", CHALLENGE_FOLDER)
-    output_csv(roles, "contribution_roles.csv", ORGANIZATION_FOLDER)
+    output_csv(roles, "contribution_roles.csv", output_folder=CHALLENGE_FOLDER)
+    output_csv(roles, "contribution_roles.csv", output_folder=ORGANIZATION_FOLDER)
 
     categories = get_challenge_categories(wks)
-    output_csv(categories, "categories.csv", CHALLENGE_FOLDER)
+    output_csv(categories, "categories.csv", output_folder=CHALLENGE_FOLDER)
 
     organizations = get_organization_data(wks)
-    output_csv(organizations, "organizations.csv", ORGANIZATION_FOLDER)
+    output_csv(organizations, "organizations.csv", output_folder=ORGANIZATION_FOLDER)
 
     challenges, incentives, sub_types = get_challenge_data(wks)
-    output_csv(challenges, "challenges.csv", CHALLENGE_FOLDER)
-    output_csv(incentives, "incentives.csv", CHALLENGE_FOLDER)
-    output_csv(sub_types, "submission_types.csv", CHALLENGE_FOLDER)
+    output_csv(challenges, "challenges.csv", output_folder=CHALLENGE_FOLDER)
+    output_csv(incentives, "incentives.csv", 
+               output_folder=CHALLENGE_FOLDER, print_row=True)
+    output_csv(sub_types, "submission_types.csv",
+               output_folder=CHALLENGE_FOLDER, print_row=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2485
Fixes #2418

## Changelog
* add script for pulling data from the [OC Data](https://docs.google.com/spreadsheets/d/1XRSUVqbZk_k9_rV1vpgPVMQ0fVV0mavwY8Aqyy0C2HQ/edit#gid=1744053577) Google Sheet, cleaning it up, then dumping it into CSV files
* add CI workflow to update the DB CSV files daily and open a PR
* add Google client (GC) credentials file (needed for `gspread` Python library) to `.gitignore`

> [!NOTE]
> I need to figure out how to add and use schematic as a step, but the workflow as-is achieves the goal of updating the CSV files (see screenshots below).

## Preview
> [!IMPORTANT]
> ### [See screenshots below for most recent changes.](https://github.com/Sage-Bionetworks/sage-monorepo/pull/2489#issuecomment-1939764562)

* **Example PR:**
<img width="690" alt="Screenshot 2024-02-07 at 9 45 51 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/834e1da5-770e-405c-8df1-5e3c9bb560bf">


* **Files updated:**
<img width="360" alt="Screenshot 2024-02-07 at 9 46 00 PM" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/c6c0b24a-8b3b-4fe3-a3ca-5f5701bfcf67">

## TODO for repo admin

The workflow uses two secrets:
* `secrets.GC_JSON` - used to create credentials file for the Google client APIs
* `secrets.GITHUB_TOKEN` - used to push changes and create PR

From what I can tell with the other workflows, `GITHUB_TOKEN` is already set so no further action is required here.

For `GC_JSON`, the credentials will be shared over LastPass (see Shared-OpenChallenges > Google Service Account JSON Key).  The key will need to be added as-is (in JSON format) as a secret to this repo.