### PR TITLE
fix(sage-monorepo): prevent the PR validation workflow to run in the merge queue

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   main:
     name: Validate PR title
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
## References

- #2825 
- https://github.com/amannn/action-semantic-pull-request/issues/236