### PR TITLE
chore(sage-monorepo): remove `@nxrocks/nx-spring-boot`

### DIFF
--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -60,9 +60,10 @@
       "dependsOn": []
     },
     "build-image-base": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/api-gateway"
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -37,9 +37,10 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/api-gateway"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/api-gateway/project.json
+++ b/apps/openchallenges/api-gateway/project.json
@@ -19,18 +19,22 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/api-gateway"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/api-gateway"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/apps/openchallenges/auth-service/project.json
+++ b/apps/openchallenges/auth-service/project.json
@@ -59,14 +59,14 @@
         "cwd": "apps/openchallenges/auth-service"
       },
       "dependsOn": []
-    },
-    "build-image": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
-      "options": {
-        "root": "apps/openchallenges/auth-service"
-      },
-      "dependsOn": ["^install"]
     }
+    // "build-image": {
+    //   "executor": "@nxrocks/nx-spring-boot:build-image",
+    //   "options": {
+    //     "root": "apps/openchallenges/auth-service"
+    //   },
+    //   "dependsOn": ["^install"]
+    // }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [

--- a/apps/openchallenges/auth-service/project.json
+++ b/apps/openchallenges/auth-service/project.json
@@ -19,18 +19,22 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/auth-service"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/auth-service"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/apps/openchallenges/auth-service/project.json
+++ b/apps/openchallenges/auth-service/project.json
@@ -37,9 +37,10 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/auth-service"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -45,21 +45,24 @@
       "dependsOn": ["test"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -82,9 +82,10 @@
       "dependsOn": []
     },
     "build-image-base": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },

--- a/apps/openchallenges/challenge-service/project.json
+++ b/apps/openchallenges/challenge-service/project.json
@@ -19,17 +19,20 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },
@@ -130,7 +133,7 @@
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-api-description",
-    "openchallenges-app-config-data", 
+    "openchallenges-app-config-data",
     "shared-java-util"
   ]
 }

--- a/apps/openchallenges/challenge-to-elasticsearch-service/project.json
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/project.json
@@ -28,21 +28,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/challenge-to-elasticsearch-service"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/challenge-to-elasticsearch-service"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/challenge-to-elasticsearch-service"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/challenge-to-elasticsearch-service/project.json
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/project.json
@@ -19,11 +19,12 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/challenge-to-elasticsearch-service"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "clean": {

--- a/apps/openchallenges/challenge-to-elasticsearch-service/project.json
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/project.json
@@ -65,13 +65,13 @@
       },
       "dependsOn": []
     },
-    "build-image": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
-      "options": {
-        "root": "apps/openchallenges/challenge-to-elasticsearch-service"
-      },
-      "dependsOn": ["^install"]
-    },
+    // "build-image": {
+    //   "executor": "@nxrocks/nx-spring-boot:build-image",
+    //   "options": {
+    //     "root": "apps/openchallenges/challenge-to-elasticsearch-service"
+    //   },
+    //   "dependsOn": ["^install"]
+    // },
     "generate": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -19,18 +19,22 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/config-server"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/config-server"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -74,9 +74,10 @@
       "dependsOn": []
     },
     "build-image-base": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/config-server"
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },

--- a/apps/openchallenges/config-server/project.json
+++ b/apps/openchallenges/config-server/project.json
@@ -37,21 +37,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/config-server"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/config-server"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/config-server"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/core-service/project.json
+++ b/apps/openchallenges/core-service/project.json
@@ -19,11 +19,12 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/core-service"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "clean": {

--- a/apps/openchallenges/core-service/project.json
+++ b/apps/openchallenges/core-service/project.json
@@ -28,9 +28,10 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/core-service"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/core-service/project.json
+++ b/apps/openchallenges/core-service/project.json
@@ -50,14 +50,14 @@
         "cwd": "apps/openchallenges/core-service"
       },
       "dependsOn": []
-    },
-    "build-image": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
-      "options": {
-        "root": "apps/openchallenges/core-service"
-      },
-      "dependsOn": ["^install"]
     }
