### PR TITLE
fix(openchallenges): dumping script quick fixes

### DIFF
--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -62,9 +62,9 @@ def get_challenge_data(wks, sheet_name="challenges"):
         challenges.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
         .replace(r"\n", " ", regex=True)
         .replace("'", "''")
-        .replace(u"\u2019", "''")  # replace curly right-quote 
-        .replace(u"\u202f", " ")  # replace narrow no-break space
-        .replace(u"\u2060", "")  # remove word joiner
+        .replace(u"\u2019", "''", regex=True)  # replace curly right-quote 
+        .replace(u"\u202f", " ", regex=True)  # replace narrow no-break space
+        .replace(u"\u2060", "", regex=True)  # remove word joiner
     )
     challenges["headline"] = (
         challenges["headline"]
@@ -172,9 +172,9 @@ def get_organization_data(wks, sheet_name="organizations"):
         organizations.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
         .replace(r"\n", " ", regex=True)
         .replace("'", "''")
-        .replace(u"\u2019", "''")  # replace curly right-quote 
-        .replace(u"\u202f", " ")  # replace narrow no-break space
-        .replace(u"\u2060", "")  # remove word joiner
+        .replace(u"\u2019", "''", regex=True)  # replace curly right-quote 
+        .replace(u"\u202f", " ", regex=True)  # replace narrow no-break space
+        .replace(u"\u2060", "", regex=True)  # remove word joiner
     )
     organizations["description"] = (
         organizations["description"]

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -64,7 +64,7 @@ def get_challenge_data(wks, sheet_name="challenges"):
         .replace("'", "''")
         .replace(u"\u2019", "''")  # replace curly right-quote 
         .replace(u"\u202f", " ")  # replace narrow no-break space
-        .replace(u"\u2020", "")  # remove word joiner
+        .replace(u"\u2060", "")  # remove word joiner
     )
     challenges["headline"] = (
         challenges["headline"]
@@ -174,7 +174,7 @@ def get_organization_data(wks, sheet_name="organizations"):
         .replace("'", "''")
         .replace(u"\u2019", "''")  # replace curly right-quote 
         .replace(u"\u202f", " ")  # replace narrow no-break space
-        .replace(u"\u2020", "")  # remove word joiner
+        .replace(u"\u2060", "")  # remove word joiner
     )
     organizations["description"] = (
         organizations["description"]


### PR DESCRIPTION
## Changelog
* typo fix for the word joiner unicode character (`\u2060`, _not_ `\u2020`)
* specify that regex is used for unicode replacement

I have verified that these changes will update the CSVs as expected:

```python
>>> challenges = df[["id", ..., "updated_at"]]
>>> challenges.loc[460, "description"]
'The Food and Drug Administration (FDA) -\u202fCenter for Devices and Radiological Health (CDRH), Sage Bionetworks, and\u202fprecisionFDA call on ...'
>>> 
>>> challenges = (
...         challenges.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
...         .replace(r"\n", " ", regex=True)
...         .replace("'", "''", regex=True)
...         .replace(u"\u2019", "''", regex=True)  # replace curly right-quote 
...         .replace(u"\u202f", " ", regex=True)  # replace narrow no-break space
...         .replace(u"\u2060", "", regex=True)  # remove word joiner
...     )
>>> challenges.loc[460, "description"]
'The Food and Drug Administration (FDA) - Center for Devices and Radiological Health (CDRH), Sage Bionetworks, and precisionFDA call on ....'
```