### PR TITLE
feat(openchallenges): dump only EDAM annotations

### DIFF
--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -215,6 +215,9 @@ def main(gc):
     categories = get_challenge_categories(wks)
     output_csv(categories, "categories.csv", output_folder=CHALLENGE_FOLDER)
 
+    edam_annotations = get_edam_annotations(wks)
+    output_csv(edam_annotations, "challenge_data_edam.csv", output_folder=CHALLENGE_FOLDER)
+
     organizations = get_organization_data(wks)
     output_csv(organizations, "organizations.csv", output_folder=ORGANIZATION_FOLDER)
 

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -185,13 +185,6 @@ def get_roles(wks, sheet_name="contribution_role"):
     )
 
 
-def get_edam_terms(wks, sheet_name="edam_terms"):
-    """Get list of EDAM terms currently used in the DB."""
-    return pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")[
-        ["id", "edam_id", "name", "subclass_of", "created_at", "updated_at"]
-    ]
-
-
 def get_edam_annotations(wks, sheet_name="challenge_data"):
     """Get data on challenge's EDAM annotations."""
     return (


### PR DESCRIPTION
Complimentary PR to #2521 (more context [here](https://github.com/Sage-Bionetworks/sage-monorepo/pull/2521#discussion_r1499886099))

Now that we are grabbing the EDAM ontology directly from source, there is no longer a need for us to dump a CSV file.

## Changelog
* update CSV dumping script to only dump the EDAM annotations
* remove the unneeded function