### PR TITLE
chore(openchallenges): create new EDAM DB

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,9 +55,7 @@
   //     }
   //   ]
   // },
-  "eslint.workingDirectories": [
-    "."
-  ],
+  "eslint.workingDirectories": ["."],
   "sqltools.autoOpenSessionFiles": false,
   "sqltools.connections": [
     {
@@ -79,7 +77,7 @@
       "port": 3306,
       "driver": "MariaDB",
       "name": "openchallenges",
-      "username": "maria",
+      "username": "edam-challenge-service",
       "password": "changeme"
     },
     {
@@ -97,12 +95,8 @@
   "java.configuration.updateBuildConfiguration": "disabled",
   "editor.inlayHints.enabled": "off",
   "rewrap.wrappingColumn": 100,
-  "editor.rulers": [
-    100
-  ],
-  "eslint.validate": [
-    "json"
-  ],
+  "editor.rulers": [100],
+  "eslint.validate": ["json"],
   "java.compile.nullAnalysis.mode": "disabled",
   "typescript.tsdk": "node_modules/typescript/lib",
   "python.analysis.autoImportCompletions": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -77,7 +77,7 @@
       "port": 3306,
       "driver": "MariaDB",
       "name": "openchallenges",
-      "username": "edam-challenge-service",
+      "username": "maria",
       "password": "changeme"
     },
     {

--- a/apps/openchallenges/mariadb/docker-entrypoint-initdb.d/init-db.sql
+++ b/apps/openchallenges/mariadb/docker-entrypoint-initdb.d/init-db.sql
@@ -15,36 +15,25 @@ grant all on edam.* to role_admin;
 grant role_admin to maria;
 set default role role_admin for maria;
 
--- Create the user for challenge-core-service
--- create user challenge_core_service identified by 'changeme';
--- grant role_admin to challenge_core_service;
--- set default role role_admin for challenge_core_service;
-
 -- Create the user for openchallenges-challenge-service
-create user challenge_service identified by 'changeme';
-grant role_admin to challenge_service;
-set default role role_admin for challenge_service;
+create user 'challenge_service' identified by 'changeme';
+grant all privileges on challenge_service.* to 'challenge_service';
+grant select on edam.* to 'challenge_service';
 
 -- Create the user for openchallenges-organization-service
-create user organization_service identified by 'changeme';
-grant role_admin to organization_service;
-set default role role_admin for organization_service;
+create user 'organization_service' identified by 'changeme';
+grant all privileges on organization_service.* to 'organization_service';
+
+-- Create the user for openchallenges-edam-etl
+create user 'edam_etl' identified by 'changeme';
+grant all privileges on edam.* to 'edam_etl';
 
 -- Create the user for openchallenges-user-service
-create user user_service identified by 'changeme';
-grant role_admin to user_service;
-set default role role_admin for user_service;
+-- create user user_service identified by 'changeme';
+-- grant role_admin to user_service;
+-- set default role role_admin for user_service;
 
 -- Create the user for openchallenges-mysqld-exporter
-create user 'mysqld-exporter' identified by 'changeme' with max_user_connections 3;;
-grant process, slave monitor on *.* to 'mysqld-exporter';
-grant select on performance_schema.* to 'mysqld-exporter';
-
--- Create the user for edam-etl
-create user 'edam-etl' identified by 'changeme';
-grant role_admin to 'edam-etl';
-set default role role_admin for 'edam-etl';
-
--- Create the read-only user to the EDAM DB for the challenge service
-create user 'edam-challenge-service' identified by 'changeme';
-grant select on edam.* to 'edam-challenge-service';
+-- create user 'mysqld-exporter' identified by 'changeme' with max_user_connections 3;;
+-- grant process, slave monitor on *.* to 'mysqld-exporter';
+-- grant select on performance_schema.* to 'mysqld-exporter';

--- a/apps/openchallenges/mariadb/docker-entrypoint-initdb.d/init-db.sql
+++ b/apps/openchallenges/mariadb/docker-entrypoint-initdb.d/init-db.sql
@@ -3,11 +3,13 @@ SET GLOBAL local_infile = 'ON';
 create database challenge_service;
 create database organization_service;
 create database user_service;
+create database edam;
 
 create role role_admin;
 grant all on challenge_service.* to role_admin;
 grant all on organization_service.* to role_admin;
 grant all on user_service.* to role_admin;
+grant all on edam.* to role_admin;
 
 -- Create the user maria
 grant role_admin to maria;
@@ -37,3 +39,12 @@ set default role role_admin for user_service;
 create user 'mysqld-exporter' identified by 'changeme' with max_user_connections 3;;
 grant process, slave monitor on *.* to 'mysqld-exporter';
 grant select on performance_schema.* to 'mysqld-exporter';
+
+-- Create the user for edam-etl
+create user 'edam-etl' identified by 'changeme';
+grant role_admin to 'edam-etl';
+set default role role_admin for 'edam-etl';
+
+-- Create the read-only user to the EDAM DB for the challenge service
+create user 'edam-challenge-service' identified by 'changeme';
+grant select on edam.* to 'edam-challenge-service';


### PR DESCRIPTION
Closes #2605

## Changelog

- create the DB `edam` in OC MariaDB instance
- create the user `edam_etl` with write permission to this new DB
- create the user `edam_challenge_service` with read-only permission to this new DB