### PR TITLE
chore(sage-monorepo): add results-visualization-framework ui library (AG-576)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,3 +30,4 @@
 /apps/model-ad/ @hallieswan @sagely1
 /docker/model-ad/ @hallieswan @sagely1
 /libs/model-ad/ @hallieswan @sagely1
+/libs/results-visualization-framework/ @hallieswan @sagely1

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -28,6 +28,7 @@ jobs:
             iatlas
             model-ad
             openchallenges
+            results-visualization-framework
             sage-monorepo
             schematic
             synapse

--- a/libs/results-visualization-framework/ui/.eslintrc.json
+++ b/libs/results-visualization-framework/ui/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "env": {
+    "jest": true
+  },
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+        "plugin:jest/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "resultsVisualizationFramework",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "results-visualization-framework",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/results-visualization-framework/ui/.eslintrc.json
+++ b/libs/results-visualization-framework/ui/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "storybook-static"],
   "env": {
     "jest": true
   },

--- a/libs/results-visualization-framework/ui/.storybook/main.ts
+++ b/libs/results-visualization-framework/ui/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/angular';
+
+const config: StorybookConfig = {
+  stories: ['../**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/angular',
+    options: {},
+  },
+};
+
+export default config;
+
+// To customize your webpack configuration you can use the webpackFinal field.
+// Check https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
+// and https://nx.dev/recipes/storybook/custom-builder-configs

--- a/libs/results-visualization-framework/ui/.storybook/tsconfig.json
+++ b/libs/results-visualization-framework/ui/.storybook/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true
+  },
+  "exclude": ["../**/*.spec.ts"],
+  "include": [
+    "../src/**/*.stories.ts",
+    "../src/**/*.stories.js",
+    "../src/**/*.stories.jsx",
+    "../src/**/*.stories.tsx",
+    "../src/**/*.stories.mdx",
+    "*.js",
+    "*.ts"
+  ]
+}