+    // "build-image": {
+    //   "executor": "@nxrocks/nx-spring-boot:build-image",
+    //   "options": {
+    //     "root": "apps/openchallenges/core-service"
+    //   },
+    //   "dependsOn": ["^install"]
+    // }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -19,17 +19,20 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/image-service"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/image-service"
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },
@@ -133,7 +136,7 @@
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-api-description",
-    "openchallenges-app-config-data", 
+    "openchallenges-app-config-data",
     "shared-java-util"
   ]
 }

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -45,21 +45,24 @@
       "dependsOn": ["test"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/image-service"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/image-service"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/image-service"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/image-service/project.json
+++ b/apps/openchallenges/image-service/project.json
@@ -85,9 +85,10 @@
       "dependsOn": []
     },
     "build-image-base": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/image-service"
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },

--- a/apps/openchallenges/kaggle-to-kafka-service/project.json
+++ b/apps/openchallenges/kaggle-to-kafka-service/project.json
@@ -19,11 +19,12 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/kaggle-to-kafka-service"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "clean": {

--- a/apps/openchallenges/kaggle-to-kafka-service/project.json
+++ b/apps/openchallenges/kaggle-to-kafka-service/project.json
@@ -28,21 +28,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/kaggle-to-kafka-service"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/kaggle-to-kafka-service"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/kaggle-to-kafka-service"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/kaggle-to-kafka-service/project.json
+++ b/apps/openchallenges/kaggle-to-kafka-service/project.json
@@ -65,13 +65,13 @@
       },
       "dependsOn": []
     },
-    "build-image": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
-      "options": {
-        "root": "apps/openchallenges/kaggle-to-kafka-service"
-      },
-      "dependsOn": ["^install"]
-    },
+    // "build-image": {
+    //   "executor": "@nxrocks/nx-spring-boot:build-image",
+    //   "options": {
+    //     "root": "apps/openchallenges/kaggle-to-kafka-service"
+    //   },
+    //   "dependsOn": ["^install"]
+    // },
     "generate": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -45,21 +45,24 @@
       "dependsOn": ["test"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -85,9 +85,10 @@
       "dependsOn": []
     },
     "build-image-base": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },

--- a/apps/openchallenges/organization-service/project.json
+++ b/apps/openchallenges/organization-service/project.json
@@ -19,17 +19,20 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "{projectRoot}"
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },
@@ -133,7 +136,7 @@
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
   "implicitDependencies": [
     "openchallenges-api-description",
-    "openchallenges-app-config-data", 
+    "openchallenges-app-config-data",
     "shared-java-util"
   ]
 }

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -19,18 +19,22 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/service-registry"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/service-registry"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -60,9 +60,10 @@
       "dependsOn": []
     },
     "build-image-base": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/service-registry"
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
     },

--- a/apps/openchallenges/service-registry/project.json
+++ b/apps/openchallenges/service-registry/project.json
@@ -37,9 +37,10 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/service-registry"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/user-service/project.json
+++ b/apps/openchallenges/user-service/project.json
@@ -28,21 +28,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/user-service"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/user-service"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "apps/openchallenges/user-service"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     },
     "serve": {

--- a/apps/openchallenges/user-service/project.json
+++ b/apps/openchallenges/user-service/project.json
@@ -65,13 +65,13 @@
       },
       "dependsOn": []
     },
-    "build-image": {
-      "executor": "@nxrocks/nx-spring-boot:build-image",
-      "options": {
-        "root": "apps/openchallenges/user-service"
-      },
-      "dependsOn": ["^install"]
-    },
+    // "build-image": {
+    //   "executor": "@nxrocks/nx-spring-boot:build-image",
+    //   "options": {
+    //     "root": "apps/openchallenges/user-service"
+    //   },
+    //   "dependsOn": ["^install"]
+    // },
     "generate": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/openchallenges/user-service/project.json
+++ b/apps/openchallenges/user-service/project.json
@@ -19,11 +19,12 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "apps/openchallenges/user-service"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}"],
       "dependsOn": ["^install"]
     },
     "clean": {

--- a/docker/openchallenges/services/challenge-service.yml
+++ b/docker/openchallenges/services/challenge-service.yml
@@ -23,8 +23,8 @@ services:
     depends_on:
       openchallenges-config-server:
         condition: service_healthy
-      openchallenges-edam-etl:
-        condition: service_completed_successfully
+      # openchallenges-edam-etl:
+      #   condition: service_completed_successfully
       openchallenges-elasticsearch:
         condition: service_healthy
       openchallenges-mariadb:

--- a/libs/openchallenges/app-config-data/project.json
+++ b/libs/openchallenges/app-config-data/project.json
@@ -12,11 +12,13 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/openchallenges/app-config-data"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}/build"]
+      "dependsOn": ["^install"]
     },
     "install": {
       "executor": "nx:run-commands",
@@ -27,10 +29,13 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/openchallenges/app-config-data"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/libs/openchallenges/app-config-data/project.json
+++ b/libs/openchallenges/app-config-data/project.json
@@ -38,21 +38,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/app-config-data"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/app-config-data"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/app-config-data"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     }
   },

