### PR TITLE
feat(openchallenges): add the task `sonar` to the project `openchallenges-edam-etl`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,13 @@
 /apps/openchallenges/ @rrchai @tschaffter @vpchung
 /libs/openchallenges/ @rrchai @tschaffter @vpchung
 
-# OC DB content
+# OpenChallenges
+## DB content
 /apps/openchallenges/challenge-service/src/main/resources/db/     @tschaffter @vpchung @gaiaandreoletti
 /apps/openchallenges/organization-service/src/main/resources/db/  @tschaffter @vpchung @gaiaandreoletti
+
+## EDAM ETL
+/apps/openchallenges/edam-etl/  @mdsage1
 
 # Schematic
 /apps/schematic/ @andrewelamb @GiaJordan @linglp @mialy-defelice @milen-sage

--- a/apps/openchallenges/edam-etl/project.json
+++ b/apps/openchallenges/edam-etl/project.json
@@ -73,6 +73,13 @@
         "command": "trivy image ghcr.io/sage-bionetworks/{projectName}:local --quiet",
         "color": true
       }
+    },
+    "sonar": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "bash $WORKSPACE_DIR/tools/sonar-scanner.sh --project-key {projectName} --project-dir .",
+        "cwd": "{projectRoot}"
+      }
     }
   },
   "tags": [

--- a/apps/openchallenges/edam-etl/project.json
+++ b/apps/openchallenges/edam-etl/project.json
@@ -85,7 +85,8 @@
   "tags": [
     "type:app",
     "scope:backend",
-    "language:python"
+    "language:python",
+    "package-manager:poetry"
   ],
   "implicitDependencies": []
 }


### PR DESCRIPTION
Closes #2565

## Changelog

- add the task `sonar` to the project `openchallenges-edam-etl`
- add @mdsage1 as a Code Owner of the project `openchallenges-edam-etl`
- document how to create a new project on SonarCloud.io (see ticket)

> [!NOTE]  
> This PR triggered the scans of projects that are not touched by this PR. This is because the GitHub workflow `sonar-scan.yml` uses an incorrect method to checkout the codebase. The correct method is currently implemented in `ci.yml`. This will be fixed in an incoming PR.