### PR TITLE
docs(sage-monorepo): add MODEL-AD to the list of products

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  merge_group:
 
 permissions:
   pull-requests: read

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Join the conversation and help the community.
 
 - Agora (evaluation)
 - iAtlas
+- MODEL-AD
 - OpenChallenge
 - Schematic
 - Synapse (evaluation)


### PR DESCRIPTION
## Changelog

- Add MODEL-AD to the list of products developed in this monorepo

> [!NOTE]  
> This PR is the first one opened since enabling on the merging queue.