### PR TITLE
fix(sage-monorepo): remove `lib/` from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
## Description

While Python projects may want to ignore this folder, we create new TypeScript projects that may have such a folder as part of the codebase. Hence, removing `lib/` from the root `.gitignore`. 

## References

- https://github.com/github/gitignore/blob/main/Python.gitignore