### PR TITLE
fix(openchallenges): add functionality to retrieve label for challenge property from mapping file

### DIFF
--- a/libs/openchallenges/challenge-search/src/index.ts
+++ b/libs/openchallenges/challenge-search/src/index.ts
@@ -1,1 +1,3 @@
 export * from './lib/challenge-search.routes';
+export * from './lib/challenge-search-filters';
+export * from './lib/get-label-by-filter-value';

--- a/libs/openchallenges/challenge-search/src/lib/get-label-by-filter-value.ts
+++ b/libs/openchallenges/challenge-search/src/lib/get-label-by-filter-value.ts
@@ -1,0 +1,13 @@
+import { Filter } from '@sagebionetworks/openchallenges/ui';
+
+/**
+ * A generic function used to retrieve the label for values of challenge properties
+ */
+
+export function getLabelByFilterValue(
+  filter: Filter[],
+  value: any
+): string | undefined {
+  const filterItem = filter.find((item) => item.value === value);
+  return filterItem ? filterItem.label : undefined;
+}

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.html
@@ -26,7 +26,7 @@
         </tr>
         <tr>
           <td class="text-right">Status</td>
-          <td>{{ prettify(challenge.status) }}</td>
+          <td>{{ getStatusLabel(challenge.status) }}</td>
         </tr>
         <tr>
           <td class="text-right">Platform</td>
@@ -58,7 +58,7 @@
               nowrap
               *ngFor="let submissionType of challenge.submissionTypes; let isLast = last"
             >
-              {{ prettify(submissionType) }}{{ isLast ? '' : ', ' }}</span
+              {{ getSubmissionTypeLabel(submissionType) }}{{ isLast ? '' : ', ' }}</span
             >
           </td>
           <ng-template #na_subs>
@@ -69,7 +69,7 @@
           <td class="text-right">Incentive(s)</td>
           <td *ngIf="challenge.incentives && challenge.incentives.length > 0; else na_prize">
             <span nowrap *ngFor="let incentive of challenge.incentives; let isLast = last">
-              {{ prettify(incentive) }}{{ isLast ? '' : ', ' }}</span
+              {{ getIncentiveLabel(incentive) }}{{ isLast ? '' : ', ' }}</span
             >
           </td>
           <ng-template #na_prize>

--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.ts
@@ -1,10 +1,22 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
-import { Challenge } from '@sagebionetworks/openchallenges/api-client-angular';
+import {
+  Challenge,
+  ChallengeIncentive,
+  ChallengeStatus,
+  ChallengeSubmissionType,
+} from '@sagebionetworks/openchallenges/api-client-angular';
 import {
   MOCK_ORGANIZATION_CARDS,
   OrganizationCard,
 } from '@sagebionetworks/openchallenges/ui';
+import {
+  challengeIncentivesFilter,
+  challengeStatusFilter,
+  challengeSubmissionTypesFilter,
+  getLabelByFilterValue,
+} from '@sagebionetworks/openchallenges/challenge-search';
+
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
@@ -17,16 +29,20 @@ import { MatIconModule } from '@angular/material/icon';
 export class ChallengeOverviewComponent {
   @Input({ required: true }) challenge!: Challenge;
   organizationCards: OrganizationCard[] = MOCK_ORGANIZATION_CARDS;
-  // mockTopics = ['breast', 'cancer'];
 
   useNaIfFalsey(str: string | null | undefined) {
-    return str || 'Not available';
+    return str ?? 'Not available';
   }
 
-  prettify(camel: string | undefined) {
-    return camel
-      ? camel.charAt(0).toUpperCase() +
-          camel.slice(1).replace(/_/g, ' ').toLowerCase()
-      : undefined;
+  getIncentiveLabel(status: ChallengeIncentive): string | undefined {
+    return getLabelByFilterValue(challengeIncentivesFilter, status);
+  }
+
+  getSubmissionTypeLabel(status: ChallengeSubmissionType): string | undefined {
+    return getLabelByFilterValue(challengeSubmissionTypesFilter, status);
+  }
+
+  getStatusLabel(status: ChallengeStatus): string | undefined {
+    return getLabelByFilterValue(challengeStatusFilter, status);
   }
 }


### PR DESCRIPTION
- fixes #2580 

## Changelogs
- Map the label for a challenge property based on a mapping file. To minimize changes, use the existing filter file, which consists of the value and label for each filterable challenge property, as the mapping file.
- Add a generic function to retrieve the label from the filter object array, allowing it to be called in other components, like `challenge-overview`
