### PR TITLE
fix(sage-monorepo): run Sonar on PRs that originates from this repo

### DIFF
--- a/.github/workflows/sonar-scan-pull-request.yml
+++ b/.github/workflows/sonar-scan-pull-request.yml
@@ -1,6 +1,9 @@
 name: Sonar Scan
 
 on:
+  # Pull request from the same repository
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   # Warning: using the pull_request_target event without the cautionary measures may allow
   # unauthorized GitHub users to open a “pwn request” and exfiltrate secrets.
   pull_request_target:


### PR DESCRIPTION
Closes #2599

UPDATE: The issue with adding the trigger `pull_request` is that it triggers another check, but we don't want to run twice the Sonar check.

## Test

I will test this fix after merging to `main` by creating a same-repo PR.

## Preview

Actually adding the trigger `pull_request` creates a new check that fails.

<img width="907" alt="image" src="https://github.com/Sage-Bionetworks/sage-monorepo/assets/3056480/530ee494-8357-42a9-afda-64690703f4c3">