--- a/libs/results-visualization-framework/ui/README.md
+++ b/libs/results-visualization-framework/ui/README.md
@@ -1,0 +1,7 @@
+# results-visualization-framework-ui
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test results-visualization-framework-ui` to execute the unit tests.

--- a/libs/results-visualization-framework/ui/jest.config.ts
+++ b/libs/results-visualization-framework/ui/jest.config.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+export default {
+  displayName: 'results-visualization-framework-ui',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {},
+  coverageDirectory: '../../../coverage/libs/results-visualization-framework/ui',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/results-visualization-framework/ui/project.json
+++ b/libs/results-visualization-framework/ui/project.json
@@ -14,6 +14,47 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint"
+    },
+    "storybook": {
+      "executor": "@storybook/angular:start-storybook",
+      "options": {
+        "port": 4400,
+        "configDir": "libs/results-visualization-framework/ui/.storybook",
+        "browserTarget": "results-visualization-framework-ui:build-storybook",
+        "compodoc": false
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    },
+    "build-storybook": {
+      "executor": "@storybook/angular:build-storybook",
+      "outputs": ["{options.outputDir}"],
+      "options": {
+        "outputDir": "dist/storybook/results-visualization-framework-ui",
+        "configDir": "libs/results-visualization-framework/ui/.storybook",
+        "browserTarget": "results-visualization-framework-ui:build-storybook",
+        "compodoc": false
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    },
+    "static-storybook": {
+      "executor": "@nx/web:file-server",
+      "options": {
+        "buildTarget": "results-visualization-framework-ui:build-storybook",
+        "staticFilePath": "dist/storybook/results-visualization-framework-ui"
+      },
+      "configurations": {
+        "ci": {
+          "buildTarget": "results-visualization-framework-ui:build-storybook:ci"
+        }
+      }
     }
   },
   "tags": ["type:feature", "scope:results-visualization-framework", "language:typescript"],

--- a/libs/results-visualization-framework/ui/project.json
+++ b/libs/results-visualization-framework/ui/project.json
@@ -1,0 +1,21 @@
+{
+  "name": "results-visualization-framework-ui",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/results-visualization-framework/ui/src",
+  "prefix": "results-visualization-framework",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/results-visualization-framework/ui"],
+      "options": {
+        "jestConfig": "libs/results-visualization-framework/ui/jest.config.ts"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  },
+  "tags": ["type:feature", "scope:results-visualization-framework", "language:typescript"],
+  "implicitDependencies": []
+}

--- a/libs/results-visualization-framework/ui/src/index.ts
+++ b/libs/results-visualization-framework/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/test/test.component';

--- a/libs/results-visualization-framework/ui/src/lib/test/test.component.html
+++ b/libs/results-visualization-framework/ui/src/lib/test/test.component.html
@@ -1,0 +1,3 @@
+<section id="test">
+  <h3 class="section-title">{{ inputText }}</h3>
+</section>

--- a/libs/results-visualization-framework/ui/src/lib/test/test.component.scss
+++ b/libs/results-visualization-framework/ui/src/lib/test/test.component.scss
@@ -1,0 +1,10 @@
+#test {
+  background: #f8f8f8;
+  margin-top: 12px;
+  padding: 88px 0;
+}
+
+.section-title {
+  text-align: center;
+  margin-bottom: 42px;
+}

--- a/libs/results-visualization-framework/ui/src/lib/test/test.component.spec.ts
+++ b/libs/results-visualization-framework/ui/src/lib/test/test.component.spec.ts
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/angular';
+import { TestComponent } from './test.component';
+
+const setUp = async (inputText: string) => {
+  await render(TestComponent, {
+    componentProperties: { inputText },
+  });
+};
+
+describe('TestComponent', () => {
+  it('should display inputText', async () => {
+    const text = 'Hello World!';
+    await setUp(text);
+    expect(screen.getByRole('heading', { name: text })).toBeVisible();
+  });
+});

--- a/libs/results-visualization-framework/ui/src/lib/test/test.component.stories.ts
+++ b/libs/results-visualization-framework/ui/src/lib/test/test.component.stories.ts
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { TestComponent } from './test.component';
+
+const meta: Meta<TestComponent> = {
+  component: TestComponent,
+  title: 'TestComponent',
+};
+export default meta;
+type Story = StoryObj<TestComponent>;
+
+export const Demo: Story = {
+  args: {
+    inputText: 'Example Text',
+  },
+};

--- a/libs/results-visualization-framework/ui/src/lib/test/test.component.ts
+++ b/libs/results-visualization-framework/ui/src/lib/test/test.component.ts
@@ -1,0 +1,13 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'results-visualization-framework-test',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './test.component.html',
+  styleUrls: ['./test.component.scss'],
+})
+export class TestComponent {
+  @Input({ required: true }) inputText = '';
+}

--- a/libs/results-visualization-framework/ui/src/test-setup.ts
+++ b/libs/results-visualization-framework/ui/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/results-visualization-framework/ui/src/test-setup.ts
+++ b/libs/results-visualization-framework/ui/src/test-setup.ts
@@ -1,1 +1,2 @@
+import '@testing-library/jest-dom';
 import 'jest-preset-angular/setup-jest';

--- a/libs/results-visualization-framework/ui/tsconfig.json
+++ b/libs/results-visualization-framework/ui/tsconfig.json
@@ -8,6 +8,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
     }
   ],
   "compilerOptions": {

--- a/libs/results-visualization-framework/ui/tsconfig.json
+++ b/libs/results-visualization-framework/ui/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "target": "es2020"
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/results-visualization-framework/ui/tsconfig.lib.json
+++ b/libs/results-visualization-framework/ui/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/results-visualization-framework/ui/tsconfig.lib.json
+++ b/libs/results-visualization-framework/ui/tsconfig.lib.json
@@ -7,6 +7,13 @@
     "inlineSources": true,
     "types": []
   },
-  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "exclude": [
+    "src/test-setup.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "jest.config.ts",
+    "**/*.stories.ts",
+    "**/*.stories.js"
+  ],
   "include": ["**/*.ts"]
 }

--- a/libs/results-visualization-framework/ui/tsconfig.spec.json
+++ b/libs/results-visualization-framework/ui/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts", "jest.config.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -104,6 +104,9 @@
       "@sagebionetworks/model-ad/util": [
         "libs/model-ad/util/src/index.ts"
       ],
+      "@sagebionetworks/results-visualization-framework/ui": [
+        "libs/results-visualization-framework/ui/src/index.ts"
+      ],
     }
   },
   "exclude": [


### PR DESCRIPTION
## Description

Adds a new UI library for components that are shared between Agora and Model-AD.

## Related Issue

- [AG-576](https://sagebionetworks.jira.com/browse/AG-576)

## Changelog

- Add `results-visualization-framework-ui` component library with a test component that demonstrates Storybook and testing-library

## Preview

- Run tests: `nx run results-visualization-framework-ui:test`
- Run storybook: `nx run results-visualization-framework-ui:storybook`

https://github.com/Sage-Bionetworks/sage-monorepo/assets/26949006/e0a85daa-5c9a-42bc-9301-c02b4fef3fd4

[AG-576]: https://sagebionetworks.jira.com/browse/AG-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