### PR TITLE
feat(schematic): fds-1688 add endpoints that return files

### DIFF
--- a/apps/schematic/api/schematic_api/controllers/storage_controller.py
+++ b/apps/schematic/api/schematic_api/controllers/storage_controller.py
@@ -26,6 +26,23 @@ from schematic_api import util
 from schematic_api.controllers import storage_controller_impl
 
 
+def get_asset_view_csv(asset_view_id, asset_type):  # noqa: E501
+    """Gets the asset view table in csv file form
+
+    Gets the asset view table in csv file form # noqa: E501
+
+    :param asset_view_id: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project
+    :type asset_view_id: str
+    :param asset_type: Type of asset, such as Synapse
+    :type asset_type: dict | bytes
+
+    :rtype: Union[str, Tuple[str, int], Tuple[str, int, Dict[str, str]]
+    """
+    if connexion.request.is_json:
+        asset_type = AssetType.from_dict(connexion.request.get_json())  # noqa: E501
+    return storage_controller_impl.get_asset_view_csv(asset_view_id, asset_type)
+
+
 def get_asset_view_json(asset_view_id, asset_type):  # noqa: E501
     """Gets the asset view table in json form
 
@@ -113,6 +130,27 @@ def get_dataset_file_metadata_page(
     )
 
 
+def get_dataset_manifest_csv(asset_type, dataset_id, asset_view_id):  # noqa: E501
+    """Gets the manifest in csv form
+
+    Gets the manifest in csv form # noqa: E501
+
+    :param asset_type: Type of asset, such as Synapse
+    :type asset_type: dict | bytes
+    :param dataset_id: The ID of a dataset.
+    :type dataset_id: str
+    :param asset_view_id: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project
+    :type asset_view_id: str
+
+    :rtype: Union[str, Tuple[str, int], Tuple[str, int, Dict[str, str]]
+    """
+    if connexion.request.is_json:
+        asset_type = AssetType.from_dict(connexion.request.get_json())  # noqa: E501
+    return storage_controller_impl.get_dataset_manifest_csv(
+        asset_type, dataset_id, asset_view_id
+    )
+
+
 def get_dataset_manifest_json(asset_type, dataset_id, asset_view_id):  # noqa: E501
     """Gets the manifest in json form
 
@@ -132,6 +170,23 @@ def get_dataset_manifest_json(asset_type, dataset_id, asset_view_id):  # noqa: E
     return storage_controller_impl.get_dataset_manifest_json(
         asset_type, dataset_id, asset_view_id
     )
+
+
+def get_manifest_csv(asset_type, manifest_id):  # noqa: E501
+    """Gets the manifest in csv form
+
+    Gets the manifest in csv form # noqa: E501
+
+    :param asset_type: Type of asset, such as Synapse
+    :type asset_type: dict | bytes
+    :param manifest_id: ID of a manifest
+    :type manifest_id: str
+
+    :rtype: Union[str, Tuple[str, int], Tuple[str, int, Dict[str, str]]
+    """
+    if connexion.request.is_json:
+        asset_type = AssetType.from_dict(connexion.request.get_json())  # noqa: E501
+    return storage_controller_impl.get_manifest_csv(asset_type, manifest_id)
 
 
 def get_manifest_json(asset_type, manifest_id):  # noqa: E501

--- a/apps/schematic/api/schematic_api/openapi/openapi.yaml
+++ b/apps/schematic/api/schematic_api/openapi/openapi.yaml
@@ -16,6 +16,73 @@ tags:
 - description: Operations about storages.
   name: Storage
 paths:
+  /assetTypes/{assetType}/assetViews/{assetViewId}/csv:
+    get:
+      description: Gets the asset view table in csv file form
+      operationId: get_asset_view_csv
+      parameters:
+      - description: ID of view listing all project data assets. E.g. for Synapse
+          this would be the Synapse ID of the fileview listing all data assets for
+          a given project
+        explode: false
+        in: path
+        name: assetViewId
+        required: true
+        schema:
+          $ref: '#/components/schemas/AssetViewId'
+        style: simple
+      - description: "Type of asset, such as Synapse"
+        explode: false
+        in: path
+        name: assetType
+        required: true
+        schema:
+          $ref: '#/components/schemas/AssetType'
+        style: simple
+      responses:
+        "200":
+          content:
+            text/csv:
+              schema:
+                type: string
+          description: Success
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Invalid request
+        "401":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Unauthorized
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: The specified resource was not found
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      security:
+      - bearerAuth: []
+      summary: Gets the asset view table in csv file form
+      tags:
+      - Storage
+      x-openapi-router-controller: schematic_api.controllers.storage_controller
   /assetTypes/{assetType}/assetViews/{assetViewId}/json:
     get:
       description: Gets the asset view table in json form
@@ -443,6 +510,81 @@ paths:
       tags:
       - Storage
       x-openapi-router-controller: schematic_api.controllers.storage_controller
+  /assetTypes/{assetType}/datasets/{datasetId}/manifestCsv:
+    get:
+      description: Gets the manifest in csv form
+      operationId: get_dataset_manifest_csv
+      parameters:
+      - description: "Type of asset, such as Synapse"
+        explode: false
+        in: path
+        name: assetType
+        required: true
+        schema:
+          $ref: '#/components/schemas/AssetType'
+        style: simple
+      - description: The ID of a dataset.
+        explode: false
+        in: path
+        name: datasetId
+        required: true
+        schema:
+          $ref: '#/components/schemas/DatasetId'
+        style: simple
+      - description: ID of view listing all project data assets. E.g. for Synapse
+          this would be the Synapse ID of the fileview listing all data assets for
+          a given project
+        explode: true
+        in: query
+        name: assetViewId
+        required: true
+        schema:
+          $ref: '#/components/schemas/AssetViewId'
+        style: form
+      responses:
+        "200":
+          content:
+            text/csv:
+              schema:
+                type: string
+          description: Success
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Invalid request
+        "401":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Unauthorized
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: The specified resource was not found
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      security:
+      - bearerAuth: []
+      summary: Gets the manifest in csv form
+      tags:
+      - Storage
+      x-openapi-router-controller: schematic_api.controllers.storage_controller
   /assetTypes/{assetType}/datasets/{datasetId}/manifestJson:
     get:
       description: Gets the manifest in json form
@@ -515,6 +657,71 @@ paths:
       security:
       - bearerAuth: []
       summary: Gets the manifest in json form
+      tags:
+      - Storage
+      x-openapi-router-controller: schematic_api.controllers.storage_controller
+  /assetTypes/{assetType}/manifests/{manifestId}/csv:
+    get:
+      description: Gets the manifest in csv form
+      operationId: get_manifest_csv
+      parameters:
+      - description: "Type of asset, such as Synapse"
+        explode: false
+        in: path
+        name: assetType
+        required: true
+        schema:
+          $ref: '#/components/schemas/AssetType'
+        style: simple
+      - description: ID of a manifest
+        explode: false
+        in: path
+        name: manifestId
+        required: true
+        schema:
+          $ref: '#/components/schemas/ManifestId'
+        style: simple
+      responses:
+        "200":
+          content:
+            text/csv:
+              schema:
+                type: string
+          description: Success
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Invalid request
+        "401":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: Unauthorized
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: The specified resource was not found
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      security:
+      - bearerAuth: []
+      summary: Gets the manifest in csv form
       tags:
       - Storage
       x-openapi-router-controller: schematic_api.controllers.storage_controller

--- a/apps/schematic/api/schematic_api/test/conftest.py
+++ b/apps/schematic/api/schematic_api/test/conftest.py
@@ -78,7 +78,7 @@ def fixture_example_manifest_metadata() -> Generator:
     yield EXAMPLE_MANIFEST_METADATA
 
 
-TEST_SCHEMA_URL = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/develop/tests/data/example.model.jsonld"  # pylint: disable=line-too-long
+TEST_SCHEMA_URL = "https://raw.githubusercontent.com/Sage-Bionetworks/schematic/main/tests/data/example.model.jsonld"  # pylint: disable=line-too-long
 
 
 @pytest.fixture(scope="session", name="test_schema_url")

--- a/apps/schematic/api/schematic_api/test/test_storage_controller_endpoints.py
+++ b/apps/schematic/api/schematic_api/test/test_storage_controller_endpoints.py
@@ -11,15 +11,13 @@ from schematic.exceptions import AccessCredentialsError  # type: ignore
 import schematic_api.controllers.storage_controller_impl
 from schematic_api.test import BaseTestCase
 from schematic_api.models.file_metadata import FileMetadata
-from schematic_api.models.dataset_metadata import DatasetMetadata
-from schematic_api.models.project_metadata import ProjectMetadata
-from .conftest import EXAMPLE_MANIFEST_METADATA, MANIFEST_METADATA_KEYS, PAGING_KEYS
 
 HEADERS = {
     "Accept": "application/json",
     "Authorization": "Bearer xxx",
 }
 
+ASSET_VIEW_CSV_URL = "/api/v1/assetTypes/synapse/assetViews/syn1/csv"
 ASSET_VIEW_JSON_URL = "/api/v1/assetTypes/synapse/assetViews/syn1/json"
 DATASET_FILE_METADATA_ARRAY_URL = (
     "/api/v1/assetTypes/synapse/datasets/syn2/fileMetadataArray?assetViewId=syn1"
@@ -27,28 +25,78 @@ DATASET_FILE_METADATA_ARRAY_URL = (
 DATASET_FILE_METADATA_PAGE_URL = (
     "/api/v1/assetTypes/synapse/datasets/syn2/fileMetadataPage?assetViewId=syn1"
 )
+DATASET_MANIFEST_CSV_URL = (
+    "/api/v1/assetTypes/synapse/datasets/syn2/manifestCsv?assetViewId=syn1"
+)
 DATASET_MANIFEST_JSON_URL = (
     "/api/v1/assetTypes/synapse/datasets/syn2/manifestJson?assetViewId=syn1"
 )
+MANIFEST_CSV_URL = "/api/v1/assetTypes/synapse/manifests/syn1/csv"
 MANIFEST_JSON_URL = "/api/v1/assetTypes/synapse/manifests/syn1/json"
-PROJECT_METADATA_ARRAY_URL = (
-    "/api/v1/assetTypes/synapse/assetViews/syn1/projectMetadataArray"
-)
-PROJECT_METADATA_PAGE_URL = (
-    "/api/v1/assetTypes/synapse/assetViews/syn1/projectMetadataPage"
-)
-PROJECT_DATASET_METATDATA_ARRRAY_URL = (
-    "/api/v1/assetTypes/synapse/projects/syn2/datasetMetadataArray?assetViewId=syn1"
-)
-PROJECT_DATASET_METATDATA_PAGE_URL = (
-    "/api/v1/assetTypes/synapse/projects/syn2/datasetMetadataPage?assetViewId=syn1"
-)
-PROJECT_MANIFEST_METADATA_ARRAY_URL = (
-    "/api/v1/assetTypes/synapse/projects/syn2/manifestMetadataArray?assetViewId=syn1"
-)
-PROJECT_MANIFEST_METADATA_PAGE_URL = (
-    "/api/v1/assetTypes/synapse/projects/syn2/manifestMetadataPage?assetViewId=syn1"
-)
+
+
+class TestGetAssetViewCsv(BaseTestCase):
+    """Test case for asset view json endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_asset_view_from_schematic",
+            return_value=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}),
+        ):
+            response = self.client.open(
+                ASSET_VIEW_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, str)
+            assert result.endswith("asset_view.csv")
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_asset_view_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                ASSET_VIEW_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_asset_view_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                ASSET_VIEW_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_asset_view_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                ASSET_VIEW_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
 
 
 class TestGetAssetViewJson(BaseTestCase):
@@ -364,6 +412,70 @@ class TestGetDatasetFileMetadataPage(BaseTestCase):
             )
 
 
+class TestGetDatasetManifestCSV(BaseTestCase):
+    """Test case for manifest json endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_dataset_manifest_from_schematic",
+            return_value=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}),
+        ):
+            response = self.client.open(
+                DATASET_MANIFEST_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, str)
+            assert result.endswith("manifest.csv")
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_dataset_manifest_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                DATASET_MANIFEST_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_dataset_manifest_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                DATASET_MANIFEST_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_dataset_manifest_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                DATASET_MANIFEST_CSV_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
 class TestGetDatasetManifestJson(BaseTestCase):
     """Test case for manifest json endpoint"""
 
