### PR TITLE
chore(openchallenges): update CSV dumping script

### DIFF
--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -53,6 +53,7 @@ def get_challenge_data(wks, sheet_name="challenges"):
             "doi",
             "start_date",
             "end_date",
+            "operation_id",
             "created_at",
             "updated_at",
         ]
@@ -74,6 +75,7 @@ def get_challenge_data(wks, sheet_name="challenges"):
     )
     challenges.loc[challenges.start_date == "", "start_date"] = "\\N"
     challenges.loc[challenges.end_date == "", "end_date"] = "\\N"
+    challenges.loc[challenges.operation_id == "", "operation_id"] = "\\N"
 
     incentives = pd.concat(
         [

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -215,6 +215,9 @@ def main(gc):
     categories = get_challenge_categories(wks)
     output_csv(categories, "categories.csv", output_folder=CHALLENGE_FOLDER)
 
+    edam_annotations = get_edam_annotations(wks)
+    output_csv(edam_annotations, "challenge_data_edam.csv", output_folder=CHALLENGE_FOLDER)
+
     organizations = get_organization_data(wks)
     output_csv(organizations, "organizations.csv", output_folder=ORGANIZATION_FOLDER)
 

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -62,6 +62,9 @@ def get_challenge_data(wks, sheet_name="challenges"):
         challenges.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
         .replace(r"\n", " ", regex=True)
         .replace("'", "''")
+        .replace(u"\u2019", "''")  # replace curly right-quote 
+        .replace(u"\u202f", " ")  # replace narrow no-break space
+        .replace(u"\u2020", "")  # remove word joiner
     )
     challenges["headline"] = (
         challenges["headline"]
@@ -169,6 +172,9 @@ def get_organization_data(wks, sheet_name="organizations"):
         organizations.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
         .replace(r"\n", " ", regex=True)
         .replace("'", "''")
+        .replace(u"\u2019", "''")  # replace curly right-quote 
+        .replace(u"\u202f", " ")  # replace narrow no-break space
+        .replace(u"\u2020", "")  # remove word joiner
     )
     organizations["description"] = (
         organizations["description"]

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -185,13 +185,6 @@ def get_roles(wks, sheet_name="contribution_role"):
     )
 
 
-def get_edam_terms(wks, sheet_name="edam_terms"):
-    """Get list of EDAM terms currently used in the DB."""
-    return pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")[
-        ["id", "edam_id", "name", "subclass_of", "created_at", "updated_at"]
-    ]
-
-
 def get_edam_annotations(wks, sheet_name="challenge_data"):
     """Get data on challenge's EDAM annotations."""
     return (


### PR DESCRIPTION
Complimentary PR to #2521 (more context [here](https://github.com/Sage-Bionetworks/sage-monorepo/pull/2521#discussion_r1499886099)) and #2534

Now that we are grabbing the EDAM ontology directly from source, there is no longer a need for us to dump a CSV file for EDAM terms.

## Changelog
* update CSV dumping script to not dump the CSV file for EDAM terms
* remove the unneeded function
* update CSV dumping script to handle select invisible unicode characters (more context [here](https://github.com/Sage-Bionetworks/sage-monorepo/pull/2534#issue-2154814288))
* include `operation_id` in the CSV dump, using NULL as the default value