### PR TITLE
feat(schematic): add generate excel manifest endpoint

### DIFF
--- a/apps/schematic/api/.gitignore
+++ b/apps/schematic/api/.gitignore
@@ -71,6 +71,8 @@ target/
 *secrets*
 synapse_config.yaml
 schematic_service_account_creds.json
+private_localhost_certificate.crt
+private_localhost.key
 
 #schematic downloaded files
 manifests

--- a/apps/schematic/api/schematic_api/controllers/manifest_generation_controller.py
+++ b/apps/schematic/api/schematic_api/controllers/manifest_generation_controller.py
@@ -10,6 +10,51 @@ from schematic_api import util
 from schematic_api.controllers import manifest_generation_controller_impl
 
 
+def generate_excel_manifest(
+    schema_url,
+    dataset_id,
+    add_annotations=None,
+    manifest_title=None,
+    data_type=None,
+    display_label_type=None,
+    use_strict_validation=None,
+    asset_view_id=None,
+):  # noqa: E501
+    """Generates an excel file
+
+    Generates an excel file # noqa: E501
+
+    :param schema_url: The URL of a schema in jsonld or csv form
+    :type schema_url: str
+    :param dataset_id: The ID of a dataset.
+    :type dataset_id: str
+    :param add_annotations: If true, annotations are added to the manifest
+    :type add_annotations: bool
+    :param manifest_title: If making one manifest, the title of the manifest. If making multiple manifests, the prefix of the title of the manifests.
+    :type manifest_title: str
+    :param data_type: A data type
+    :type data_type: str
+    :param display_label_type: The type of label to display
+    :type display_label_type: str
+    :param use_strict_validation: If true, users are blocked from entering incorrect values. If false, users will get a warning when using incorrect values.
+    :type use_strict_validation: bool
+    :param asset_view_id: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project
+    :type asset_view_id: str
+
+    :rtype: Union[file, Tuple[file, int], Tuple[file, int, Dict[str, str]]
+    """
+    return manifest_generation_controller_impl.generate_excel_manifest(
+        schema_url,
+        dataset_id,
+        add_annotations,
+        manifest_title,
+        data_type,
+        display_label_type,
+        use_strict_validation,
+        asset_view_id,
+    )
+
+
 def generate_google_sheet_manifests(
     schema_url,
     add_annotations=None,
@@ -17,8 +62,8 @@ def generate_google_sheet_manifests(
     manifest_title=None,
     data_type_array=None,
     display_label_type=None,
-    asset_view_id=None,
     use_strict_validation=None,
+    asset_view_id=None,
     generate_all_manifests=None,
 ):  # noqa: E501
     """Generates a list of google sheet links
@@ -37,10 +82,10 @@ def generate_google_sheet_manifests(
     :type data_type_array: List[str]
     :param display_label_type: The type of label to display
     :type display_label_type: str
-    :param asset_view_id: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project
-    :type asset_view_id: str
     :param use_strict_validation: If true, users are blocked from entering incorrect values. If false, users will get a warning when using incorrect values.
     :type use_strict_validation: bool
+    :param asset_view_id: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project
+    :type asset_view_id: str
     :param generate_all_manifests: If true, a manifest for all components will be generated, datasetIds will be ignored. If false, manifests for each id in datasetIds will be generated.
     :type generate_all_manifests: bool
 
@@ -53,7 +98,7 @@ def generate_google_sheet_manifests(
         manifest_title,
         data_type_array,
         display_label_type,
-        asset_view_id,
         use_strict_validation,
+        asset_view_id,
         generate_all_manifests,
     )

--- a/apps/schematic/api/schematic_api/controllers/manifest_generation_controller_impl.py
+++ b/apps/schematic/api/schematic_api/controllers/manifest_generation_controller_impl.py
@@ -11,7 +11,6 @@ from schematic_api.controllers.utils import (
     handle_exceptions,
     get_access_token,
     download_schema_file_as_jsonld,
-    InvalidValueError,
 )
 
 
@@ -73,10 +72,10 @@ def generate_google_sheet_manifests(
     dataset_id_array: list[str] | None,
     manifest_title: str | None,
     data_type_array: list[str] | None,
-    display_label_type: DisplayLabelType = "class_label",
-    use_strict_validation: bool = True,
-    asset_view_id: str | None = None,
-    generate_all_manifests: bool = False,
+    display_label_type: DisplayLabelType,
+    use_strict_validation: bool,
+    asset_view_id: str | None,
+    generate_all_manifests: bool,
 ) -> tuple[GoogleSheetLinks | BasicError, int]:
     """Generates a list of links to manifests in google sheet form
 
@@ -94,13 +93,6 @@ def generate_google_sheet_manifests(
           The type of label to use as display
           Defaults to "class_label"
 
-    Raises:
-        ValueError: When generate_all_manifests is true and either dataset_id_array or
-          data_type_array are provided
-        ValueError: When generate_all_manifests is false and data_type_array is not provided
-        ValueError: When generate_all_manifests is false and dataset_id_array is provided,
-          but it doesn't match the length of data_type_array
-
     Returns:
         tuple[GoogleSheetLinks | BasicError, int]: A tuple
            The first item is either the google sheet links of the manifests or an error object
@@ -108,43 +100,15 @@ def generate_google_sheet_manifests(
     """
 
     if generate_all_manifests:
-        if dataset_id_array:
-            raise InvalidValueError(
-                "When generate_all_manifests is True dataset_id_array must be None",
-                {"dataset_id_array": dataset_id_array},
-            )
-        if data_type_array:
-            raise InvalidValueError(
-                "When generate_all_manifests is True data_type_array must be None",
-                {"data_type_array": data_type_array},
-            )
         data_type_array = ["all manifests"]
-
-    else:
-        if not data_type_array:
-            raise InvalidValueError(
-                (
-                    "When generate_all_manifests is False data_type_array must be a list with "
-                    "at least one item"
-                ),
-                {"data_type_array": data_type_array},
-            )
-        if dataset_id_array and len(dataset_id_array) != len(data_type_array):
-            raise InvalidValueError(
-                (
-                    "When generate_all_manifests is False data_type_array and dataset_id_array "
-                    "must both lists with the same length"
-                ),
-                {
-                    "data_type_array": data_type_array,
-                    "dataset_id_array": dataset_id_array,
-                },
-            )
+    if not data_type_array:
+        data_type_array = []
 
     access_token = get_access_token()
     if asset_view_id:
         CONFIG.synapse_master_fileview_id = asset_view_id
     schema_path = download_schema_file_as_jsonld(schema_url)
+
     links = ManifestGenerator.create_manifests(
         path_to_data_model=schema_path,
         output_format="google_sheet",

--- a/apps/schematic/api/schematic_api/controllers/manifest_generation_controller_impl.py
+++ b/apps/schematic/api/schematic_api/controllers/manifest_generation_controller_impl.py
@@ -16,6 +16,57 @@ from schematic_api.controllers.utils import (
 
 
 @handle_exceptions
+def generate_excel_manifest(
+    schema_url: str,
+    dataset_id: str | None,
+    add_annotations: bool,
+    manifest_title: str,
+    data_type: str | None,
+    display_label_type: DisplayLabelType,
+    use_strict_validation: bool,
+    asset_view_id: str | None,
+) -> tuple[str | BasicError, int]:
+    """Generates a manifest in excel form
+
+    Args:
+        schema_url (str): The URL of the schema
+        dataset_id (str | None): Use this to get the existing manifest in the dataset.
+          Must be of same type as the data_type
+        add_annotations (bool): Whether or not annotatiosn get added to the manifest
+        manifest_title (str): Title of the manifest
+        data_type (str | None): The datatype of the manifest to generate
+        display_label_type (DisplayLabelType): The type of label to use as display
+        use_strict_validation (bool): Whether or not to use google sheet strict validation
+        asset_view_id (str): ID of the asset view
+
+    Returns:
+        tuple[str | BasicError], int]: A tuple
+           The first item is a path to an manifest in Excel form or an error object
+           The second item is the response status
+    """
+    access_token = get_access_token()
+    if asset_view_id:
+        CONFIG.synapse_master_fileview_id = asset_view_id
+    schema_path = download_schema_file_as_jsonld(schema_url)
+    manifest_path_list = ManifestGenerator.create_manifests(
+        path_to_data_model=schema_path,
+        output_format="excel",
+        data_types=[data_type],
+        title=manifest_title,
+        access_token=access_token,
+        dataset_ids=[dataset_id],
+        strict=use_strict_validation,
+        use_annotations=add_annotations,
+        data_model_labels=display_label_type,
+    )
+    manifest = manifest_path_list[0]
+    assert isinstance(manifest, str)
+    result: str | BasicError = manifest
+    status = 200
+    return result, status
+
+
+@handle_exceptions
 def generate_google_sheet_manifests(
     schema_url: str,
     add_annotations: bool,
@@ -23,8 +74,8 @@ def generate_google_sheet_manifests(
     manifest_title: str | None,
     data_type_array: list[str] | None,
     display_label_type: DisplayLabelType = "class_label",
-    asset_view_id: str | None = None,
     use_strict_validation: bool = True,
+    asset_view_id: str | None = None,
     generate_all_manifests: bool = False,
 ) -> tuple[GoogleSheetLinks | BasicError, int]:
     """Generates a list of links to manifests in google sheet form

--- a/apps/schematic/api/schematic_api/openapi/openapi.yaml
+++ b/apps/schematic/api/schematic_api/openapi/openapi.yaml
@@ -1325,6 +1325,106 @@ paths:
       tags:
       - Schema
       x-openapi-router-controller: schematic_api.controllers.schema_controller
+  /generateExcelManifest:
+    get:
+      description: Generates an excel file
+      operationId: generate_excel_manifest
+      parameters:
+      - description: The URL of a schema in jsonld or csv form
+        explode: true
+        in: query
+        name: schemaUrl
+        required: true
+        schema:
+          $ref: '#/components/schemas/SchemaUrl'
+        style: form
+      - description: "If true, annotations are added to the manifest"
+        explode: true
+        in: query
+        name: addAnnotations
+        required: false
+        schema:
+          default: false
+          type: boolean
+        style: form
+      - description: The ID of a dataset.
+        explode: true
+        in: query
+        name: datasetId
+        required: true
+        schema:
+          $ref: '#/components/schemas/DatasetId'
+        style: form
+      - description: "If making one manifest, the title of the manifest. If making\
+          \ multiple manifests, the prefix of the title of the manifests."
+        explode: true
+        in: query
+        name: manifestTitle
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: A data type
+        explode: true
+        in: query
+        name: dataType
+        required: false
+        schema:
+          $ref: '#/components/schemas/DataType'
+        style: form
+      - description: The type of label to display
+        explode: true
+        in: query
+        name: displayLabelType
+        required: false
+        schema:
+          default: class_label
+          enum:
+          - class_label
+          - display_label
+          type: string
+        style: form
+      - description: "If true, users are blocked from entering incorrect values. If\
+          \ false, users will get a warning when using incorrect values."
+        explode: true
+        in: query
+        name: useStrictValidation
+        required: false
+        schema:
+          default: true
+          type: boolean
+        style: form
+      - description: ID of view listing all project data assets. E.g. for Synapse
+          this would be the Synapse ID of the fileview listing all data assets for
+          a given project
+        explode: true
+        in: query
+        name: assetViewId
+        required: false
+        schema:
+          $ref: '#/components/schemas/AssetViewId'
+        style: form
+      responses:
+        "200":
+          content:
+            application/vnd.ms-excel:
+              schema:
+                format: binary
+                type: string
+          description: Success
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BasicError'
+          description: The request cannot be fulfilled due to an unexpected server
+            error
+      security:
+      - bearerAuth: []
+      summary: Generates an excel file
+      tags:
+      - ManifestGeneration
+      x-openapi-router-controller: schematic_api.controllers.manifest_generation_controller
   /generateGoogleSheetManifests:
     get:
       description: Generates a list of google sheet links
@@ -1384,16 +1484,6 @@ paths:
           - display_label
           type: string
         style: form
-      - description: ID of view listing all project data assets. E.g. for Synapse
-          this would be the Synapse ID of the fileview listing all data assets for
-          a given project
-        explode: true
-        in: query
-        name: assetViewId
-        required: false
-        schema:
-          $ref: '#/components/schemas/AssetViewId'
-        style: form
       - description: "If true, users are blocked from entering incorrect values. If\
           \ false, users will get a warning when using incorrect values."
         explode: true
@@ -1403,6 +1493,16 @@ paths:
         schema:
           default: true
           type: boolean
+        style: form
+      - description: ID of view listing all project data assets. E.g. for Synapse
+          this would be the Synapse ID of the fileview listing all data assets for
+          a given project
+        explode: true
+        in: query
+        name: assetViewId
+        required: false
+        schema:
+          $ref: '#/components/schemas/AssetViewId'
         style: form
       - description: "If true, a manifest for all components will be generated, datasetIds\
           \ will be ignored. If false, manifests for each id in datasetIds will be\
@@ -2823,6 +2923,26 @@ components:
       schema:
         $ref: '#/components/schemas/DataTypeArray'
       style: form
+    useStrictValidation:
+      description: "If true, users are blocked from entering incorrect values. If\
+        \ false, users will get a warning when using incorrect values."
+      explode: true
+      in: query
+      name: useStrictValidation
+      required: false
+      schema:
+        default: true
+        type: boolean
+      style: form
+    dataType:
+      description: A data type
+      explode: true
+      in: query
+      name: dataType
+      required: false
+      schema:
+        $ref: '#/components/schemas/DataType'
+      style: form
   responses:
     InternalServerError:
       content:
@@ -3397,11 +3517,15 @@ components:
       items:
         $ref: '#/components/schemas/DatasetId'
       type: array
+    DataType:
+      description: A data type
+      example: Patient
+      title: DataType
+      type: string
     DataTypeArray:
       description: An array of data types
       items:
-        example: Patient
-        type: string
+        $ref: '#/components/schemas/DataType'
       type: array
     GoogleSheetLinks:
       description: An array of google sheet links

--- a/apps/schematic/api/schematic_api/test/conftest.py
+++ b/apps/schematic/api/schematic_api/test/conftest.py
@@ -27,9 +27,6 @@ def csv_to_json_str(path: str) -> str:
 GET_ACCESS_TOKEN_MOCK = (
     "schematic_api.controllers.manifest_generation_controller_impl.get_access_token"
 )
-CREATE_SINGLE_MANIFEST_MOCK = (
-    "schematic.manifest.generator.ManifestGenerator.create_single_manifest"
-)
 CREATE_MANIFESTS_MOCK = (
     "schematic.manifest.generator.ManifestGenerator.create_manifests"
 )

--- a/apps/schematic/api/schematic_api/test/test_manifest_generation_controller_impl.py
+++ b/apps/schematic/api/schematic_api/test/test_manifest_generation_controller_impl.py
@@ -7,8 +7,47 @@ from schematic_api.models.basic_error import BasicError
 from schematic_api.models.google_sheet_links import GoogleSheetLinks
 from schematic_api.controllers.manifest_generation_controller_impl import (
     generate_google_sheet_manifests,
+    generate_excel_manifest,
 )
 from .conftest import GET_ACCESS_TOKEN_MOCK, CREATE_MANIFESTS_MOCK
+
+
+class TestGenerateExcelManifest:
+    """Tests generate_excel_manifest"""
+
+    def success(self, test_schema_url: str) -> None:
+        """Test for successful result"""
+        with patch(GET_ACCESS_TOKEN_MOCK):
+            with patch(CREATE_MANIFESTS_MOCK, return_value="path"):  # type: ignore
+                result, status = generate_excel_manifest(
+                    schema_url=test_schema_url,
+                    dataset_id="syn2",
+                    add_annotations=False,
+                    manifest_title="title",
+                    data_type="syn3",
+                    display_label_type="class_label",
+                    use_strict_validation=True,
+                    asset_view_id="syn1",
+                )
+                assert status == 200
+                assert result == "path"
+
+    def error_statuses(self) -> None:
+        """Test for error statuses"""
+        with patch(GET_ACCESS_TOKEN_MOCK):
+            with patch(CREATE_MANIFESTS_MOCK):
+                result, status = generate_excel_manifest(
+                    schema_url="not_a_url",
+                    dataset_id="syn2",
+                    add_annotations=False,
+                    manifest_title="title",
+                    data_type="syn3",
+                    display_label_type="class_label",
+                    use_strict_validation=True,
+                    asset_view_id="syn1",
+                )
+                assert status == 404
+                assert isinstance(result, BasicError)
 
 
 class TestGenerateGoogleSheetManifests:
@@ -27,12 +66,13 @@ class TestGenerateGoogleSheetManifests:
                     manifest_title="title",
                     use_strict_validation=True,
                     generate_all_manifests=False,
+                    display_label_type="class_label",
                 )
                 assert status == 200
                 assert isinstance(result, GoogleSheetLinks)
                 assert result.links == ["link1", "link2"]
 
-    def test_error_statuses(self, test_schema_url: str) -> None:
+    def test_error_statuses(self) -> None:
         """Test for error statuses"""
         with patch(GET_ACCESS_TOKEN_MOCK):
             with patch(CREATE_MANIFESTS_MOCK):
@@ -45,92 +85,7 @@ class TestGenerateGoogleSheetManifests:
                     manifest_title="title",
                     use_strict_validation=True,
                     generate_all_manifests=False,
+                    display_label_type="class_label",
                 )
                 assert status == 404
                 assert isinstance(result, BasicError)
