### PR TITLE
fix(sage-monorepo): enable `nx affected` to compare HEAD to the official main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v3
+        uses: nrwl/nx-set-shas@v4
 
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,16 +97,13 @@ jobs:
 
       - name: Checkout upstream/main for Nx
         run: |
-          git remote add upstream https://github.com/Sage-Bionetworks/sage-monorepo.git
+          git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream main
+          git branch --track main upstream/main
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
-
-      - name: Create the main branch from upstream/main
-        run: |
-          git branch --track main upstream/main
-
+          
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ env:
   # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   DOCKER_USERNAME: ${{ github.actor }}
   DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+  HEAD_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
 
 jobs:
   push:
@@ -24,8 +26,10 @@ jobs:
     #   NX_BRANCH: main
     steps:
       - uses: actions/checkout@v4
-        name: Checkout [${{ github.ref_name }}]
+        name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
         with:
+          # We need to fetch all branches and commits so that Nx affected has a base to compare
+          # against.
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
@@ -82,14 +86,22 @@ jobs:
           || !startsWith(github.head_ref, 'renovate/')
         )
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ env.HEAD_REF }}
+          repository: ${{ env.HEAD_REPOSITORY }}
+          # We need to fetch all branches and commits so that Nx affected has a base to compare
+          # against.
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
+
+      - name: Checkout the official `main` branch for Nx
+        run: |
+          git remote add upstream https://github.com/Sage-Bionetworks/sage-monorepo.git
+          git branch --track main upstream/main
 
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
           git fetch upstream main
           git branch --track main upstream/main
           git branch -vv
+          
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         )
     steps:
       - uses: actions/checkout@v4
-        name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
+        # name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
         with:
           # ref: ${{ env.HEAD_REF }}
           # repository: ${{ env.HEAD_REPOSITORY }}
@@ -95,16 +95,16 @@ jobs:
           # against.
           fetch-depth: 0
 
-      - name: Checkout upstream/main for Nx
-        run: |
-          #git remote add upstream https://github.com/${{ github.repository }}.git
-          #git fetch upstream main
-          #git branch --track main upstream/main
-          git remote add downstream https://github.com/${{ env.HEAD_REPOSITORY }}.git
-          git fetch downstream ${{ env.HEAD_REF }}
-          git checkout -b ${{ env.HEAD_REF }} --track downstream/${{ env.HEAD_REF }}
-          git remote --v
-          git branch -vv
+      # - name: Checkout upstream/main for Nx
+      #   run: |
+      #     #git remote add upstream https://github.com/${{ github.repository }}.git
+      #     #git fetch upstream main
+      #     #git branch --track main upstream/main
+      #     git remote add downstream https://github.com/${{ env.HEAD_REPOSITORY }}.git
+      #     git fetch downstream ${{ env.HEAD_REF }}
+      #     git checkout -b ${{ env.HEAD_REF }} --track downstream/${{ env.HEAD_REF }}
+      #     git remote --v
+      #     git branch -vv
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         )
     steps:
       - uses: actions/checkout@v4
-        name: Checkout merge commit from origin and ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
+        name: Checkout merge commit
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare
           # against.
@@ -95,8 +95,6 @@ jobs:
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
-        with:
-          main-branch-name: 'main'
           
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,8 @@ jobs:
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream main
           git branch --track main upstream/main
+          git remote --v
           git branch -vv
-
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     # env:
     #   NX_BRANCH: main
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout [${{ github.ref_name }}]
         with:
           fetch-depth: 0
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v3
+        uses: nrwl/nx-set-shas@v4
 
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,12 @@ jobs:
           git fetch upstream main
           git branch --track main upstream/main
           git branch -vv
-          
+
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
+        with:
+          main-branch-name: 'main'
           
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,12 @@ jobs:
 
       - name: Checkout upstream/main for Nx
         run: |
-          git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream main
-          git branch --track main upstream/main
+          #git remote add upstream https://github.com/${{ github.repository }}.git
+          #git fetch upstream main
+          #git branch --track main upstream/main
+          git remote add downstream https://github.com/${{ env.HEAD_REPOSITORY }}.git
+          git fetch downstream ${{ env.HEAD_REF }}
+          git checkout -b ${{ env.HEAD_REF }} --track downstream/${{ env.HEAD_REF }}
           git remote --v
           git branch -vv
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
       - uses: actions/checkout@v4
         name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
         with:
