### PR TITLE
fix(agora): tag agora-data image with data release version when publishing to GHCR

### DIFF
--- a/apps/agora/data/project.json
+++ b/apps/agora/data/project.json
@@ -53,7 +53,7 @@
         "context": "{projectRoot}",
         "metadata": {
           "images": ["ghcr.io/sage-bionetworks/{projectName}"],
-          "tags": ["type=edge,branch=main", "type=sha"]
+          "tags": ["type=edge,branch=main", "type=sha", "type=raw,value=$DATA_FILE.$DATA_VERSION"]
         },
         "push": true
       },


### PR DESCRIPTION
## Description

Tags `agora-data` image with data release version when publishing to GHCR

## Related Issue

Related to #2732

## Changelog

- Tags `agora-data` image with data release version when publishing to GHCR
