### PR TITLE
chore(sage-monorepo): add bridge2ai project scope to PR title linter

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -23,6 +23,7 @@ jobs:
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |
             agora
+            bridge2ai
             common
             iatlas
             openchallenges


### PR DESCRIPTION
## Changelog

Add the `bridge2ai` project to the scope.