### PR TITLE
refactor(openchallenges): overideable config-server spring import config

### DIFF
--- a/apps/openchallenges/service-registry/src/main/resources/application.yml
+++ b/apps/openchallenges/service-registry/src/main/resources/application.yml
@@ -4,7 +4,8 @@ spring:
   profiles:
     active: dev,local
   config:
-    import: 'configserver:http://openchallenges-config-server:8090'
+    confighost: http://openchallenges-config-server:8090
+    import: configserver:${confighost}
   cloud:
     config:
       username: openchallenges


### PR DESCRIPTION
spring boot [issue
3346](https://github.com/spring-projects/spring-boot/issues/33446) says it's not possible to override Spring Import with SPRING_CONFIG_IMPORT env var.  The suggestion is to use confighost instead which can be overriden with a CONFIGHOST env var.