--- a/libs/openchallenges/kafka-admin/project.json
+++ b/libs/openchallenges/kafka-admin/project.json
@@ -38,21 +38,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-admin"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-admin"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-admin"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     }
   },

--- a/libs/openchallenges/kafka-admin/project.json
+++ b/libs/openchallenges/kafka-admin/project.json
@@ -12,11 +12,12 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
-      "options": {
-        "root": "libs/openchallenges/kafka-admin"
-      },
+      "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/build"],
+      "options": {
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
+      },
       "dependsOn": ["^install"]
     },
     "install": {
@@ -28,10 +29,13 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/openchallenges/kafka-admin"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/libs/openchallenges/kafka-consumer/project.json
+++ b/libs/openchallenges/kafka-consumer/project.json
@@ -38,21 +38,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-consumer"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-consumer"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-consumer"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     }
   },

--- a/libs/openchallenges/kafka-consumer/project.json
+++ b/libs/openchallenges/kafka-consumer/project.json
@@ -12,11 +12,12 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
-      "options": {
-        "root": "libs/openchallenges/kafka-consumer"
-      },
+      "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/build"],
+      "options": {
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
+      },
       "dependsOn": ["^install"]
     },
     "install": {
@@ -28,10 +29,13 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/openchallenges/kafka-consumer"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/libs/openchallenges/kafka-model/project.json
+++ b/libs/openchallenges/kafka-model/project.json
@@ -12,11 +12,13 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/openchallenges/kafka-model"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}/build"]
+      "dependsOn": ["^install"]
     },
     "avro-generate": {
       "executor": "nx:run-commands",
@@ -39,10 +41,13 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/openchallenges/kafka-model"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/libs/openchallenges/kafka-model/project.json
+++ b/libs/openchallenges/kafka-model/project.json
@@ -50,9 +50,10 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-model"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     }
   },

--- a/libs/openchallenges/kafka-producer/project.json
+++ b/libs/openchallenges/kafka-producer/project.json
@@ -38,21 +38,24 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-producer"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     },
     "format": {
-      "executor": "@nxrocks/nx-spring-boot:format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-producer"
+        "command": "./gradlew spotlessApply",
+        "cwd": "{projectRoot}"
       }
     },
     "format-check": {
-      "executor": "@nxrocks/nx-spring-boot:check-format",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/openchallenges/kafka-producer"
+        "command": "./gradlew spotlessCheck",
+        "cwd": "{projectRoot}"
       }
     }
   },

--- a/libs/openchallenges/kafka-producer/project.json
+++ b/libs/openchallenges/kafka-producer/project.json
@@ -12,11 +12,12 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
-      "options": {
-        "root": "libs/openchallenges/kafka-producer"
-      },
+      "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/build"],
+      "options": {
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
+      },
       "dependsOn": ["^install"]
     },
     "install": {
@@ -28,10 +29,13 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/openchallenges/kafka-producer"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/libs/shared/java/util/project.json
+++ b/libs/shared/java/util/project.json
@@ -12,11 +12,13 @@
       }
     },
     "build": {
-      "executor": "@nxrocks/nx-spring-boot:build",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/shared/java/util"
+        "command": "./gradlew build",
+        "cwd": "{projectRoot}"
       },
-      "outputs": ["{projectRoot}/build"]
+      "dependsOn": ["^install"]
     },
     "install": {
       "executor": "nx:run-commands",
@@ -27,10 +29,13 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "executor": "@nxrocks/nx-spring-boot:test",
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/build"],
       "options": {
-        "root": "libs/shared/java/util"
-      }
+        "command": "./gradlew test",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "clean": {
       "executor": "@nxrocks/nx-spring-boot:clean",

--- a/libs/shared/java/util/project.json
+++ b/libs/shared/java/util/project.json
@@ -38,9 +38,10 @@
       "dependsOn": ["^install"]
     },
     "clean": {
-      "executor": "@nxrocks/nx-spring-boot:clean",
+      "executor": "nx:run-commands",
       "options": {
-        "root": "libs/shared/java/util"
+        "command": "./gradlew clean",
+        "cwd": "{projectRoot}"
       }
     }
   },

