### PR TITLE
feat(iatlas): add health check to the `iatlas-postgres` container

### DIFF
--- a/apps/iatlas/postgres/Dockerfile
+++ b/apps/iatlas/postgres/Dockerfile
@@ -1,1 +1,5 @@
 FROM postgres:12.4-alpine
+
+COPY docker-healthcheck /usr/local/bin/
+
+HEALTHCHECK CMD ["docker-healthcheck"]

--- a/apps/iatlas/postgres/docker-healthcheck
+++ b/apps/iatlas/postgres/docker-healthcheck
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# See https://github.com/docker-library/healthcheck/blob/master/postgres/docker-healthcheck
+
+set -eo pipefail
+
+host="$(hostname -i || echo '127.0.0.1')"
+user="${POSTGRES_USER:-postgres}"
+db="${POSTGRES_DB:-$POSTGRES_USER}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-}"
+
+args=(
+	# force postgres to not use the local unix socket (test "external" connectibility)
+	--host "$host"
+	--username "$user"
+	--dbname "$db"
+	--quiet --no-align --tuples-only
+)
+
+if select="$(echo 'SELECT 1' | psql "${args[@]}")" && [ "$select" = '1' ]; then
+	exit 0
+fi
+
+exit 1

--- a/tools/configure-hostnames.sh
+++ b/tools/configure-hostnames.sh
@@ -4,6 +4,7 @@
 
 # list of hostnames (defined in alphabetical order)
 declare -a hostnames=(
+  "127.0.0.1 iatlas-postgres"
   "127.0.0.1 openchallenges-api-gateway"
   "127.0.0.1 openchallenges-app"
   "127.0.0.1 openchallenges-auth-service"


### PR DESCRIPTION
Closes #2492

## Changelog

- Add health check to the `iatlas-postgres` container
- Register the local hostname `iatlas-postgres`

## Preview

Build the image:

```
nx build-image iatlas-postgres
```

Start the container:

```
nx serve-detach iatlas-postgres
```

Open the Docker extension for VS Code. The health of the container is now displayed.

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/c7c1eb73-056a-4f6a-8b4c-dc17ac86fe20)
