### PR TITLE
chore(sage-monorepo): fix Sonar workflow job names

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   HEAD_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref_name }}
-  HEAD_REPOSITORY: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.event.repository.name }}
+  HEAD_REPOSITORY: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
 
 jobs:
   sonar:

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -12,8 +12,8 @@ on:
     types: [opened, synchronize, reopened, labeled]
 
 env:
-  HEAD_REF: ${{ github.event.pull_request.head.ref }}
-  HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+  HEAD_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref_name }}
+  HEAD_REPOSITORY: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.event.repository.name }}
 
 jobs:
   sonar:
@@ -42,4 +42,4 @@ jobs:
       - name: Scan the affected projects with Sonar
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx affected --target=sonar"
+            && nx run-many --target=sonar"


### PR DESCRIPTION
## Changelog

- fix the name of a job step when pushing to an upstream branch
- temporarily run Sonar on all projects to initialize scans for upstream branches