--- a/nx.json
+++ b/nx.json
@@ -30,7 +30,7 @@
     }
   },
   "defaultProject": "openchallenges-app",
-  "plugins": ["@nxrocks/nx-spring-boot"],
+  "plugins": [],
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
     "build": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "@nx/plugin": "16.7.2",
     "@nx/web": "16.7.2",
     "@nx/workspace": "16.7.2",
-    "@nxrocks/nx-spring-boot": "8.0.3",
     "@openapitools/openapi-generator-cli": "2.5.2",
     "@playwright/test": "^1.36.0",
     "@prettier/plugin-xml": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6646,39 +6646,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nxrocks/common@npm:2.4.3":
-  version: 2.4.3
-  resolution: "@nxrocks/common@npm:2.4.3"
-  dependencies:
-    hpagent: ^1.2.0
-    unzipper: ^0.10.11
-    xmlbuilder2: ^3.1.0
-    xpath: ^0.0.32
-  peerDependencies:
-    "@nx/devkit": ">=16.0.0"
-    "@nx/workspace": ">=16.0.0"
-  checksum: 2e3d76ded4d6dd336bb33b59630caabdd1e91894b002c78c79e2bee7fefb34e0ddc1c5a810b6e223b1ea24c9d4e521437949ed4088ec97b6df445f7cb162b7b2
-  languageName: node
-  linkType: hard
-
-"@nxrocks/nx-spring-boot@npm:8.0.3":
-  version: 8.0.3
-  resolution: "@nxrocks/nx-spring-boot@npm:8.0.3"
-  dependencies:
-    "@nxrocks/common": 2.4.3
-    enquirer: ^2.3.6
-    hpagent: ^1.2.0
-    node-fetch: ^2.6.1
-    unzipper: ^0.10.11
-    xmlbuilder2: ^3.1.0
-    xpath: ^0.0.32
-  peerDependencies:
-    "@nx/devkit": ">=16.0.0"
-    "@nx/workspace": ">=16.0.0"
-  checksum: 584d4a1398359a5cb83957283aa0567b086ce551940689cd76a1b43791893bbf41660ecd5462cdd7f101e67881103488625841d862fa19990b5d1dc3822c25c1
-  languageName: node
-  linkType: hard
-
 "@octokit/auth-app@npm:^4.0.2":
   version: 4.0.13
   resolution: "@octokit/auth-app@npm:4.0.13"
@@ -7023,43 +6990,6 @@ __metadata:
     "@octokit/webhooks-types": 5.8.0
     aggregate-error: ^3.1.0
   checksum: 97da13d2464095d68068ff2fd7d2aa42d1c88e6271eb929ae50890396d16862debfa2078e650823bacf42c4a1c606137d3715a5f970bfcbc2bbdf66bca38760e
-  languageName: node
-  linkType: hard
-
-"@oozcitak/dom@npm:1.15.10":
-  version: 1.15.10
-  resolution: "@oozcitak/dom@npm:1.15.10"
-  dependencies:
-    "@oozcitak/infra": 1.0.8
-    "@oozcitak/url": 1.0.4
-    "@oozcitak/util": 8.3.8
-  checksum: c83f5dc778b12f8e52e35fac0aa741bfac074faf3f3b60345723de46cba4c8ef0dced2839379fb93e21007f52336f875cf9ddfff6c598020b0688cb7d6f03ec7
-  languageName: node
-  linkType: hard
-
-"@oozcitak/infra@npm:1.0.8":
-  version: 1.0.8
-  resolution: "@oozcitak/infra@npm:1.0.8"
-  dependencies:
-    "@oozcitak/util": 8.3.8
-  checksum: fc76a17187d67df39cf38ae8138ce1757d6b86e5d2ff3c90f5db12194380005b4e22fb6caec4bd40dce363fb8c89f6f945bb0577e6ecee59755773b7ff793164
-  languageName: node
-  linkType: hard
-
-"@oozcitak/url@npm:1.0.4":
-  version: 1.0.4
-  resolution: "@oozcitak/url@npm:1.0.4"
-  dependencies:
-    "@oozcitak/infra": 1.0.8
-    "@oozcitak/util": 8.3.8
-  checksum: ab4a9726b447910e093c0efcb92c4486e1bc314e0c9375f1a4082d1f0b2cc80bbfd433cc6953641b1ddaf73df21bd7002bb5cf581d8ff104a9eac5d21633b781
-  languageName: node
-  linkType: hard
-
-"@oozcitak/util@npm:8.3.8":
-  version: 8.3.8
-  resolution: "@oozcitak/util@npm:8.3.8"
-  checksum: 3aaa936fb3ba5a8561b54f41ef55cbba633b52f7f95c74e9c4a8068e3cbe893dc30865a24483d3887a0d8a201ee4584daf51f0a177fb8e5997c0bdd289c4f559
   languageName: node
   linkType: hard
 
