### PR TITLE
feat(model-ad): externalize the app config

### DIFF
--- a/apps/model-ad/app/project.json
+++ b/apps/model-ad/app/project.json
@@ -22,6 +22,7 @@
         "inlineStyleLanguage": "scss",
         "assets": [
           "apps/model-ad/app/src/assets",
+          "apps/model-ad/app/src/config",
           "apps/model-ad/app/src/humans.txt",
           "apps/model-ad/app/src/robots.txt",
           {

--- a/apps/model-ad/app/src/app/app.config.ts
+++ b/apps/model-ad/app/src/app/app.config.ts
@@ -1,8 +1,53 @@
-import { ApplicationConfig } from '@angular/core';
-import { provideRouter } from '@angular/router';
-import { appRoutes } from './app.routes';
-import { provideClientHydration } from '@angular/platform-browser';
+import { ApplicationConfig, APP_INITIALIZER, APP_ID } from '@angular/core';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+  withInMemoryScrolling,
+} from '@angular/router';
+import {
+  withInterceptorsFromDi,
+  provideHttpClient,
+} from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+// import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/model-ad/api-client-angular';
+import { configFactory, ConfigService } from '@sagebionetworks/model-ad/config';
+
+import { routes } from './app.routes';
+
+// This index is used to remove the corresponding provider in app.config.server.ts.
+export const APP_BASE_URL_PROVIDER_INDEX = 1;
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideClientHydration(), provideRouter(appRoutes)],
+  providers: [
+    { provide: APP_ID, useValue: 'model-ad-app' },
+    {
+      // This provider must be specified at the index defined by APP_BASE_URL_PROVIDER_INDEX.
+      provide: 'APP_BASE_URL',
+      useFactory: () => '.',
+      deps: [],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: configFactory,
+      deps: [ConfigService],
+      multi: true,
+    },
+    // {
+    //   provide: API_CLIENT_BASE_PATH,
+    //   useFactory: (configService: ConfigService) =>
+    //     configService.config.isPlatformServer
+    //       ? configService.config.ssrApiUrl
+    //       : configService.config.csrApiUrl,
+    //   deps: [ConfigService],
+    // },
+    provideAnimations(),
+    provideHttpClient(withInterceptorsFromDi()),
+    provideRouter(
+      routes,
+      withEnabledBlockingInitialNavigation(),
+      withInMemoryScrolling({
+        scrollPositionRestoration: 'enabled',
+      })
+    ),
+  ],
 };

--- a/apps/model-ad/app/src/app/app.config.ts
+++ b/apps/model-ad/app/src/app/app.config.ts
@@ -15,6 +15,7 @@ import { configFactory, ConfigService } from '@sagebionetworks/model-ad/config';
 import { routes } from './app.routes';
 
 // This index is used to remove the corresponding provider in app.config.server.ts.
