### PR TITLE
chore(sage-monorepo): disable Nx remote cache

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,7 @@
 {
   "tasksRunnerOptions": {
     "default": {
+      "runner": "nx/tasks-runners/default",
       "options": {
         "canTrackAnalytics": false,
         "showUsageWarnings": true,

--- a/nx.json
+++ b/nx.json
@@ -119,5 +119,6 @@
     ]
   },
   "useInferencePlugins": false,
-  "defaultBase": "main"
+  "defaultBase": "main",
+  "packageManager": "pnpm"
 }


### PR DESCRIPTION
The remote cache was generated when using Yarn. We are now using pnpm and the remote cache leads to errors, so we should no longer rely on it for now. Here I'm disabling the remote cache until I figure out how to clear the remote cache or decide to create a new workspace if clearing the remote cache is not possible as I believe.

## Changelog

- Disable Nx remote cache
- Tell Nx that the package manager is pnpm