### PR TITLE
refactor(openchallenges): overideable config-server spring import config

### DIFF
--- a/apps/openchallenges/api-gateway/src/main/resources/application.yml
+++ b/apps/openchallenges/api-gateway/src/main/resources/application.yml
@@ -4,8 +4,9 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    import: 'configserver:'
   cloud:
     config:
+      uri: http://openchallenges-config-server:8090
       username: openchallenges
       password: changeme

--- a/apps/openchallenges/challenge-service/src/main/resources/application.yml
+++ b/apps/openchallenges/challenge-service/src/main/resources/application.yml
@@ -4,9 +4,10 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    import: 'configserver:'
   cloud:
     config:
+      uri: http://openchallenges-config-server:8090
       username: openchallenges
       password: changeme
   # TODO: Move to the remote config file

--- a/apps/openchallenges/challenge-to-elasticsearch-service/src/main/resources/application.yml
+++ b/apps/openchallenges/challenge-to-elasticsearch-service/src/main/resources/application.yml
@@ -4,9 +4,10 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    import: 'configserver:'
     # name: openchallenges-organization-service,openchallenges
   cloud:
     config:
+      uri: http://openchallenges-config-server:8090
       username: openchallenges
       password: changeme

--- a/apps/openchallenges/image-service/src/main/resources/application.yml
+++ b/apps/openchallenges/image-service/src/main/resources/application.yml
@@ -4,8 +4,9 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    import: 'configserver:'
   cloud:
     config:
+      uri: http://openchallenges-config-server:8090
       username: openchallenges
       password: changeme

--- a/apps/openchallenges/kaggle-to-kafka-service/src/main/resources/application.yml
+++ b/apps/openchallenges/kaggle-to-kafka-service/src/main/resources/application.yml
@@ -4,8 +4,9 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    import: 'configserver:'
   cloud:
     config:
+      uri: http://openchallenges-config-server:8090
       username: openchallenges
       password: changeme

--- a/apps/openchallenges/organization-service/src/main/resources/application.yml
+++ b/apps/openchallenges/organization-service/src/main/resources/application.yml
@@ -4,10 +4,11 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    import: 'configserver:'
     # name: openchallenges-organization-service,openchallenges
   cloud:
     config:
+      uri: http://openchallenges-config-server:8090
       username: openchallenges
       password: changeme
   # TODO: Move to the remote config file

--- a/apps/openchallenges/service-registry/src/main/resources/application.yml
+++ b/apps/openchallenges/service-registry/src/main/resources/application.yml
@@ -4,7 +4,8 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    confighost: http://openchallenges-config-server:8090
+    import: configserver:${confighost}
   cloud:
     config:
       username: openchallenges

--- a/apps/openchallenges/service-registry/src/main/resources/application.yml
+++ b/apps/openchallenges/service-registry/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
   profiles:
     active: dev,local
   config:
-    confighost: http://openchallenges-config-server:8090
-    import: configserver:${confighost}
+    import: 'configserver:'
   cloud:
     config:
+      uri: http://openchallenges-config-server:8090
       username: openchallenges
       password: changeme


### PR DESCRIPTION
spring boot [issue 3346](https://github.com/spring-projects/spring-boot/issues/33446)
says it's not possible to override Spring Import with SPRING_CONFIG_IMPORT env var.  The suggestion is to use confighost instead which can be overriden with a CONFIGHOST env var.