### PR TITLE
fix(sage-monorepo): keep only the root workspace as pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - 'apps/**'
   - 'libs/**'
+  - '!apps/openchallenges/infra'
+  - '!apps/openchallenges/infra/old'
   # prevent the creation of libs/**/api-client-angular/node_modules when running `workspace-install`
   # that break the apps and tests
   - '!libs/**/api-client-angular'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - 'apps/**'
   - 'libs/**'
+  # prevent the creation of libs/**/api-client-angular/node_modules that break the apps and tests
+  - '!libs/**/api-client-angular'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'apps/**'
   - 'libs/**'
-  # prevent the creation of libs/**/api-client-angular/node_modules that break the apps and tests
+  # prevent the creation of libs/**/api-client-angular/node_modules when running `workspace-install`
+  # that break the apps and tests
   - '!libs/**/api-client-angular'


### PR DESCRIPTION
## Changelog

- Exclude API clients for Angular from pnpm workspaces

## Preview

Remaining workspaces:

```console
$ pnpm m ls --depth -1 --json
[
  {
    "name": "sage-monorepo",
    "version": "0.0.0",
    "path": "/workspaces/sage-monorepo",
    "private": true
  }
]
```