-
-                result, status = generate_google_sheet_manifests(
-                    schema_url=test_schema_url,
-                    dataset_id_array=["syn2", "syn3"],
-                    asset_view_id="syn1",
-                    data_type_array=["syn4", "syn5"],
-                    add_annotations=False,
-                    manifest_title="title",
-                    use_strict_validation=True,
-                    generate_all_manifests=True,
-                )
-                assert status == 422
-                assert isinstance(result, BasicError)
-                assert result.detail == (
-                    "When generate_all_manifests is True dataset_id_array must be None: "
-                    "{'dataset_id_array': ['syn2', 'syn3']}"
-                )
-
-                result, status = generate_google_sheet_manifests(
-                    schema_url=test_schema_url,
-                    dataset_id_array=None,
-                    asset_view_id="syn1",
-                    data_type_array=["syn4", "syn5"],
-                    add_annotations=False,
-                    manifest_title="title",
-                    use_strict_validation=True,
-                    generate_all_manifests=True,
-                )
-                assert status == 422
-                assert isinstance(result, BasicError)
-                assert result.detail == (
-                    "When generate_all_manifests is True data_type_array must be None: "
-                    "{'data_type_array': ['syn4', 'syn5']}"
-                )
-
-                result, status = generate_google_sheet_manifests(
-                    schema_url=test_schema_url,
-                    dataset_id_array=None,
-                    asset_view_id="syn1",
-                    data_type_array=None,
-                    add_annotations=False,
-                    manifest_title="title",
-                    use_strict_validation=True,
-                    generate_all_manifests=False,
-                )
-                assert status == 422
-                assert isinstance(result, BasicError)
-                assert result.detail == (
-                    "When generate_all_manifests is False data_type_array must be a list with "
-                    "at least one item: {'data_type_array': None}"
-                )
-
-                result, status = generate_google_sheet_manifests(
-                    schema_url=test_schema_url,
-                    dataset_id_array=None,
-                    asset_view_id="syn1",
-                    data_type_array=[],
-                    add_annotations=False,
-                    manifest_title="title",
-                    use_strict_validation=True,
-                    generate_all_manifests=False,
-                )
-                assert status == 422
-                assert isinstance(result, BasicError)
-                assert result.detail == (
-                    "When generate_all_manifests is False data_type_array must be a list with "
-                    "at least one item: {'data_type_array': []}"
-                )
-
-                result, status = generate_google_sheet_manifests(
-                    schema_url=test_schema_url,
-                    dataset_id_array=["syn4"],
-                    asset_view_id="syn1",
-                    data_type_array=["syn2", "syn3"],
-                    add_annotations=False,
-                    manifest_title="title",
-                    use_strict_validation=True,
-                    generate_all_manifests=False,
-                )
-                assert status == 422
-                assert isinstance(result, BasicError)
-                assert result.detail == (
-                    "When generate_all_manifests is False data_type_array and dataset_id_array "
-                    "must both lists with the same length: "
-                    "{'data_type_array': ['syn2', 'syn3'], 'dataset_id_array': ['syn4']}"
-                )