@@ -10397,13 +10327,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big-integer@npm:^1.6.17":
-  version: 1.6.51
-  resolution: "big-integer@npm:1.6.51"
-  checksum: 3d444173d1b2e20747e2c175568bedeebd8315b0637ea95d75fd27830d3b8e8ba36c6af40374f36bdaea7b5de376dcada1b07587cb2a79a928fccdb6e6e3c518
-  languageName: node
-  linkType: hard
-
 "big.js@npm:^5.2.2":
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
@@ -10449,16 +10372,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary@npm:~0.3.0":
-  version: 0.3.0
-  resolution: "binary@npm:0.3.0"
-  dependencies:
-    buffers: ~0.1.1
-    chainsaw: ~0.1.0
-  checksum: b4699fda9e2c2981e74a46b0115cf0d472eda9b68c0e9d229ef494e92f29ce81acf0a834415094cffcc340dfee7c4ef8ce5d048c65c18067a7ed850323f777af
-  languageName: node
-  linkType: hard
-
 "bl@npm:^1.0.0":
   version: 1.2.3
   resolution: "bl@npm:1.2.3"
@@ -10491,13 +10404,6 @@ __metadata:
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
   checksum: 869417503c722e7dc54ca46715f70e15f4d9c602a423a02c825570862d12935be59ed9c7ba34a9b31f186c017c23cac6b54e35446f8353059c101da73eac22ef
-  languageName: node
-  linkType: hard
-
-"bluebird@npm:~3.4.1":
-  version: 3.4.7
-  resolution: "bluebird@npm:3.4.7"
-  checksum: bffa9dee7d3a41ab15c4f3f24687b49959b4e64e55c058a062176feb8ccefc2163414fb4e1a0f3053bf187600936509660c3ebd168fd9f0e48c7eba23b019466
   languageName: node
   linkType: hard
 
@@ -10754,13 +10660,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-indexof-polyfill@npm:~1.0.0":
-  version: 1.0.2
-  resolution: "buffer-indexof-polyfill@npm:1.0.2"
-  checksum: fbfb2d69c6bb2df235683126f9dc140150c08ac3630da149913a9971947b667df816a913b6993bc48f4d611999cb99a1589914d34c02dccd2234afda5cb75bbc
-  languageName: node
-  linkType: hard
-
 "buffer@npm:4.9.2":
   version: 4.9.2
   resolution: "buffer@npm:4.9.2"
@@ -10779,13 +10678,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.1.13
   checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
-  languageName: node
-  linkType: hard
-
-"buffers@npm:~0.1.1":
-  version: 0.1.1
-  resolution: "buffers@npm:0.1.1"
-  checksum: ad6f8e483efab39cefd92bdc04edbff6805e4211b002f4d1cfb70c6c472a61cc89fb18c37bcdfdd4ee416ca096e9ff606286698a7d41a18b539bac12fd76d4d5
   languageName: node
   linkType: hard
 
@@ -11047,15 +10939,6 @@ __metadata:
   peerDependencies:
     constructs: ^10.0.25
   checksum: e4d3d03fd9bf034e785a63006cf5f7c855c1d7fd63dedaa298d7c612c6db4be1b50fc20e2bb094ef7b622ebc16aa5c9a3e0e3643b48c6d52f7845aa1f4308ebb
-  languageName: node
-  linkType: hard
-
-"chainsaw@npm:~0.1.0":
-  version: 0.1.0
-  resolution: "chainsaw@npm:0.1.0"
-  dependencies:
-    traverse: ">=0.3.0 <0.4"
-  checksum: 22a96b9fb0cd9fb20813607c0869e61817d1acc81b5d455cc6456b5e460ea1dd52630e0f76b291cf8294bfb6c1fc42e299afb52104af9096242699d6d3aa6d3e
   languageName: node
   linkType: hard
 
