### PR TITLE
chore(sage-monorepo): run Sonar only on affected projects again

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Scan the affected projects with Sonar
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-            && nx run-many --target=sonar"
+            && nx affected --target=sonar"


### PR DESCRIPTION
## Changelog

- revert temporary change made to the Sonar scan workflow in #2518