### PR TITLE
fix(agora): build `agora-api` app as standalone app

### DIFF
--- a/apps/agora/api/Dockerfile
+++ b/apps/agora/api/Dockerfile
@@ -10,7 +10,6 @@ RUN chmod +x docker-entrypoint.sh
 
 WORKDIR ${APP_DIR}
 COPY dist/apps/agora/api ${APP_DIR}
-# RUN npm install
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=20 --start-period=5s \
   CMD curl --fail --silent "localhost:3333/health" | jq '.status' | grep UP || exit 1

--- a/apps/agora/api/Dockerfile
+++ b/apps/agora/api/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod +x docker-entrypoint.sh
 
 WORKDIR ${APP_DIR}
 COPY dist/apps/agora/api ${APP_DIR}
-RUN npm install
+# RUN npm install
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=20 --start-period=5s \
   CMD curl --fail --silent "localhost:3333/health" | jq '.status' | grep UP || exit 1

--- a/apps/agora/api/project.json
+++ b/apps/agora/api/project.json
@@ -13,9 +13,7 @@
     },
     "build": {
       "executor": "@nx/webpack:webpack",
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
         "target": "node",
@@ -23,11 +21,9 @@
         "outputPath": "dist/apps/agora/api",
         "main": "apps/agora/api/src/main.ts",
         "tsConfig": "apps/agora/api/tsconfig.app.json",
-        "assets": [
-          "apps/agora/api/src/assets"
-        ],
+        "assets": ["apps/agora/api/src/assets"],
         "webpackConfig": "apps/agora/api/webpack.config.js",
-        "generatePackageJson": true
+        "externalDependencies": []
       },
       "configurations": {
         "development": {},
@@ -69,39 +65,24 @@
       "options": {
         "context": ".",
         "metadata": {
-          "images": [
-            "ghcr.io/sage-bionetworks/agora-api"
-          ],
-          "tags": [
-            "type=edge,branch=main",
-            "type=raw,value=local",
-            "type=sha"
-          ]
+          "images": ["ghcr.io/sage-bionetworks/agora-api"],
+          "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
         },
         "push": false
       },
-      "dependsOn": [
-        "build"
-      ]
+      "dependsOn": ["build"]
     },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {
         "context": ".",
         "metadata": {
-          "images": [
-            "ghcr.io/sage-bionetworks/agora-api"
-          ],
-          "tags": [
-            "type=edge,branch=main",
-            "type=sha"
-          ]
+          "images": ["ghcr.io/sage-bionetworks/agora-api"],
+          "tags": ["type=edge,branch=main", "type=sha"]
         },
         "push": true
       },
-      "dependsOn": [
-        "build-image"
-      ]
+      "dependsOn": ["build-image"]
     },
     "scan-image": {
       "executor": "nx:run-commands",
@@ -112,9 +93,7 @@
     },
     "test": {
       "executor": "@nx/jest:jest",
-      "outputs": [
-        "{workspaceRoot}/coverage/{projectRoot}"
-      ],
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "apps/agora/api/jest.config.ts"
       }


### PR DESCRIPTION
Fixes #2773

## Changelog

- Bundle the dependencies with the `agora-api` app
- Fix the task `agora-api:build:production` (see successful CI workflow run below)

## Notes

Building the app will generate several warnings. Despite the "error", those are still warnings and the command exit status is successful (0).

```console
$ nx run agora-api:build:production

...
WARNING in ../../../node_modules/.pnpm/mongodb@6.7.0_socks@2.8.3/node_modules/mongodb/lib/deps.js 45:35-75
Module not found: Error: Can't resolve '@aws-sdk/credential-providers' in '/workspaces/sage-monorepo/node_modules/.pnpm/mongodb@6.7.0_socks@2.8.3/node_modules/mongodb/lib'

WARNING in ../../../node_modules/.pnpm/mongodb@6.7.0_socks@2.8.3/node_modules/mongodb/lib/deps.js 57:35-58
Module not found: Error: Can't resolve 'gcp-metadata' in '/workspaces/sage-monorepo/node_modules/.pnpm/mongodb@6.7.0_socks@2.8.3/node_modules/mongodb/lib'

WARNING in ../../../node_modules/.pnpm/mongodb@6.7.0_socks@2.8.3/node_modules/mongodb/lib/deps.js 69:22-39
Module not found: Error: Can't resolve 'snappy' in '/workspaces/sage-monorepo/node_modules/.pnpm/mongodb@6.7.0_socks@2.8.3/node_modules/mongodb/lib'
```

These warnings (there are more warning that are related to other libraries) occur because the MongoDB library you're using has optional dependencies that are not installed in your project. These are usually dependencies that MongoDB can optionally use for certain features, such as AWS credential providers, Google Cloud Platform metadata, and the snappy compression library. Since these are optional, MongoDB does not require them for basic operation, but Webpack is warning you that it cannot find these modules.

Despite these warnings, the app works fine.

```console
$ nx build-image agora-api
$ nx serve-detach agora-api

# OR

$ nx serve agora-api
```

Check:

```
$ curl 'http://localhost:3333/v1/dataversion'
{"_id":"66ce25afebad76c9018e119e","data_file":"syn13363290","data_version":"68","team_images_id":"syn12861877"}
```