@@ -13175,15 +13058,6 @@ __metadata:
   bin:
     downlevel-dts: index.js
   checksum: 846ad69da03795340b2fbd9432ff41605b885bf5a7d6636faa86342e91d9e4b27a49c2f68380a2f7ba26ddc28a11b3b02581a41c6b5c7034b8b0fb099c017307
-  languageName: node
-  linkType: hard
-
-"duplexer2@npm:~0.1.4":
-  version: 0.1.4
-  resolution: "duplexer2@npm:0.1.4"
-  dependencies:
-    readable-stream: ^2.0.2
-  checksum: 744961f03c7f54313f90555ac20284a3fb7bf22fdff6538f041a86c22499560eb6eac9d30ab5768054137cb40e6b18b40f621094e0261d7d8c35a37b7a5ad241
   languageName: node
   linkType: hard
 
@@ -15454,18 +15328,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fstream@npm:^1.0.12":
-  version: 1.0.12
-  resolution: "fstream@npm:1.0.12"
-  dependencies:
-    graceful-fs: ^4.1.2
-    inherits: ~2.0.0
-    mkdirp: ">=0.5 0"
-    rimraf: 2
-  checksum: e6998651aeb85fd0f0a8a68cec4d05a3ada685ecc4e3f56e0d063d0564a4fc39ad11a856f9020f926daf869fc67f7a90e891def5d48e4cadab875dc313094536
-  languageName: node
-  linkType: hard
-
 "function-bind@npm:^1.1.1":
   version: 1.1.1
   resolution: "function-bind@npm:1.1.1"
@@ -15954,7 +15816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.10, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.10, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
@@ -16231,7 +16093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hpagent@npm:^1.2.0, hpagent@npm:~1.2.0":
+"hpagent@npm:~1.2.0":
   version: 1.2.0
   resolution: "hpagent@npm:1.2.0"
   checksum: b029da695edae438cee4da2a437386f9db4ac27b3ceb7306d02e1b586c9c194741ed2e943c8a222e0cfefaf27ee3f863aca7ba1721b0950a2a19bf25bc0d85e2
@@ -16688,7 +16550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.0, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -18108,18 +17970,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:3.14.1, js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.0, js-yaml@npm:^3.14.1":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
-  dependencies:
-    argparse: ^1.0.7
-    esprima: ^4.0.0
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -18128,6 +17978,18 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.0, js-yaml@npm:^3.14.1":
+  version: 3.14.1
+  resolution: "js-yaml@npm:3.14.1"
+  dependencies:
+    argparse: ^1.0.7
+    esprima: ^4.0.0
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
   languageName: node
   linkType: hard
 
@@ -19076,13 +18938,6 @@ __metadata:
   version: 2.0.3
   resolution: "lines-and-columns@npm:2.0.3"
   checksum: 5955363dfd7d3d7c476d002eb47944dbe0310d57959e2112dce004c0dc76cecfd479cf8c098fd479ff344acdf04ee0e82b455462a26492231ac152f6c48d17a1
-  languageName: node
-  linkType: hard
-
-"listenercount@npm:~1.0.1":
-  version: 1.0.1
-  resolution: "listenercount@npm:1.0.1"
-  checksum: 0f1c9077cdaf2ebc16473c7d72eb7de6d983898ca42500f03da63c3914b6b312dd5f7a90d2657691ea25adf3fe0ac5a43226e8b2c673fd73415ed038041f4757
   languageName: node
   linkType: hard
 
@@ -20061,7 +19916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:>=0.5 0, mkdirp@npm:^0.5.6":
+"mkdirp@npm:^0.5.6":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
   dependencies:
@@ -23483,7 +23338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.3.0, readable-stream@npm:^2.3.5, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.5, readable-stream@npm:^2.3.0, readable-stream@npm:^2.3.5, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -23995,17 +23850,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:2":
-  version: 2.7.1
-  resolution: "rimraf@npm:2.7.1"
-  dependencies:
-    glob: ^7.1.3
-  bin:
-    rimraf: ./bin.js
-  checksum: cdc7f6eacb17927f2a075117a823e1c5951792c6498ebcce81ca8203454a811d4cf8900314154d3259bb8f0b42ab17f67396a8694a54cae3283326e57ad250cd
-  languageName: node
-  linkType: hard
-
 "rimraf@npm:3.0.2, rimraf@npm:^3.0.0, rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
