### PR TITLE
feat(openchallenges): add "MLCube" as a submission type

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSubmissionTypeDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeSubmissionTypeDto.java
@@ -15,6 +15,8 @@ public enum ChallengeSubmissionTypeDto {
 
   NOTEBOOK("notebook"),
 
+  MLCUBE("mlcube"),
+
   OTHER("other");
 
   private String value;

--- a/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
+++ b/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
@@ -77,7 +77,7 @@ CREATE TABLE `challenge_incentive`
 CREATE TABLE `challenge_submission_type`
 (
     `id`                    int NOT NULL AUTO_INCREMENT,
-    `name`                  ENUM('container_image', 'prediction_file', 'notebook', 'other'),
+    `name`                  ENUM('container_image', 'prediction_file', 'notebook', 'mlcube', 'other'),
     `challenge_id`          bigint(20) NOT NULL,
     `created_at`            DATETIME DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -407,6 +407,7 @@ components:
       - container_image
       - prediction_file
       - notebook
+      - mlcube
       - other
       example: container_image
       type: string

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -109,6 +109,9 @@ def get_challenge_data(wks, sheet_name="challenges"):
             df[df.notebook_submission == "TRUE"][["id", "created_at"]].assign(
                 submission_types="notebook"
             ),
+            df[df.mlcube_submission == "TRUE"][["id", "created_at"]].assign(
+                submission_types="mlcube"
+            ),
             df[df.other_submission == "TRUE"][["id", "created_at"]].assign(
                 submission_types="other"
             ),
@@ -116,7 +119,7 @@ def get_challenge_data(wks, sheet_name="challenges"):
     ).rename(columns={"id": "challenge_id"})
     sub_types["submission_types"] = pd.Categorical(
         sub_types["submission_types"],
-        categories=["prediction_file", "container_image", "notebook", "other"],
+        categories=["prediction_file", "container_image", "notebook", "mlcube", "other"],
     )
     sub_types = sub_types.sort_values(["challenge_id", "submission_types"])
     sub_types.index = np.arange(1, len(sub_types) + 1)

--- a/libs/openchallenges/api-client-angular/src/lib/model/challengeSubmissionType.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/challengeSubmissionType.ts
@@ -14,12 +14,13 @@
 /**
  * The submission type of the challenge.
  */
-export type ChallengeSubmissionType = 'container_image' | 'prediction_file' | 'notebook' | 'other';
+export type ChallengeSubmissionType = 'container_image' | 'prediction_file' | 'notebook' | 'mlcube' | 'other';
 
 export const ChallengeSubmissionType = {
     ContainerImage: 'container_image' as ChallengeSubmissionType,
     PredictionFile: 'prediction_file' as ChallengeSubmissionType,
     Notebook: 'notebook' as ChallengeSubmissionType,
+    MLCube: 'mlcube' as ChallengeSubmissionType,
     Other: 'other' as ChallengeSubmissionType
 };
 

--- a/libs/openchallenges/api-description/build/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/build/challenge.openapi.yaml
@@ -221,6 +221,7 @@ components:
         - container_image
         - prediction_file
         - notebook
+        - mlcube
         - other
       example: container_image
     ChallengeCategory:

--- a/libs/openchallenges/api-description/build/openapi.yaml
+++ b/libs/openchallenges/api-description/build/openapi.yaml
@@ -371,6 +371,7 @@ components:
         - container_image
         - prediction_file
         - notebook
+        - mlcube
         - other
       example: container_image
     ChallengeCategory:

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeSubmissionType.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeSubmissionType.yaml
@@ -4,5 +4,6 @@ enum:
   - container_image
   - prediction_file
   - notebook
+  - mlcube
   - other
 example: container_image

--- a/libs/openchallenges/challenge-search/src/lib/challenge-search-filters.ts
+++ b/libs/openchallenges/challenge-search/src/lib/challenge-search-filters.ts
@@ -84,6 +84,10 @@ export const challengeSubmissionTypesFilter: Filter[] = [
     label: 'Notebook',
   },
   {
+    value: ChallengeSubmissionType.MLCube,
+    label: 'MLCube',
+  },
+  {
     value: ChallengeSubmissionType.Other,
     label: 'Other',
   },


### PR DESCRIPTION
Fixes #2509

## Changelog

* update OC Data spreadsheet to include `mlcube_submission` column
* update db-update script to include "mlcube_submission" in the CSV dump
* add `mlcube` as an enum value to the `challenge_submission_type` database table
* add `mlcube` to the API description
* regenerate:
    * OpenAPI spec (with `nx build openchallenges-api-description`)
    * Java files (with `nx run openchallenges-challenge-service:generate`)
    * Angular API client (with `nx run openchallenges-api-client-angular:generate`)
* add "MLCube" as one of the facet values for **Submission Type**

## Preview

* **Describe `challenge_submission_type` table:**
![Screenshot 2024-02-19 at 3 57 24 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/013af4d9-5519-4966-a82c-9d377acde1f0)

* **Challenge search page:**
![Screenshot 2024-02-19 at 3 52 25 PM](https://github.com/Sage-Bionetworks/sage-monorepo/assets/9377970/dad69a35-e8fd-4054-abd7-32f64e9f0df9)

