### PR TITLE
feat(openchallenges): enable users to search challenges using EDAM operation ID and preferred label

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
@@ -133,8 +133,8 @@ public class ChallengeEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "operation_id", nullable = true)
-  //   @IndexedEmbedded(includePaths = {"classId", "preferredLabel"})
-  //   @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
+  @IndexedEmbedded(includePaths = {"class_id", "preferred_label"})
+  @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
   private EdamOperationEntity operation;
 
   @Column(name = "created_at")

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
@@ -133,6 +133,8 @@ public class ChallengeEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "operation_id", nullable = true)
+  //   @IndexedEmbedded(includePaths = {"classId", "preferredLabel"})
+  //   @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
   private EdamOperationEntity operation;
 
   @Column(name = "created_at")

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
@@ -10,7 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 @Entity
@@ -28,10 +28,10 @@ public class EdamOperationEntity {
   private Long id;
 
   @Column(name = "class_id", nullable = false)
-  @FullTextField(name = "class_id")
+  @GenericField(name = "class_id")
   private String classId;
 
   @Column(name = "preferred_label", nullable = false)
-  @FullTextField(name = "preferred_label")
+  @GenericField(name = "preferred_label")
   private String preferredLabel;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
@@ -10,7 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 @Entity
@@ -28,10 +28,10 @@ public class EdamOperationEntity {
   private Long id;
 
   @Column(name = "class_id", nullable = false)
-  @GenericField(name = "class_id")
+  @FullTextField(name = "class_id")
   private String classId;
 
   @Column(name = "preferred_label", nullable = false)
-  @GenericField(name = "preferred_label")
+  @FullTextField(name = "preferred_label")
   private String preferredLabel;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
@@ -28,10 +28,10 @@ public class EdamOperationEntity {
   private Long id;
 
   @Column(name = "class_id", nullable = false)
-  @FullTextField()
+  @FullTextField(name = "class_id")
   private String classId;
 
   @Column(name = "preferred_label", nullable = false)
-  @FullTextField()
+  @FullTextField(name = "preferred_label")
   private String preferredLabel;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/EdamOperationEntity.java
@@ -10,6 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 @Entity
 @Table(name = "edam_concept")
@@ -17,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Indexed(index = "openchallenges-edam-concept")
 public class EdamOperationEntity {
 
   @Id
@@ -25,8 +28,10 @@ public class EdamOperationEntity {
   private Long id;
 
   @Column(name = "class_id", nullable = false)
+  @FullTextField()
   private String classId;
 
   @Column(name = "preferred_label", nullable = false)
+  @FullTextField()
   private String preferredLabel;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeService.java
@@ -31,7 +31,13 @@ public class ChallengeService {
   private ChallengeMapper challengeMapper = new ChallengeMapper();
 
   private static final List<String> SEARCHABLE_FIELDS =
-      Arrays.asList("name", "headline", "description", "input_data_types.name");
+      Arrays.asList(
+          "name",
+          "headline",
+          "description",
+          "input_data_types.name",
+          "operation.class_id",
+          "operation.preferred_label");
 
   @Transactional(readOnly = true)
   public ChallengesPageDto listChallenges(ChallengeSearchQueryDto query) {


### PR DESCRIPTION
Closes #2550

## Changelog

- enable the user to search challenges by EDAM ID and preferred name

## Preview

### Search by EDAM concept ID

`http://localhost:8000/challenge?searchTerms=http://edamontology.org/operation_3207`

![Screen Shot 2024-03-07 at 11 32 05](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/8d022616-09c8-4487-8c5f-26e9dfae497e)

### Search by EDAM concept ID - ES tokenizes on slash by default 🙏

I knew ES was tokenizing on blank space by default but not that it also tokenizes on slash. I wanted to allow users to search with only the last part of the class ID (e.g. "operation_3207") so it's nice that this feature is already implemented.

`http://localhost:8000/challenge?searchTerms=operation_3207`

![Screen Shot 2024-03-07 at 11 23 24](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/d4b4e278-2241-4cfe-914c-ca83b5f55dcd)

BTW, this is how we can visualize how ES tokenize the property `operation.class_id`:

```
http://localhost:9200/openchallenges-challenge-000001/_termvectors/4?fields=operation.class_id

{
  "_index": "openchallenges-challenge-000001",
  "_type": "_doc",
  "_id": "4",
  "_version": 1,
  "found": true,
  "took": 1,
  "term_vectors": {
    "operation.class_id": {
      "field_statistics": {
        "sum_doc_freq": 12,
        "doc_count": 4,
        "sum_ttf": 12
      },
      "terms": {
        "edamontology.org": {
          "term_freq": 1,
          "tokens": [
            {
              "position": 1,
              "start_offset": 7,
              "end_offset": 23
            }
          ]
        },
        "http": {
          "term_freq": 1,
          "tokens": [
            {
              "position": 0,
              "start_offset": 0,
              "end_offset": 4
            }
          ]
        },
        "operation_3207": {
          "term_freq": 1,
          "tokens": [
            {
              "position": 2,
              "start_offset": 24,
              "end_offset": 38
            }
          ]
        }
      }
    }
  }
}
```

### Search by EDAM concept preferred name

`http://localhost:8000/challenge?searchTerms=Gene%20methylation%20analysis`

![Screen Shot 2024-03-07 at 11 10 14](https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/745df47e-efd5-4127-83b8-466a44eb9336)


### An example of challenge with a non-null operation value

```
http://localhost:9200/openchallenges-challenge-000001/_search?q=(name:%22Drug%20Sensitivity%20and%20Drug%20Synergy%20Prediction%22)

{
  "took": 33,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 20.742569,
    "hits": [
      {
        "_index": "openchallenges-challenge-000001",
        "_type": "_doc",
        "_id": "4",
        "_score": 20.742569,
        "_source": {
          "contributions": [
            {
              "organization_id": 1,
              "role": "sponsor"
            },
            {
              "organization_id": 52,
              "role": "data_contributor"
            },
            {
              "organization_id": 131,
              "role": "sponsor"
            },
            {
              "organization_id": 150,
              "role": "data_contributor"
            }
          ],
          "created_at": "2023-11-01T22:08:36.000000000Z",
          "description": "Development of new cancer therapeutics currently requires a long and protracted process of experimentation and testing. Human cancer cell lines represent a good model to help identify associations between molecular subtypes, pathways, and drug response. In recent years there have been several efforts to generate genomic profiles of collections of cell lines and to determine their response to panels of candidate therapeutic compounds. These data provide the basis for the development of in silico models of sensitivity based either on the unperturbed genetic potential of a cancer cell, or by using perturbation data to incorporate knowledge of actual cell response. Making predictions from either of these data profiles will be beneficial in identifying single and combinatorial chemotherapeutic response in patients. To that end, the present challenge seeks computational methods, derived from the molecular profiling of cell lines both in a static state and in response to perturbation of ...",
          "doi": "",
          "end_date": "2012-10-01",
          "headline": "Predicting drug sensitivity in human cell lines",
          "input_data_types": {
            "name": "metabolomic",
            "slug": "metabolomic"
          },
          "name": "Drug Sensitivity and Drug Synergy Prediction",
          "operation": {
            "class_id": "http://edamontology.org/operation_3207",
            "preferred_label": "Gene methylation analysis"
          },
          "platform": {
            "name": "Synapse",
            "slug": "synapse"
          },
          "starred_count": 0,
          "start_date": "2012-06-01",
          "status": "completed",
          "submission_types": {
            "name": "prediction_file"
          },
          "_entity_type": "ChallengeEntity"
        }
      }
    ]
  }
}
```

### Indexed EDAM concept in ES

```
http://localhost:9200/openchallenges-edam-concept-000001/_search?q=*:*&size=2

{
  "took": 2,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 3472,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "openchallenges-edam-concept-000001",
        "_type": "_doc",
        "_id": "51",
        "_score": 1,
        "_source": {
          "class_id": "http://edamontology.org/data_0885",
          "preferred_label": "Structure database search results",
          "_entity_type": "EdamOperationEntity"
        }
      },
      {
        "_index": "openchallenges-edam-concept-000001",
        "_type": "_doc",
        "_id": "60",
        "_score": 1,
        "_source": {
          "class_id": "http://edamontology.org/data_0894",
          "preferred_label": "Amino acid annotation",
          "_entity_type": "EdamOperationEntity"
        }
      }
    ]
  }
}
```