--- a/apps/schematic/api/schematic_api/test/test_synapse_endpoints.py
+++ b/apps/schematic/api/schematic_api/test/test_synapse_endpoints.py
@@ -40,6 +40,28 @@ HEADERS = {
 
 @pytest.mark.synapse
 @pytest.mark.secrets
+class TestGenerateExcelManifest(BaseTestCase):
+    """Tests excel manifest endpoint"""
+
+    def test_success(self) -> None:
+        """Test for successful result"""
+        url = (
+            f"/api/v1/generateExcelManifest?schemaUrl={TEST_SCHEMA_URL}"
+            "&assetViewId=syn28559058"
+            "&dataType=Patient"
+            "&datasetId=syn51730545"
+        )
+        response = self.client.open(url, method="GET", headers=HEADERS)
+        self.assert200(response, f"Response body is : {response.data.decode('utf-8')}")
+        result = response.json
+        assert isinstance(result, str)
+        assert result.endswith("Example.Patient.manifest.xlsx")
+        assert os.path.exists(result)
+        os.remove(result)
+
+
+@pytest.mark.synapse
+@pytest.mark.secrets
 class TestGenerateGoogleSheetManifests(BaseTestCase):
     """Tests google sheet manifest endpoint"""
 

--- a/libs/schematic/api-description/build/openapi.yaml
+++ b/libs/schematic/api-description/build/openapi.yaml
@@ -872,19 +872,13 @@ paths:
         - $ref: '#/components/parameters/manifestTitle'
         - $ref: '#/components/parameters/dataTypeArray'
         - $ref: '#/components/parameters/displayLabelType'
+        - $ref: '#/components/parameters/useStrictValidation'
         - name: assetViewId
           in: query
           description: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project
           required: false
           schema:
             $ref: '#/components/schemas/AssetViewId'
-        - name: useStrictValidation
-          in: query
-          description: If true, users are blocked from entering incorrect values. If false, users will get a warning when using incorrect values.
-          required: false
-          schema:
-            type: boolean
-            default: true
         - name: generateAllManifests
           in: query
           description: If true, a manifest for all components will be generated, datasetIds will be ignored. If false, manifests for each id in datasetIds will be generated.
@@ -901,6 +895,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GoogleSheetLinks'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /generateExcelManifest:
+    get:
+      tags:
+        - ManifestGeneration
+      summary: Generates an excel file
+      description: Generates an excel file
+      operationId: generateExcelManifest
+      parameters:
+        - $ref: '#/components/parameters/schemaUrl'
+        - $ref: '#/components/parameters/addAnnotations'
+        - $ref: '#/components/parameters/datasetIdQuery'
+        - $ref: '#/components/parameters/manifestTitle'
+        - $ref: '#/components/parameters/dataType'
+        - $ref: '#/components/parameters/displayLabelType'
+        - $ref: '#/components/parameters/useStrictValidation'
+        - name: assetViewId
+          in: query
+          description: ID of view listing all project data assets. E.g. for Synapse this would be the Synapse ID of the fileview listing all data assets for a given project
+          required: false
+          schema:
+            $ref: '#/components/schemas/AssetViewId'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/vnd.ms-excel:
+              schema:
+                type: string
+                format: binary
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
@@ -1359,12 +1386,15 @@ components:
       description: An array of dataset ids
       items:
         $ref: '#/components/schemas/DatasetId'
+    DataType:
+      description: A data type
+      type: string
+      example: Patient
     DataTypeArray:
       description: An array of data types
       type: array
       items:
-        type: string
-        example: Patient
+        $ref: '#/components/schemas/DataType'
     GoogleSheetLinks:
       type: object
       description: An array of google sheet links
@@ -1681,3 +1711,18 @@ components:
       required: false
       schema:
         $ref: '#/components/schemas/DataTypeArray'
+    useStrictValidation:
+      name: useStrictValidation
+      in: query
+      description: If true, users are blocked from entering incorrect values. If false, users will get a warning when using incorrect values.
+      required: false
+      schema:
+        type: boolean
+        default: true
+    dataType:
+      name: dataType
+      in: query
+      description: A data type
+      required: false
+      schema:
+        $ref: '#/components/schemas/DataType'

--- a/libs/schematic/api-description/src/components/parameters/query/dataType.yaml
+++ b/libs/schematic/api-description/src/components/parameters/query/dataType.yaml
@@ -1,0 +1,6 @@
+name: dataType
+in: query
+description: A data type
+required: false
+schema:
+  $ref: ../../schemas/DataType.yaml

--- a/libs/schematic/api-description/src/components/parameters/query/useStrictValidation.yaml
+++ b/libs/schematic/api-description/src/components/parameters/query/useStrictValidation.yaml
@@ -1,0 +1,8 @@
+name: useStrictValidation
+in: query
+description: If true, users are blocked from entering incorrect values.
+  If false, users will get a warning when using incorrect values.
+required: false
+schema:
+  type: boolean
+  default: true

--- a/libs/schematic/api-description/src/components/schemas/DataType.yaml
+++ b/libs/schematic/api-description/src/components/schemas/DataType.yaml
@@ -1,0 +1,3 @@
+description: A data type
+type: string
+example: Patient

--- a/libs/schematic/api-description/src/components/schemas/DataTypeArray.yaml
+++ b/libs/schematic/api-description/src/components/schemas/DataTypeArray.yaml
@@ -1,5 +1,4 @@
 description: An array of data types
 type: array
 items:
-  type: string
-  example: Patient
+  $ref: DataType.yaml

--- a/libs/schematic/api-description/src/openapi.yaml
+++ b/libs/schematic/api-description/src/openapi.yaml
@@ -118,3 +118,6 @@ paths:
 
   /generateGoogleSheetManifests:
     $ref: paths/generateGoogleSheetManifests.yaml
+
+  /generateExcelManifest:
+    $ref: paths/generateExcelManifest.yaml

--- a/libs/schematic/api-description/src/paths/generateExcelManifest.yaml
+++ b/libs/schematic/api-description/src/paths/generateExcelManifest.yaml
@@ -1,15 +1,15 @@
 get:
   tags:
     - ManifestGeneration
-  summary: Generates a list of google sheet links
-  description: Generates a list of google sheet links
-  operationId: generateGoogleSheetManifests
+  summary: Generates an excel file
+  description: Generates an excel file
+  operationId: generateExcelManifest
   parameters:
     - $ref: ../components/parameters/query/schemaUrl.yaml
     - $ref: ../components/parameters/query/addAnnotations.yaml
-    - $ref: ../components/parameters/query/datasetIdArray.yaml
+    - $ref: ../components/parameters/query/datasetIdQuery.yaml
     - $ref: ../components/parameters/query/manifestTitle.yaml
-    - $ref: ../components/parameters/query/dataTypeArray.yaml
+    - $ref: ../components/parameters/query/dataType.yaml
     - $ref: ../components/parameters/query/displayLabelType.yaml
     - $ref: ../components/parameters/query/useStrictValidation.yaml
     - name: assetViewId
@@ -18,23 +18,15 @@ get:
       required: false
       schema:
         $ref: ../components/schemas/AssetViewId.yaml
-    - name: generateAllManifests
-      in: query
-      description:
-        If true, a manifest for all components will be generated, datasetIds will be ignored.
-        If false, manifests for each id in datasetIds will be generated.
-      required: false
-      schema:
-        type: boolean
-        default: false
   security:
     - bearerAuth: []
   responses:
     '200':
-      description: Success
+      description: 'Success'
       content:
-        application/json:
+        application/vnd.ms-excel:
           schema:
-            $ref: ../components/schemas/GoogleSheetLinks.yaml
+            type: string
+            format: binary
     '500':
       $ref: ../components/responses/InternalServerError.yaml


### PR DESCRIPTION
- fixes [FDS-1605]
- adds generate excel manifest endpoint
- removes input validation from generate google sheets manifest endoint (functionality moved to schematic)
- removed defaults from generate google sheets manifest endoint (to help testing)
- files for runing the API locally added to gitignore file

[FDS-1605]: https://sagebionetworks.jira.com/browse/FDS-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