### PR TITLE
fix(sage-monorepo): fix buildx error when running on a detached HEAD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Switch from the detached HEAD of the merge commit to a new branch
-          # Buildx does not work on a detached HEAD, so we checkout HEAD
+          # Buildx does not work on a detached HEAD
         run: git switch -c new-branch
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,13 @@ jobs:
           # against.
           fetch-depth: 0
 
+      - name: Switch from the detached HEAD of the merge commit to a new branch
+          # Buildx does not work on a detached HEAD, so we checkout HEAD
+        run: git switch -c new-branch
+
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4
-          
+
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container
 


### PR DESCRIPTION
Fixes #2542

## Changelog

- switch from the detached HEAD of the merge commit to a new branch in the CI workflow triggered by a PR