@@ -426,6 +538,62 @@ class TestGetDatasetManifestJson(BaseTestCase):
             )
 
 
+class TestGetManifestCSV(BaseTestCase):
+    """Test case for manifest json endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_manifest_from_schematic",
+            return_value=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}),
+        ):
+            response = self.client.open(MANIFEST_CSV_URL, method="GET", headers=HEADERS)
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, str)
+            assert result.endswith("manifest.csv")
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_manifest_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(MANIFEST_CSV_URL, method="GET", headers=HEADERS)
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_manifest_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(MANIFEST_CSV_URL, method="GET", headers=HEADERS)
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_manifest_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(MANIFEST_CSV_URL, method="GET", headers=HEADERS)
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
 class TestGetManifestJson(BaseTestCase):
     """Test case for manifest json endpoint"""
 
@@ -482,456 +650,6 @@ class TestGetManifestJson(BaseTestCase):
         ):
             response = self.client.open(
                 MANIFEST_JSON_URL, method="GET", headers=HEADERS
-            )
-            self.assert500(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-
-class TestGetProjectMetadataArray(BaseTestCase):
-    """Test case for projects endpoint"""
-
-    def test_success(self) -> None:
-        """Test for successful result"""
-
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            return_value=[
-                ProjectMetadata("syn1", "name1"),
-                ProjectMetadata("syn2", "name2"),
-            ],
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert200(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-            result = response.json
-            assert isinstance(result, dict)
-            assert list(result.keys()) == ["projects"]
-            assert isinstance(result["projects"], list)
-            for item in result["projects"]:
-                assert isinstance(item, dict)
-                assert list(item.keys()) == ["id", "name"]
-                assert isinstance(item["name"], str)
-                assert isinstance(item["id"], str)
-
-    def test_401(self) -> None:
-        """Test for 401 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            side_effect=SynapseNoCredentialsError,
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert401(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_403(self) -> None:
-        """Test for 403 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            side_effect=AccessCredentialsError("project"),
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert403(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_500(self) -> None:
-        """Test for 500 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            side_effect=TypeError,
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert500(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-
-class TestGetProjectMetadataPage(BaseTestCase):
-    """Test case for projects endpoint"""
-
-    def test_success(self) -> None:
-        """Test for successful result"""
-
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            return_value=[
-                ProjectMetadata("syn1", "name1"),
-                ProjectMetadata("syn2", "name2"),
-            ],
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert200(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-            result = response.json
-            assert isinstance(result, dict)
-            assert list(result.keys()) == sorted(PAGING_KEYS + ["projects"])
-            assert result["number"] == 1
-            assert result["size"] == 100000
-            assert not result["hasNext"]
-            assert not result["hasPrevious"]
-            assert result["totalPages"] == 1
-            assert isinstance(result["totalElements"], int)
-            assert isinstance(result["projects"], list)
-            for item in result["projects"]:
-                assert isinstance(item, dict)
-                assert list(item.keys()) == ["id", "name"]
-                assert isinstance(item["name"], str)
-                assert isinstance(item["id"], str)
-
-    def test_401(self) -> None:
-        """Test for 401 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            side_effect=SynapseNoCredentialsError,
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert401(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_403(self) -> None:
-        """Test for 403 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            side_effect=AccessCredentialsError("project"),
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert403(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_500(self) -> None:
-        """Test for 500 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_metadata_from_schematic",
-            side_effect=TypeError,
-        ):
-            response = self.client.open(
-                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert500(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-
-class TestGetProjectDatasetMetadataArray(BaseTestCase):
-    """Test case for dataset metadat endpoint"""
-
-    def test_success(self) -> None:
-        """Test for successful result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            return_value=[
-                DatasetMetadata("syn1", "name1"),
-                DatasetMetadata("syn2", "name2"),
-            ],
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert200(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-            result = response.json
-            assert isinstance(result, dict)
-            assert isinstance(result["datasets"], list)
-            for item in result["datasets"]:
-                assert isinstance(item, dict)
-                assert list(item.keys()) == ["id", "name"]
-                assert isinstance(item["id"], str)
-                assert isinstance(item["name"], str)
-
-    def test_401(self) -> None:
-        """Test for 401 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            side_effect=SynapseNoCredentialsError,
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert401(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_403(self) -> None:
-        """Test for 403 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            side_effect=AccessCredentialsError("project"),
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert403(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_500(self) -> None:
-        """Test for 500 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            side_effect=TypeError,
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert500(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-
-class TestGetProjectDatasetMetadataPage(BaseTestCase):
-    """Test case for dataset metadat endpoint"""
-
-    def test_success(self) -> None:
-        """Test for successful result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            return_value=[
-                DatasetMetadata("syn1", "name1"),
-                DatasetMetadata("syn2", "name2"),
-            ],
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert200(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-            result = response.json
-            assert isinstance(result, dict)
-            assert result["number"] == 1
-            assert result["size"] == 100000
-            assert not result["hasNext"]
-            assert not result["hasPrevious"]
-            assert result["totalPages"] == 1
-            assert isinstance(result["totalElements"], int)
-            assert isinstance(result["datasets"], list)
-            for item in result["datasets"]:
-                assert isinstance(item, dict)
-                assert list(item.keys()) == ["id", "name"]
-                assert isinstance(item["id"], str)
-                assert isinstance(item["name"], str)
-
-    def test_401(self) -> None:
-        """Test for 401 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            side_effect=SynapseNoCredentialsError,
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert401(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_403(self) -> None:
-        """Test for 403 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            side_effect=AccessCredentialsError("project"),
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert403(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_500(self) -> None:
-        """Test for 500 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_dataset_metadata_from_schematic",
-            side_effect=TypeError,
-        ):
-            response = self.client.open(
-                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert500(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-
-class TestGetProjectManifestMetadataArray(BaseTestCase):
-    """Test case for manifests endpoint"""
-
-    def test_success(self) -> None:
-        """Test for successful result"""
-
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            return_value=EXAMPLE_MANIFEST_METADATA,
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert200(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-            result = response.json
-            assert isinstance(result, dict)
-            assert isinstance(result["manifests"], list)
-            for item in result["manifests"]:
-                assert isinstance(item, dict)
-                assert list(item.keys()) == MANIFEST_METADATA_KEYS
-                assert isinstance(item["id"], str)
-                assert isinstance(item["name"], str)
-                assert isinstance(item["datasetName"], str)
-                assert isinstance(item["datasetId"], str)
-                assert isinstance(item["componentName"], str)
-
-    def test_401(self) -> None:
-        """Test for 401 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            side_effect=SynapseNoCredentialsError,
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert401(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_403(self) -> None:
-        """Test for 403 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            side_effect=AccessCredentialsError("project"),
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert403(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_500(self) -> None:
-        """Test for 500 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            side_effect=TypeError,
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
-            )
-            self.assert500(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-
-class TestGetProjectManifestMetadataPage(BaseTestCase):
-    """Test case for manifests endpoint"""
-
-    def test_success(self) -> None:
-        """Test for successful result"""
-
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            return_value=EXAMPLE_MANIFEST_METADATA,
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert200(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-            result = response.json
-            assert isinstance(result, dict)
-            assert result["number"] == 1
-            assert result["size"] == 100000
-            assert not result["hasNext"]
-            assert not result["hasPrevious"]
-            assert result["totalPages"] == 1
-            assert isinstance(result["totalElements"], int)
-            assert isinstance(result["manifests"], list)
-            for item in result["manifests"]:
-                assert isinstance(item, dict)
-                assert list(item.keys()) == MANIFEST_METADATA_KEYS
-                assert isinstance(item["id"], str)
-                assert isinstance(item["name"], str)
-                assert isinstance(item["datasetName"], str)
-                assert isinstance(item["datasetId"], str)
-                assert isinstance(item["componentName"], str)
-
-    def test_401(self) -> None:
-        """Test for 401 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            side_effect=SynapseNoCredentialsError,
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert401(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_403(self) -> None:
-        """Test for 403 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            side_effect=AccessCredentialsError("project"),
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
-            )
-            self.assert403(
-                response, f"Response body is : {response.data.decode('utf-8')}"
-            )
-
-    def test_500(self) -> None:
-        """Test for 500 result"""
-        with patch.object(
-            schematic_api.controllers.storage_controller_impl,
-            "get_project_manifest_metadata_from_schematic",
-            side_effect=TypeError,
-        ):
-            response = self.client.open(
-                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
             )
             self.assert500(
                 response, f"Response body is : {response.data.decode('utf-8')}"

--- a/apps/schematic/api/schematic_api/test/test_storage_controller_endpoints2.py
+++ b/apps/schematic/api/schematic_api/test/test_storage_controller_endpoints2.py
@@ -1,0 +1,492 @@
+"""Tests for endpoints"""
+# pylint: disable=duplicate-code
+
+import unittest
+from unittest.mock import patch
+
+from synapseclient.core.exceptions import SynapseNoCredentialsError  # type: ignore
+from schematic.exceptions import AccessCredentialsError  # type: ignore
+
+import schematic_api.controllers.storage_controller_impl
+from schematic_api.test import BaseTestCase
+from schematic_api.models.dataset_metadata import DatasetMetadata
+from schematic_api.models.project_metadata import ProjectMetadata
+from .conftest import EXAMPLE_MANIFEST_METADATA, MANIFEST_METADATA_KEYS, PAGING_KEYS
+
+HEADERS = {
+    "Accept": "application/json",
+    "Authorization": "Bearer xxx",
+}
+
+PROJECT_METADATA_ARRAY_URL = (
+    "/api/v1/assetTypes/synapse/assetViews/syn1/projectMetadataArray"
+)
+PROJECT_METADATA_PAGE_URL = (
+    "/api/v1/assetTypes/synapse/assetViews/syn1/projectMetadataPage"
+)
+PROJECT_DATASET_METATDATA_ARRRAY_URL = (
+    "/api/v1/assetTypes/synapse/projects/syn2/datasetMetadataArray?assetViewId=syn1"
+)
+PROJECT_DATASET_METATDATA_PAGE_URL = (
+    "/api/v1/assetTypes/synapse/projects/syn2/datasetMetadataPage?assetViewId=syn1"
+)
+PROJECT_MANIFEST_METADATA_ARRAY_URL = (
+    "/api/v1/assetTypes/synapse/projects/syn2/manifestMetadataArray?assetViewId=syn1"
+)
+PROJECT_MANIFEST_METADATA_PAGE_URL = (
+    "/api/v1/assetTypes/synapse/projects/syn2/manifestMetadataPage?assetViewId=syn1"
+)
+
+
+class TestGetProjectMetadataArray(BaseTestCase):
+    """Test case for projects endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            return_value=[
+                ProjectMetadata("syn1", "name1"),
+                ProjectMetadata("syn2", "name2"),
+            ],
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, dict)
+            assert list(result.keys()) == ["projects"]
+            assert isinstance(result["projects"], list)
+            for item in result["projects"]:
+                assert isinstance(item, dict)
+                assert list(item.keys()) == ["id", "name"]
+                assert isinstance(item["name"], str)
+                assert isinstance(item["id"], str)
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
+class TestGetProjectMetadataPage(BaseTestCase):
+    """Test case for projects endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            return_value=[
+                ProjectMetadata("syn1", "name1"),
+                ProjectMetadata("syn2", "name2"),
+            ],
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, dict)
+            assert list(result.keys()) == sorted(PAGING_KEYS + ["projects"])
+            assert result["number"] == 1
+            assert result["size"] == 100000
+            assert not result["hasNext"]
+            assert not result["hasPrevious"]
+            assert result["totalPages"] == 1
+            assert isinstance(result["totalElements"], int)
+            assert isinstance(result["projects"], list)
+            for item in result["projects"]:
+                assert isinstance(item, dict)
+                assert list(item.keys()) == ["id", "name"]
+                assert isinstance(item["name"], str)
+                assert isinstance(item["id"], str)
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_metadata_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                PROJECT_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
+class TestGetProjectDatasetMetadataArray(BaseTestCase):
+    """Test case for dataset metadat endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            return_value=[
+                DatasetMetadata("syn1", "name1"),
+                DatasetMetadata("syn2", "name2"),
+            ],
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, dict)
+            assert isinstance(result["datasets"], list)
+            for item in result["datasets"]:
+                assert isinstance(item, dict)
+                assert list(item.keys()) == ["id", "name"]
+                assert isinstance(item["id"], str)
+                assert isinstance(item["name"], str)
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_ARRRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
+class TestGetProjectDatasetMetadataPage(BaseTestCase):
+    """Test case for dataset metadat endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            return_value=[
+                DatasetMetadata("syn1", "name1"),
+                DatasetMetadata("syn2", "name2"),
+            ],
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, dict)
+            assert result["number"] == 1
+            assert result["size"] == 100000
+            assert not result["hasNext"]
+            assert not result["hasPrevious"]
+            assert result["totalPages"] == 1
+            assert isinstance(result["totalElements"], int)
+            assert isinstance(result["datasets"], list)
+            for item in result["datasets"]:
+                assert isinstance(item, dict)
+                assert list(item.keys()) == ["id", "name"]
+                assert isinstance(item["id"], str)
+                assert isinstance(item["name"], str)
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_dataset_metadata_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                PROJECT_DATASET_METATDATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
+class TestGetProjectManifestMetadataArray(BaseTestCase):
+    """Test case for manifests endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            return_value=EXAMPLE_MANIFEST_METADATA,
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, dict)
+            assert isinstance(result["manifests"], list)
+            for item in result["manifests"]:
+                assert isinstance(item, dict)
+                assert list(item.keys()) == MANIFEST_METADATA_KEYS
+                assert isinstance(item["id"], str)
+                assert isinstance(item["name"], str)
+                assert isinstance(item["datasetName"], str)
+                assert isinstance(item["datasetId"], str)
+                assert isinstance(item["componentName"], str)
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_ARRAY_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
+class TestGetProjectManifestMetadataPage(BaseTestCase):
+    """Test case for manifests endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            return_value=EXAMPLE_MANIFEST_METADATA,
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert200(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+            result = response.json
+            assert isinstance(result, dict)
+            assert result["number"] == 1
+            assert result["size"] == 100000
+            assert not result["hasNext"]
+            assert not result["hasPrevious"]
+            assert result["totalPages"] == 1
+            assert isinstance(result["totalElements"], int)
+            assert isinstance(result["manifests"], list)
+            for item in result["manifests"]:
+                assert isinstance(item, dict)
+                assert list(item.keys()) == MANIFEST_METADATA_KEYS
+                assert isinstance(item["id"], str)
+                assert isinstance(item["name"], str)
+                assert isinstance(item["datasetName"], str)
+                assert isinstance(item["datasetId"], str)
+                assert isinstance(item["componentName"], str)
+
+    def test_401(self) -> None:
+        """Test for 401 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            side_effect=SynapseNoCredentialsError,
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert401(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_403(self) -> None:
+        """Test for 403 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            side_effect=AccessCredentialsError("project"),
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert403(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+    def test_500(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_project_manifest_metadata_from_schematic",
+            side_effect=TypeError,
+        ):
+            response = self.client.open(
+                PROJECT_MANIFEST_METADATA_PAGE_URL, method="GET", headers=HEADERS
+            )
+            self.assert500(
+                response, f"Response body is : {response.data.decode('utf-8')}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/schematic/api/schematic_api/test/test_storage_controller_impl.py
+++ b/apps/schematic/api/schematic_api/test/test_storage_controller_impl.py
@@ -25,8 +25,11 @@ from schematic_api.models.file_metadata_page import FileMetadataPage
 from schematic_api.models.file_metadata_array import FileMetadataArray
 import schematic_api.controllers.storage_controller_impl
 from schematic_api.controllers.storage_controller_impl import (
+    get_dataset_manifest_csv,
     get_dataset_manifest_json,
+    get_manifest_csv,
     get_manifest_json,
+    get_asset_view_csv,
     get_asset_view_json,
     get_dataset_file_metadata_array,
     get_dataset_file_metadata_page,
@@ -37,6 +40,36 @@ from schematic_api.controllers.storage_controller_impl import (
     get_project_manifest_metadata_array,
     get_project_manifest_metadata_page,
 )
+
+
+class TestGetAssetViewCsv:
+    """Test case for get_asset_view_csv"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_asset_view_from_schematic",
+            return_value=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}),
+        ):
+            result, status = get_asset_view_csv(
+                asset_type="synapse", asset_view_id="syn1"
+            )
+            assert status == 200
+            assert result.endswith("asset_view.csv")
+
+    def test_internal_error(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_asset_view_from_schematic",
+            side_effect=TypeError,
+        ):
+            result, status = get_asset_view_csv(
+                asset_type="synapse", asset_view_id="syn1"
+            )
+            assert status == 500
+            assert isinstance(result, BasicError)
 
 
 class TestGetAssetViewJson:
@@ -262,6 +295,36 @@ class TestGetDatasetFileMetadataPage:
             assert isinstance(result, BasicError)
 
 
+class TestGetDatasetManifestCsv:
+    """Test case for get_dataset_manifest_csv"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_dataset_manifest_from_schematic",
+            return_value=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}),
+        ):
+            result, status = get_dataset_manifest_csv(
+                asset_type="synapse", dataset_id="syn1", asset_view_id="syn2"
+            )
+            assert status == 200
+            assert result.endswith("manifest.csv")
+
+    def test_internal_error(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_dataset_manifest_from_schematic",
+            side_effect=TypeError,
+        ):
+            result, status = get_dataset_manifest_csv(
+                asset_type="synapse", dataset_id="syn1", asset_view_id="syn2"
+            )
+            assert status == 500
+            assert isinstance(result, BasicError)
+
+
 class TestGetDatasetManifestJson:
     """Test case for get_dataset_manifest_json"""
 
@@ -327,6 +390,32 @@ class TestGetDatasetManifestJson:
             result, status = get_dataset_manifest_json(
                 asset_type="synapse", dataset_id="syn1", asset_view_id="syn2"
             )
+            assert status == 500
+            assert isinstance(result, BasicError)
+
+
+class TestGetManifestCsv:
+    """Test case for get_manifest_csv"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_manifest_from_schematic",
+            return_value=pd.DataFrame({"col1": [1, 2], "col2": [3, 4]}),
+        ):
+            result, status = get_manifest_csv(asset_type="synapse", manifest_id="syn1")
+            assert status == 200
+            assert result.endswith("manifest.csv")
+
+    def test_internal_error(self) -> None:
+        """Test for 500 result"""
+        with patch.object(
+            schematic_api.controllers.storage_controller_impl,
+            "get_manifest_from_schematic",
+            side_effect=TypeError,
+        ):
+            result, status = get_manifest_csv(asset_type="synapse", manifest_id="syn1")
             assert status == 500
             assert isinstance(result, BasicError)
 

--- a/apps/schematic/api/schematic_api/test/test_synapse_endpoints.py
+++ b/apps/schematic/api/schematic_api/test/test_synapse_endpoints.py
@@ -118,6 +118,17 @@ class TestValidationEndpoints(BaseTestCase):
 class TestStorageEndpoints(BaseTestCase):
     """Integration tests"""
 
+    def test_get_asset_view_csv(self) -> None:
+        """Test for successful result"""
+        url = "/api/v1/assetTypes/synapse/" f"assetViews/{TEST_ASSET_VIEW}/csv"
+        response = self.client.open(url, method="GET", headers=HEADERS)
+        self.assert200(response, f"Response body is : {response.data.decode('utf-8')}")
+        path = json.loads(response.data)
+        assert isinstance(path, str)
+        assert path.endswith(".asset_view.csv")
+        asset_view = pd.read_csv(path)
+        assert isinstance(asset_view, pd.DataFrame)
+
     def test_get_asset_view_json(self) -> None:
         """Test for successful result"""
         url = "/api/v1/assetTypes/synapse/" f"assetViews/{TEST_ASSET_VIEW}/json"
@@ -163,6 +174,21 @@ class TestStorageEndpoints(BaseTestCase):
             for key in ["id", "name"]:
                 assert key in item
 
+    def test_get_dataset_manifest_csv(self) -> None:
+        """Test for successful result"""
+        url = (
+            "/api/v1/assetTypes/synapse/"
+            f"datasets/{TEST_DATASET}/manifestCsv"
+            f"?assetViewId={TEST_ASSET_VIEW}"
+        )
+        response = self.client.open(url, method="GET", headers=HEADERS)
+        self.assert200(response, f"Response body is : {response.data.decode('utf-8')}")
+        path = json.loads(response.data)
+        assert isinstance(path, str)
+        assert path.endswith(".manifest.csv")
+        asset_view = pd.read_csv(path)
+        assert isinstance(asset_view, pd.DataFrame)
+
     def test_get_dataset_manifest_json(self) -> None:
         """Test for successful result"""
         url = (
@@ -177,6 +203,17 @@ class TestStorageEndpoints(BaseTestCase):
         assert isinstance(response_dict, dict)
         dataframe = pd.DataFrame.from_dict(response_dict)
         assert isinstance(dataframe, pd.DataFrame)
+
+    def test_get_manifest_csv(self) -> None:
+        """Test for successful result"""
+        url = "/api/v1/assetTypes/synapse/" f"manifests/{TEST_MANIFEST}/csv"
+        response = self.client.open(url, method="GET", headers=HEADERS)
+        self.assert200(response, f"Response body is : {response.data.decode('utf-8')}")
+        path = json.loads(response.data)
+        assert isinstance(path, str)
+        assert path.endswith(".manifest.csv")
+        asset_view = pd.read_csv(path)
+        assert isinstance(asset_view, pd.DataFrame)
 
     def test_get_manifest_json(self) -> None:
         """Test for successful result"""

--- a/libs/schematic/api-description/build/openapi.yaml
+++ b/libs/schematic/api-description/build/openapi.yaml
@@ -190,6 +190,35 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /assetTypes/{assetType}/assetViews/{assetViewId}/csv:
+    parameters:
+      - $ref: '#/components/parameters/assetViewId'
+      - $ref: '#/components/parameters/assetType'
+    get:
+      tags:
+        - Storage
+      summary: Gets the asset view table in csv file form
+      description: Gets the asset view table in csv file form
+      operationId: getAssetViewCsv
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            text/csv:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /assetTypes/{assetType}/datasets/{datasetId}/manifestJson:
     parameters:
       - $ref: '#/components/parameters/assetType'
@@ -211,6 +240,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManifestJson'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /assetTypes/{assetType}/datasets/{datasetId}/manifestCsv:
+    parameters:
+      - $ref: '#/components/parameters/assetType'
+      - $ref: '#/components/parameters/datasetId'
+    get:
+      tags:
+        - Storage
+      summary: Gets the manifest in csv form
+      description: Gets the manifest in csv form
+      operationId: getDatasetManifestCsv
+      parameters:
+        - $ref: '#/components/parameters/assetViewIdQuery'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            text/csv:
+              schema:
+                type: string
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -369,6 +429,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManifestJson'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /assetTypes/{assetType}/manifests/{manifestId}/csv:
+    parameters:
+      - $ref: '#/components/parameters/assetType'
+      - $ref: '#/components/parameters/manifestId'
+    get:
+      tags:
+        - Storage
+      summary: Gets the manifest in csv form
+      description: Gets the manifest in csv form
+      operationId: getManifestCsv
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            text/csv:
+              schema:
+                type: string
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':

--- a/libs/schematic/api-description/src/openapi.yaml
+++ b/libs/schematic/api-description/src/openapi.yaml
@@ -41,8 +41,14 @@ paths:
   /assetTypes/{assetType}/assetViews/{assetViewId}/json:
     $ref: paths/assetTypes/@{assetType}/assetViews/@{assetViewId}/json.yaml
 
+  /assetTypes/{assetType}/assetViews/{assetViewId}/csv:
+    $ref: paths/assetTypes/@{assetType}/assetViews/@{assetViewId}/csv.yaml
+
   /assetTypes/{assetType}/datasets/{datasetId}/manifestJson:
     $ref: paths/assetTypes/@{assetType}/datasets/@{datasetId}/manifestJson.yaml
+
+  /assetTypes/{assetType}/datasets/{datasetId}/manifestCsv:
+    $ref: paths/assetTypes/@{assetType}/datasets/@{datasetId}/manifestCsv.yaml
 
   /assetTypes/{assetType}/assetViews/{assetViewId}/projectMetadataArray:
     $ref: paths/assetTypes/@{assetType}/assetViews/@{assetViewId}/projectMetadataArray.yaml
@@ -58,6 +64,9 @@ paths:
 
   /assetTypes/{assetType}/manifests/{manifestId}/json:
     $ref: paths/assetTypes/@{assetType}/manifests/@{manifestId}/json.yaml
+
+  /assetTypes/{assetType}/manifests/{manifestId}/csv:
+    $ref: paths/assetTypes/@{assetType}/manifests/@{manifestId}/csv.yaml
 
   /nodes/{nodeLabel}/dependencyArray:
     $ref: paths/nodes/@{nodeLabel}/dependencyArray.yaml

--- a/libs/schematic/api-description/src/paths/assetTypes/@{assetType}/assetViews/@{assetViewId}/csv.yaml
+++ b/libs/schematic/api-description/src/paths/assetTypes/@{assetType}/assetViews/@{assetViewId}/csv.yaml
@@ -1,0 +1,28 @@
+parameters:
+  - $ref: ../../../../../components/parameters/path/assetViewId.yaml
+  - $ref: ../../../../../components/parameters/path/assetType.yaml
+get:
+  tags:
+    - Storage
+  summary: Gets the asset view table in csv file form
+  description: Gets the asset view table in csv file form
+  operationId: getAssetViewCsv
+  security:
+    - bearerAuth: []
+  responses:
+    '200':
+      description: Success
+      content:
+        text/csv:
+          schema:
+            type: string
+    '400':
+      $ref: ../../../../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../../../../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../../../../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../../../../components/responses/NotFound.yaml
+    '500':
+      $ref: ../../../../../components/responses/InternalServerError.yaml

--- a/libs/schematic/api-description/src/paths/assetTypes/@{assetType}/datasets/@{datasetId}/manifestCsv.yaml
+++ b/libs/schematic/api-description/src/paths/assetTypes/@{assetType}/datasets/@{datasetId}/manifestCsv.yaml
@@ -1,0 +1,30 @@
+parameters:
+  - $ref: ../../../../../components/parameters/path/assetType.yaml
+  - $ref: ../../../../../components/parameters/path/datasetId.yaml
+get:
+  tags:
+    - Storage
+  summary: Gets the manifest in csv form
+  description: Gets the manifest in csv form
+  operationId: getDatasetManifestCsv
+  parameters:
+    - $ref: ../../../../../components/parameters/query/assetViewIdQuery.yaml
+  security:
+    - bearerAuth: []
+  responses:
+    '200':
+      description: Success
+      content:
+        text/csv:
+          schema:
+            type: string
+    '400':
+      $ref: ../../../../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../../../../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../../../../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../../../../components/responses/NotFound.yaml
+    '500':
+      $ref: ../../../../../components/responses/InternalServerError.yaml

--- a/libs/schematic/api-description/src/paths/assetTypes/@{assetType}/manifests/@{manifestId}/csv.yaml
+++ b/libs/schematic/api-description/src/paths/assetTypes/@{assetType}/manifests/@{manifestId}/csv.yaml
@@ -1,0 +1,28 @@
+parameters:
+  - $ref: ../../../../../components/parameters/path/assetType.yaml
+  - $ref: ../../../../../components/parameters/path/manifestId.yaml
+get:
+  tags:
+    - Storage
+  summary: Gets the manifest in csv form
+  description: Gets the manifest in csv form
+  operationId: getManifestCsv
+  security:
+    - bearerAuth: []
+  responses:
+    '200':
+      description: Success
+      content:
+        text/csv:
+          schema:
+            type: string
+    '400':
+      $ref: ../../../../../components/responses/BadRequest.yaml
+    '401':
+      $ref: ../../../../../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../../../../../components/responses/Unauthorized.yaml
+    '404':
+      $ref: ../../../../../components/responses/NotFound.yaml
+    '500':
+      $ref: ../../../../../components/responses/InternalServerError.yaml


### PR DESCRIPTION
- fixes [FDS-1688]
- Adds endpoints that return csv files
- Please review 

1. all files in `libs/schematic/api-description/src/`
2. all files in `apps/schematic/api/schematic_api/controllers/`  except  `storage_controller.py`

[FDS-1688]: https://sagebionetworks.jira.com/browse/FDS-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