### PR TITLE
refactor(openchallenges): allow DB connection from other hosts

### DIFF
--- a/apps/openchallenges/mariadb/Dockerfile
+++ b/apps/openchallenges/mariadb/Dockerfile
@@ -1,5 +1,6 @@
 FROM mariadb:10.9.3
 
 COPY docker-healthcheck /usr/local/bin/
+COPY my.cnf /etc/
 
 HEALTHCHECK CMD ["docker-healthcheck"]

--- a/apps/openchallenges/mariadb/docker-entrypoint-initdb.d/init-db.sql
+++ b/apps/openchallenges/mariadb/docker-entrypoint-initdb.d/init-db.sql
@@ -37,3 +37,8 @@ grant all privileges on edam.* to 'edam_etl';
 -- create user 'mysqld-exporter' identified by 'changeme' with max_user_connections 3;;
 -- grant process, slave monitor on *.* to 'mysqld-exporter';
 -- grant select on performance_schema.* to 'mysqld-exporter';
+
+
+-- Allow access from other hosts
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'0.0.0.0' IDENTIFIED BY 'changeme' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON *.* TO 'maria'@'0.0.0.0' IDENTIFIED BY 'changeme' WITH GRANT OPTION;

--- a/apps/openchallenges/mariadb/my.cnf
+++ b/apps/openchallenges/mariadb/my.cnf
@@ -1,0 +1,39 @@
+# The MariaDB configuration file
+#
+# The MariaDB/MySQL tools read configuration files in the following order:
+# 0. "/etc/mysql/my.cnf" symlinks to this file, reason why all the rest is read.
+# 1. "/etc/mysql/mariadb.cnf" (this file) to set global defaults,
+# 2. "/etc/mysql/conf.d/*.cnf" to set global options.
+# 3. "/etc/mysql/mariadb.conf.d/*.cnf" to set MariaDB-only options.
+# 4. "~/.my.cnf" to set user-specific options.
+#
+# If the same option is defined multiple times, the last one will apply.
+#
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# If you are new to MariaDB, check out https://mariadb.com/kb/en/basic-mariadb-articles/
+
+#
+# This group is read both by the client and the server
+# use it for options that affect everything
+#
+[client-server]
+# Port or socket location where to connect
+# port = 3306
+socket = /run/mysqld/mysqld.sock
+
+# Import all .cnf files from configuration directory
+[mariadbd]
+skip-host-cache
+skip-name-resolve
+
+!includedir /etc/mysql/mariadb.conf.d/
+!includedir /etc/mysql/conf.d/
+
+# https://mariadb.com/kb/en/configuring-mariadb-for-remote-client-access/
+skip-networking=0
+skip-bind-address
+
+


### PR DESCRIPTION
The current MariaDb configurations does not allow remote hosts to access the DB. Now that we are deploying with AWS ECS we need to allow remote hosts to connect to the DB[1] which can be running in a different VPC subnet.  This change should allow that to happen.

[1] https://mariadb.com/kb/en/configuring-mariadb-for-remote-client-access/