@@ -24235,7 +24079,6 @@ __metadata:
     "@nx/plugin": 16.7.2
     "@nx/web": 16.7.2
     "@nx/workspace": 16.7.2
-    "@nxrocks/nx-spring-boot": 8.0.3
     "@openapitools/openapi-generator-cli": 2.5.2
     "@playwright/test": ^1.36.0
     "@prettier/plugin-xml": 2.2.0
@@ -24751,7 +24594,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setimmediate@npm:^1.0.5, setimmediate@npm:~1.0.4":
+"setimmediate@npm:^1.0.5":
   version: 1.0.5
   resolution: "setimmediate@npm:1.0.5"
   checksum: c9a6f2c5b51a2dabdc0247db9c46460152ffc62ee139f3157440bd48e7c59425093f42719ac1d7931f054f153e2d26cf37dfeb8da17a794a58198a2705e527fd
@@ -26334,13 +26177,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"traverse@npm:>=0.3.0 <0.4":
-  version: 0.3.9
-  resolution: "traverse@npm:0.3.9"
-  checksum: 982982e4e249e9bbf063732a41fe5595939892758524bbef5d547c67cdf371b13af72b5434c6a61d88d4bb4351d6dabc6e22d832e0d16bc1bc684ef97a1cc59e
-  languageName: node
-  linkType: hard
-
 "traverse@npm:^0.6.6":
   version: 0.6.7
   resolution: "traverse@npm:0.6.7"
@@ -26971,24 +26807,6 @@ __metadata:
   version: 4.0.0
   resolution: "untildify@npm:4.0.0"
   checksum: 39ced9c418a74f73f0a56e1ba4634b4d959422dff61f4c72a8e39f60b99380c1b45ed776fbaa0a4101b157e4310d873ad7d114e8534ca02609b4916bb4187fb9
-  languageName: node
-  linkType: hard
-
-"unzipper@npm:^0.10.11":
-  version: 0.10.14
-  resolution: "unzipper@npm:0.10.14"
-  dependencies:
-    big-integer: ^1.6.17
-    binary: ~0.3.0
-    bluebird: ~3.4.1
-    buffer-indexof-polyfill: ~1.0.0
-    duplexer2: ~0.1.4
-    fstream: ^1.0.12
-    graceful-fs: ^4.2.2
-    listenercount: ~1.0.1
-    readable-stream: ~2.3.6
-    setimmediate: ~1.0.4
-  checksum: b46ae9a72e4b4c224be6a8f46447dd7cb3761a59450827e869747c4564a8f555f877fc19c7e3b5d146127a7dd3e2ffea186116682f6646e64479f99dd23565bc
   languageName: node
   linkType: hard
 
@@ -27953,18 +27771,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xmlbuilder2@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "xmlbuilder2@npm:3.1.1"
-  dependencies:
-    "@oozcitak/dom": 1.15.10
-    "@oozcitak/infra": 1.0.8
-    "@oozcitak/util": 8.3.8
-    js-yaml: 3.14.1
-  checksum: fdcd38d271f1571972ec1facda5bb0d441c4d7d4fa0696cb591a1804549527c462479937194329a453ae5efcd5110c6d3a3d6cf98e210afa2c78bd0400fc6d3c
-  languageName: node
-  linkType: hard
-
 "xmlbuilder@npm:^15.1.1":
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
@@ -27990,13 +27796,6 @@ __metadata:
   version: 2.0.0
   resolution: "xmlhttprequest-ssl@npm:2.0.0"
   checksum: 1e98df67f004fec15754392a131343ea92e6ab5ac4d77e842378c5c4e4fd5b6a9134b169d96842cc19422d77b1606b8df84a5685562b3b698cb68441636f827e
-  languageName: node
-  linkType: hard
-
-"xpath@npm:^0.0.32":
-  version: 0.0.32
-  resolution: "xpath@npm:0.0.32"
-  checksum: 887e9747b960ea45fb47a9464744424512de0a49205e82c2ad6be662d7a2f1a75145662a143304340864c6da68fd8d767cce4065cc198ee07a3d4897e0a3d4bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #2584

## Changelog

- remove the Nx plugin `@nxrocks/nx-spring-boot`
- replace Java tasks that used the plugin with direct calls to `gradlew`
- remove the container `openchallenges-edam-etl` from the stack because its image is broken