### PR TITLE
feat(sage-monorepo): lint staged Dockerfiles with Hadolint (ARCH-278)

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,9 +1,9 @@
 ignored:
-  # Pin versions in apt-get install.
+  # Pin versions in `apt-get install`.
   # Reason: Identifying the versions of apt packages is not trivial. The versions available would
   # also differ for different base images. This decision should be re-evaluated periodically.
   - DL3008
-  # Pin versions in apt get install.
+  # Pin versions in `apk add`.
   # Reason: Identifying the versions of apk packages is not trivial. The versions available would
   # also differ for different base images. This decision should be re-evaluated periodically.
   - DL3018

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -19,4 +19,9 @@ module.exports = {
     // Lint the projects affected by the staged files
     `nx affected --target=lint --files=${filenames.join(',')}`,
   ],
+
+  '**/*[dD]ockerfile*': (filenames) => [
+    // Lint Dockerfiles with Hadolint
+    `hadolint ${filenames.join(' ')}`,
+  ],
 };

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -107,7 +107,7 @@ RUN curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${trivy
 # Install act
 RUN curl -fsSL "https://raw.githubusercontent.com/nektos/act/v${actVersion}/install.sh" | bash -
 
-# Install AWS CLI2
+# Install AWS CLI
 RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
   && unzip awscliv2.zip \
   && ./aws/install \

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -43,7 +43,6 @@ ENV DEVCONTAINER_VERSION=${devcontainerVersion} \
   LC_ALL=en_US.UTF-8
 
 # Install system packages
-# hadolint ignore=DL3008
 RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && apt-get install --no-install-recommends -qq -y \
     ca-certificates curl git bash-completion gnupg2 lsb-release ssh sudo \

--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -107,7 +107,7 @@ RUN curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${trivy
 # Install act
 RUN curl -fsSL "https://raw.githubusercontent.com/nektos/act/v${actVersion}/install.sh" | bash -
 
-# Install AWS CLI
+# Install AWS CLI2
 RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
   && unzip awscliv2.zip \
   && ./aws/install \


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/ARCH-278

## Changelog

- Configure `lint-staged` to lint staged Dockerfiles with Hadolint
- Remove a rule exception from the dev container Dockerfile
- Update a comment Hadolint config file

## Preview

![image](https://github.com/user-attachments/assets/8b2ad95b-446d-47e7-a6d2-ab54e3074cfb)