+// TODO: This index could be out of sync if we are not careful. Find a more elegant way.
 export const APP_BASE_URL_PROVIDER_INDEX = 1;
 
 export const appConfig: ApplicationConfig = {

--- a/apps/model-ad/app/src/app/app.routes.ts
+++ b/apps/model-ad/app/src/app/app.routes.ts
@@ -1,6 +1,6 @@
 import { Route } from '@angular/router';
 
-export const appRoutes: Route[] = [
+export const routes: Route[] = [
   {
     path: 'not-found',
     loadChildren: () =>

--- a/apps/model-ad/app/src/config/config.json
+++ b/apps/model-ad/app/src/config/config.json
@@ -1,0 +1,9 @@
+{
+  "apiDocsUrl": "http://localhost:8000/api-docs",
+  "appVersion": "1.0.0-beta",
+  "csrApiUrl": "http://localhost:8082/api/v1",
+  "dataUpdatedOn": "yyyy-mm-dd",
+  "environment": "development",
+  "googleTagManagerId": "",
+  "ssrApiUrl": "http://openchallenges-api-gateway:8082/api/v1"
+}

--- a/apps/model-ad/app/src/config/config.json
+++ b/apps/model-ad/app/src/config/config.json
@@ -5,5 +5,5 @@
   "dataUpdatedOn": "yyyy-mm-dd",
   "environment": "development",
   "googleTagManagerId": "",
-  "ssrApiUrl": "http://openchallenges-api-gateway:8082/api/v1"
+  "ssrApiUrl": "http://model-ad-api-gateway:8082/api/v1"
 }

--- a/apps/model-ad/app/src/config/config.json.template
+++ b/apps/model-ad/app/src/config/config.json.template
@@ -1,0 +1,9 @@
+{
+  "apiDocsUrl": "${API_DOCS_URL}",
+  "appVersion": "${APP_VERSION}",
+  "csrApiUrl": "${CSR_API_URL}",
+  "dataUpdatedOn": "${DATA_UPDATED_ON}",
+  "environment": "${ENVIRONMENT}",
+  "googleTagManagerId": "${GOOGLE_TAG_MANAGER_ID}",
+  "ssrApiUrl": "${SSR_API_URL}"
+}

--- a/libs/model-ad/config/.eslintrc.json
+++ b/libs/model-ad/config/.eslintrc.json
@@ -1,0 +1,50 @@
+{
+  "extends": [
+    "../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "env": {
+    "jest": true
+  },
+  "overrides": [
+    {
+      "files": [
+        "*.ts"
+      ],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+        "plugin:jest/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "modelAd",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "model-ad",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.html"
+      ],
+      "extends": [
+        "plugin:@nx/angular-template"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/model-ad/config/README.md
+++ b/libs/model-ad/config/README.md
@@ -1,7 +1,7 @@
-# openchallenges-config
+# model-ad-config
 
 This library was generated with [Nx](https://nx.dev).
 
 ## Running unit tests
 
-Run `nx test openchallenges-config` to execute the unit tests.
+Run `nx test model-ad-config` to execute the unit tests.

--- a/libs/model-ad/config/README.md
+++ b/libs/model-ad/config/README.md
@@ -1,0 +1,7 @@
+# openchallenges-config
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test openchallenges-config` to execute the unit tests.

--- a/libs/model-ad/config/jest.config.ts
+++ b/libs/model-ad/config/jest.config.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+export default {
+  displayName: 'model-ad-config',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {},
+  coverageDirectory: '../../../coverage/libs/model-ad/config',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/model-ad/config/project.json
+++ b/libs/model-ad/config/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "model-ad-config",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/model-ad/config/src",
+  "prefix": "model-ad",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": [
+        "{workspaceRoot}/coverage/libs/model-ad/config"
+      ],
+      "options": {
+        "jestConfig": "libs/model-ad/config/jest.config.ts"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  },
+  "tags": [
+    "type:feature",
+    "scope:model-ad",
+    "language:typescript"
+  ],
+  "implicitDependencies": []
+}

--- a/libs/model-ad/config/src/index.ts
+++ b/libs/model-ad/config/src/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/app.config';
+export * from './lib/config.factory';
+export * from './lib/config.service';

--- a/libs/model-ad/config/src/lib/app.config.ts
+++ b/libs/model-ad/config/src/lib/app.config.ts
@@ -1,0 +1,25 @@
+/* eslint-disable no-unused-vars */
+export enum Environment {
+  Production = 'prod',
+  Staging = 'staging',
+  Test = 'test',
+  Development = 'dev',
+  Local = 'local',
+}
+/* eslint-enable no-unused-vars */
+
+export interface AppConfig {
+  appVersion: string;
+  csrApiUrl: string;
+  dataUpdatedOn: string;
+  environment: Environment;
+  googleTagManagerId: string;
+  isPlatformServer: boolean;
+  keycloakRealm: string;
+  privacyPolicyUrl: string;
+  ssrApiUrl: string;
+  termsOfUseUrl: string;
+  apiDocsUrl: string;
+}
+
+export const EMPTY_APP_CONFIG = {} as AppConfig;

--- a/libs/model-ad/config/src/lib/config.factory.ts
+++ b/libs/model-ad/config/src/lib/config.factory.ts
@@ -1,0 +1,5 @@
+import { ConfigService } from './config.service';
+
+export const configFactory = (configService: ConfigService) => {
+  return () => configService.loadConfig();
+};

--- a/libs/model-ad/config/src/lib/config.service.ts
+++ b/libs/model-ad/config/src/lib/config.service.ts
@@ -1,0 +1,48 @@
+import { isPlatformServer } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
+import { lastValueFrom } from 'rxjs';
+import { AppConfig, EMPTY_APP_CONFIG } from './app.config';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ConfigService {
+  config: AppConfig = EMPTY_APP_CONFIG;
+
+  constructor(
+    private http: HttpClient,
+    @Inject(PLATFORM_ID) private platformId: string,
+    @Inject('APP_PORT') @Optional() private readonly port: string
+  ) {}
+
+  async loadConfig(): Promise<void> {
+    // The location of the browser folder, which includes the config folder, depends on whether the
+    // present code is run in the browser and by the node server. We could use the request received
+    // by the node server (SSR) and get the host and port, but this does not work when the port is
+    // different from the Angular or node port. Note that `localhost` works inside the container
+    // (production) as well as outside (dev server). APP_BASE_URL could be used when running the dev
+    // server and accessing it directly (e.g. APP_BASE_URL = 'http://localhost:37677') but not when
+    // accessing the production server in the container from apex (APP_BASE_URL =
+    // 'http://localhost:8000', which is invalid inside the container).
+    const browserRoot = isPlatformServer(this.platformId)
+      ? `http://localhost:${this.port}`
+      : '.';
+
+    const appConfig$ = this.http.get<AppConfig>(
+      `${browserRoot}/config/config.json`
+    );
+    try {
+      const config = await lastValueFrom(appConfig$);
+      this.config = config;
+      this.config.isPlatformServer = isPlatformServer(this.platformId);
+      this.config.privacyPolicyUrl =
+        'https://sagebionetworks.jira.com/wiki/spaces/OA/pages/2948530178/OpenChallenges+Privacy+Policy';
+      this.config.termsOfUseUrl =
+        'https://sagebionetworks.jira.com/wiki/spaces/OA/pages/2948333575/OpenChallenges+Terms+of+Use';
+    } catch (err) {
+      console.error('Unable to load the config file: ', err);
+      return await Promise.resolve();
+    }
+  }
+}

--- a/libs/model-ad/config/src/test-setup.ts
+++ b/libs/model-ad/config/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/model-ad/config/tsconfig.json
+++ b/libs/model-ad/config/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "target": "es2020"
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/model-ad/config/tsconfig.lib.json
+++ b/libs/model-ad/config/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/model-ad/config/tsconfig.spec.json
+++ b/libs/model-ad/config/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts", "jest.config.ts"]
+}

--- a/libs/model-ad/not-found/src/lib/not-found.component.ts
+++ b/libs/model-ad/not-found/src/lib/not-found.component.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { RouterModule } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
-// import { ConfigService } from '@sagebionetworks/openchallenges/config';
 import { FooterComponent } from '@sagebionetworks/model-ad/ui';
 import { ConfigService } from '@sagebionetworks/model-ad/config';
 

--- a/libs/model-ad/not-found/src/lib/not-found.component.ts
+++ b/libs/model-ad/not-found/src/lib/not-found.component.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 // import { ConfigService } from '@sagebionetworks/openchallenges/config';
 import { FooterComponent } from '@sagebionetworks/model-ad/ui';
+import { ConfigService } from '@sagebionetworks/model-ad/config';
 
 @Component({
   selector: 'model-ad-not-found',
@@ -26,11 +27,11 @@ export class NotFoundComponent {
   public termsOfUseUrl: string;
   public apiDocsUrl: string;
 
-  constructor() {
-    this.appVersion = 'foo';
-    this.dataUpdatedOn = 'foo';
-    this.privacyPolicyUrl = 'foo';
-    this.termsOfUseUrl = 'foo';
-    this.apiDocsUrl = 'foo';
+  constructor(private readonly configService: ConfigService) {
+    this.appVersion = this.configService.config.appVersion;
+    this.dataUpdatedOn = this.configService.config.dataUpdatedOn;
+    this.privacyPolicyUrl = this.configService.config.privacyPolicyUrl;
+    this.termsOfUseUrl = this.configService.config.termsOfUseUrl;
+    this.apiDocsUrl = this.configService.config.apiDocsUrl;
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -92,6 +92,9 @@
       "@sagebionetworks/model-ad/not-found": [
         "libs/model-ad/not-found/src/index.ts"
       ],
+      "@sagebionetworks/model-ad/config": [
+        "libs/model-ad/config/src/index.ts"
+      ],
     }
   },
   "exclude": [


### PR DESCRIPTION
## Changelogs

- create the library `model-ad-config`
- add config file for the development server in `src/config/config.json`
- add template config file used when the app is containerized in `src/config/config.json.template`
- load the config during the initialization of the app
- inject the config server into the constructor of the not-found page

## References

- [The Twelve-Factor App](https://www.12factor.net/)

## Notes

Today, VS Code became unresponsive. After closing and reopening VS Code, we noticed that the port 4200 was in use. I assumed that it was the development server of MODEL-AD that was still running in the background. One way to kill a process that uses a specific port is using the workspace command `workspace-kill-port {port number}`. This command failed because my assumption was incorrect: it was actually the Docker container of the OpenChallenges (OC) app that was running, and the kill command can't stop a container that is using a port. One way I'm trying to prevent this specific issue (port conflicts) is to assign different ports to different projects in the monorepo. We currently have multiple projects that use the default Angular port 4200. We will change this first next time we meet.