### PR TITLE
docs(sage-monorepo): fix the format of the co-author docs page

### DIFF
--- a/docs/developers-guide/creating-a-commit-with-multiple-authors.md
+++ b/docs/developers-guide/creating-a-commit-with-multiple-authors.md
@@ -2,6 +2,9 @@
 
 ## Introduction
 
+This page highlights key practices in code sharing and attribution within software development
+projects.
+
 You can attribute a commit to more than one author by adding one or more `Co-authored-by` trailers
 to the commit's message. Co-authored commits are visible on GitHub.
 
@@ -10,11 +13,13 @@ to the commit's message. Co-authored commits are visible on GitHub.
 Annotating commits with co-authors is required when:
 
 - You are about to commit previously-untracked code written by other users.
-  - Example:
-    1. User A develops a new feature and submits it as a PR.
-    2. User B is tasked with refactoring the PR from User A into multiple PRs.
-    3. User B copy-paste code written by User A and adapt it.
-    4. User B adds User A as a co-author when the commits include code written by User A.
+
+    > :memo: **Example**
+    >
+    > 1. Bea develops a new feature and submits it as a pull request (PR).
+    > 2. Eddy is tasked with refactoring Bea's PR into multiple PRs.
+    > 3. Eddy copies and pastes code written by Bea and adapts it.
+    > 4. Eddy adds Bea as a co-author to the commits that include code she wrote.
 
 ## Adding co-authors to a commit
 
@@ -34,14 +39,37 @@ Co-authored-by: ANOTHER-NAME <ANOTHER-EMAIL>"
 
 The name and "no-reply" emails of the Sage Monorepo contributors (sorted alphabetically):
 
-- Co-authored-by: andrewelamb <7220713+andrewelamb@users.noreply.github.com>
-- Co-authored-by: gaiaandreoletti <46945609+gaiaandreoletti@users.noreply.github.com>
-- Co-authored-by: Lingling <55448354+linglp@users.noreply.github.com>
-- Co-authored-by: mdsage1 <122999770+mdsage1@users.noreply.github.com>
-- Co-authored-by: Rongrong Chai <73901500+rrchai@users.noreply.github.com>
-- Co-authored-by: sagely1 <114952739+sagely1@users.noreply.github.com>
-- Co-authored-by: Thomas Schaffter <3056480+tschaffter@users.noreply.github.com>
-- Co-authored-by: Verena Chung <9377970+vpchung@users.noreply.github.com>
+```
+Co-authored-by: andrewelamb <7220713+andrewelamb@users.noreply.github.com>
+```
+
+```
+Co-authored-by: gaiaandreoletti <46945609+gaiaandreoletti@users.noreply.github.com>
+```
+
+```
+Co-authored-by: Lingling <55448354+linglp@users.noreply.github.com>
+```
+
+```
+Co-authored-by: mdsage1 <122999770+mdsage1@users.noreply.github.com>
+```
+
+```
+Co-authored-by: Rongrong Chai <73901500+rrchai@users.noreply.github.com>
+```
+
+```
+Co-authored-by: sagely1 <114952739+sagely1@users.noreply.github.com>
+```
+
+```
+Co-authored-by: Thomas Schaffter <3056480+tschaffter@users.noreply.github.com>
+```
+
+```
+Co-authored-by: Verena Chung <9377970+vpchung@users.noreply.github.com>
+```
 
 > [!NOTE]
 > The names and user ID are collected from the profile page of the contributors. If a contributor

--- a/docs/developers-guide/creating-a-commit-with-multiple-authors.md
+++ b/docs/developers-guide/creating-a-commit-with-multiple-authors.md
@@ -2,24 +2,23 @@
 
 ## Introduction
 
-This page highlights key practices in code sharing and attribution within software development
-projects.
-
 You can attribute a commit to more than one author by adding one or more `Co-authored-by` trailers
 to the commit's message. Co-authored commits are visible on GitHub.
 
 ## When to add co-authors to a commit?
 
-Annotating commits with co-authors is required when:
+Annotating commits with `Co-authored-by` is generally encouraged when copying code from other
+developers.
 
-- You are about to commit previously-untracked code written by other users.
+Annotating commits with `Co-authored-by` is **required** when you are committing
+previously-untracked code written by other users.
 
-    > :memo: **Example**
-    >
-    > 1. Bea develops a new feature and submits it as a pull request (PR).
-    > 2. Eddy is tasked with refactoring Bea's PR into multiple PRs.
-    > 3. Eddy copies and pastes code written by Bea and adapts it.
-    > 4. Eddy adds Bea as a co-author to the commits that include code she wrote.
+!!! example "Example"
+
+    1. Bea develops a new feature and submits it as a pull request (PR).
+    2. Eddy is tasked with refactoring Bea's PR into multiple PRs.
+    3. Eddy copies and pastes code written by Bea and adapts it.
+    4. Eddy adds Bea as a co-author to the commits that include code she wrote.
 
 ## Adding co-authors to a commit
 
@@ -71,10 +70,11 @@ Co-authored-by: Thomas Schaffter <3056480+tschaffter@users.noreply.github.com>
 Co-authored-by: Verena Chung <9377970+vpchung@users.noreply.github.com>
 ```
 
-> [!NOTE]
-> The names and user ID are collected from the profile page of the contributors. If a contributor
-does not specify their name on the profile page, the listing below uses their GitHub username
-instead of their name. The user ID can be found in the URL of the user's avatar.
+!!! note
+
+    The names, usernames and user IDs of the contributors are collected from their GitHub profile
+    pages. If a contributor does not specify their name on the profile page, the listing uses their
+    username instead of their name. The user ID can be found in the URL of the user's avatar.
 
 ## References
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,18 +73,17 @@ theme:
       info: octicons/info-16
   features:
     - content.code.copy
-    - navigation.tabs
     - navigation.footer
     - navigation.sections
+    - navigation.tabs
     - search.highlight
     - search.share
     - search.suggest
     - toc.follow
 
 plugins:
-  - search
-  - mkdocstrings
   - autorefs
+  - search
   - termynal
 
 markdown_extensions:


### PR DESCRIPTION
Closes #2526

## References

- [Admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/)