### PR TITLE
feat(sage-monorepo): add `on.merge_group` to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
       - main
       - 'renovate/**'
   pull_request:
+  merge_group:
 
 env:
   NX_BRANCH: ${{ github.event.number }}


### PR DESCRIPTION
[Triggering merge group checks with GitHub Actions](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)