### PR TITLE
fix(sage-monorepo): publish a new dev container with valid GitHub CLI GPG key

### DIFF
--- a/tools/devcontainers/sage/.devcontainer/devcontainer.json
+++ b/tools/devcontainers/sage/.devcontainer/devcontainer.json
@@ -9,8 +9,5 @@
   },
   "remoteUser": "vscode",
   "shutdownAction": "stopContainer",
-  "runArgs": [
-    "--name",
-    "sage_devcontainer_test"
-  ]
+  "runArgs": ["--name", "sage_devcontainer_test"]
 }


### PR DESCRIPTION
Contributes to #2794

## Notes

- Touch the definition of the dev container to trigger a rebuild with the new GitHub CLI GPG key
- It is expected that the CI/CD workflow will fail because the dev container image it uses is affected by the issue we are fixing here.