### PR TITLE
fix(openchallenges): update Sage logo

### DIFF
--- a/libs/openchallenges/team/src/lib/team.component.html
+++ b/libs/openchallenges/team/src/lib/team.component.html
@@ -9,7 +9,7 @@
     <p class="mat-body-strong">
       OpenChallenges is made by a team of engineers and scientists at Sage Bionetworks.
     </p>
-    <img height="80px" [src]="(sageLogo$ | async)?.url" alt="Sage Bionetworks" />
+    <img [src]="(sageLogo$ | async)?.url" alt="Sage Bionetworks" />
   </div>
   <div class="member-group">
     <div class="member-card">

--- a/libs/openchallenges/team/src/lib/team.component.ts
+++ b/libs/openchallenges/team/src/lib/team.component.ts
@@ -59,7 +59,7 @@ export class TeamComponent implements OnInit {
       objectKey: 'openchallenges-icon.svg',
     });
     this.sageLogo$ = this.imageService.getImage({
-      objectKey: 'logo/sage-bionetworks-alt.svg',
+      objectKey: 'logo/SageBionetworks-Logo-FullColor.svg',
     });
 
     this.thomasAvatar$ = this.getAvatarImage('team/thomas_schaffter_v3.jpg');

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.html
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.html
@@ -31,7 +31,7 @@
     </div>
     <div class="col-4 app-info">
       <ul>
-        <li><img height="55px" [src]="(sageLogo$ | async)?.url" alt="Sage Bionetworks"/></li>
+        <li><img [src]="(sageLogo$ | async)?.url" alt="Sage Bionetworks"/></li>
         <li>App version: {{ appVersion }}</li>
         <li>Data updated on: {{ dataUpdatedOn }}</li>
       </ul>

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.ts
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.ts
@@ -27,7 +27,7 @@ export class FooterComponent implements OnInit {
 
   ngOnInit() {
     this.sageLogo$ = this.imageService.getImage({
-      objectKey: 'logo/sage-bionetworks-alt-white.svg',
+      objectKey: 'logo/SageBionetworks-Logo-FullColor-WhiteText.svg',
     });
   }
 }


### PR DESCRIPTION
## Changelog

* use Sage's new logo 
* remove `height` specifications; since the new logos are smaller than the previous logos, specifying the heights made the logos looked blurry, so they have been removed

## Preview

* **Footer**
![Screenshot 2024-02-14 at 5 02 46 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/0c0b9bfe-c8fa-440e-8da7-2933c2145546)


* **Meet the Team page**
![Screenshot 2024-02-14 at 5 02 35 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/b6f3c47b-df7b-4200-b413-642627ed586b)

* **Sage profile**
(this will be seen in the next DB update)
![Screenshot 2024-02-14 at 5 20 38 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/b86fb27f-34f5-4349-bf90-34c26583d372)