-          ref: ${{ env.HEAD_REF }}
-          repository: ${{ env.HEAD_REPOSITORY }}
+          # ref: ${{ env.HEAD_REF }}
+          # repository: ${{ env.HEAD_REPOSITORY }}
           # We need to fetch all branches and commits so that Nx affected has a base to compare
           # against.
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream main
           git branch --track main upstream/main
+          git branch -vv
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
   HEAD_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
 
+# Fake comment
 jobs:
   push:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,17 @@ jobs:
           # against.
           fetch-depth: 0
 
-      - name: Checkout the official `main` branch for Nx
+      - name: Checkout upstream/main for Nx
         run: |
           git remote add upstream https://github.com/Sage-Bionetworks/sage-monorepo.git
           git fetch upstream main
-          git branch --track main upstream/main
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
+
+      - name: Create the main branch from upstream/main
+        run: |
+          git branch --track main upstream/main
 
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,24 +87,11 @@ jobs:
         )
     steps:
       - uses: actions/checkout@v4
-        # name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
+        name: Checkout merge commit from origin and ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}
         with:
-          # ref: ${{ env.HEAD_REF }}
-          # repository: ${{ env.HEAD_REPOSITORY }}
           # We need to fetch all branches and commits so that Nx affected has a base to compare
           # against.
           fetch-depth: 0
-
-      # - name: Checkout upstream/main for Nx
-      #   run: |
-      #     #git remote add upstream https://github.com/${{ github.repository }}.git
-      #     #git fetch upstream main
-      #     #git branch --track main upstream/main
-      #     git remote add downstream https://github.com/${{ env.HEAD_REPOSITORY }}.git
-      #     git fetch downstream ${{ env.HEAD_REF }}
-      #     git checkout -b ${{ env.HEAD_REF }} --track downstream/${{ env.HEAD_REF }}
-      #     git remote --v
-      #     git branch -vv
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Checkout the official `main` branch for Nx
         run: |
           git remote add upstream https://github.com/Sage-Bionetworks/sage-monorepo.git
+          git fetch upstream main
           git branch --track main upstream/main
 
       - name: Set up the dev container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
   HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
   HEAD_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
 
-# Fake comment
 jobs:
   push:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
@@ -96,14 +95,14 @@ jobs:
           # against.
           fetch-depth: 0
 
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
-
       - name: Checkout the official `main` branch for Nx
         run: |
           git remote add upstream https://github.com/Sage-Bionetworks/sage-monorepo.git
           git fetch upstream main
           git branch --track main upstream/main
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v4
 
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container


### PR DESCRIPTION
Close #2537

## Changelog

- fix how the merge commit is checked out for a PR
- update to `actions/checkout@v4`
- update to `nrwl/nx-set-shas@v4`

## Preview

In the context of a pull request created from a fork, the CI workflow was checking out the source repository (fork) and branch that triggered the PR with the action `actions/checkout@v4` (now updated to v4). Instead, we should rely on the default behavior of this action to checkout a merge commit created from 1) the last commit pushed to the base branch (the official, upstream `main` branch) and 2) the last commit pushed to the source branch used to create this PR.

Example: This workflow run reports the SHA of the merged commit, `f9bc2a178306146a2278c4a171e5361b10a802f5`:

```
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +f9bc2a178306146a2278c4a171e5361b10a802f5:refs/remotes/pull/2538/merge
  From https://github.com/Sage-Bionetworks/sage-monorepo
   * [new branch]        gh-pages   -> origin/gh-pages
   * [new branch]        main       -> origin/main
   * [new ref]           f9bc2a178306146a2278c4a171e5361b10a802f5 -> pull/2538/merge
Determining the checkout info
Checking out the ref
/usr/bin/git log -1 --format='%H'
'f9bc2a178306146a2278c4a171e5361b10a802f5'
```

We can then head to https://github.com/Sage-Bionetworks/sage-monorepo/commit/f9bc2a178306146a2278c4a171e5361b10a802f5 to see the two parent commits that were used to create this merge commit.

![image](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/09e2ecc5-180d-42b0-a6eb-36460f9ee64e)

where:

- e4427dffc99b8394098e601754401e4710a9fa00 is the SHA of the last commit pushed to the base branch
- 298dc1ffc8dd22bf3b527499e419dd5499d96ee9 is the SHA of the last commit pushed the source branch
```

The action `nrwl/nx-set-shas@v4` now properly derives the Base and Head SHA. Note that this action does not necessarily set the Base SHA to point to the last commit of the base branch. Instead, the Base SHA should by default point to the last "successful" commit pushed. This behavior can be customized using the inputs of the the action `nrwl/nx-set-shas@v4`.