### PR TITLE
fix(sage-monorepo): test Sonar workflow with local PR

### DIFF
--- a/apps/openchallenges/app/README.md
+++ b/apps/openchallenges/app/README.md
@@ -2,6 +2,8 @@
 
 ## Configuration
 
+plop
+
 ### Dev Server
 
 - Server host: The server port is defined by the property `options.host` in `project.json` for the


### PR DESCRIPTION
## Update

This PR is a proof that the current Sonar workflow works as expected for same-repo PRs. I'm not sure why the workflow didn't trigger in #2598. I will keep monitoring this issue when the next DB update PR is created.