### PR TITLE
chore(schematic): validate Schematic OpenAPI description using workspace-level configuration (FDS-2435)

### DIFF
--- a/libs/schematic/api-description/project.json
+++ b/libs/schematic/api-description/project.json
@@ -8,15 +8,13 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": ["redocly bundle --output build/openapi.yaml src/openapi.yaml"],
-        "parallel": true,
         "cwd": "{projectRoot}"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "lint-openapi --config openapi-lint-config.yaml --ruleset spectral.yaml build/openapi.yaml",
-        "cwd": "{projectRoot}"
+        "command": "lint-openapi --config tools/ibm-openapi-validator/config.yaml {projectRoot}/build/openapi.yaml"
       },
       "dependsOn": ["build"]
     },

--- a/libs/schematic/api-description/spectral.yaml
+++ b/libs/schematic/api-description/spectral.yaml
@@ -1,8 +1,0 @@
-extends: '@ibm-cloud/openapi-ruleset'
-rules:
-  ibm-accept-and-return-models: off
-  ibm-enum-casing-convention: off
-  ibm-parameter-casing-convention: off
-  ibm-path-segment-casing-convention: off
-  ibm-property-casing-convention: off
-  ibm-operation-summary-length: warn


### PR DESCRIPTION
## Changelog

- Validate Schematic OpenAPI description using workspace-level configuration
- Remove the local config of the validator from `schematic-api-description`

## Configuration

The workspace-level configuration and ruleset of the OpenAPI validator can be found here:

- `tools/ibm-openapi-validator/config.yaml`
- `tools/ibm-openapi-validator/spectral.yaml` (ruleset)

## Preview

```console
$ nx lint schematic-api-description

> nx run schematic-api-description:build

> redocly bundle --output build/openapi.yaml src/openapi.yaml

bundling src/openapi.yaml...
📦 Created a bundle for src/openapi.yaml at build/openapi.yaml 335ms.

> nx run schematic-api-description:lint

> lint-openapi --config tools/ibm-openapi-validator/config.yaml libs/schematic/api-description/build/openapi.yaml

IBM OpenAPI Validator (validator: 1.22.1), @Copyright IBM Corporation 2017, 2024.

Validation Results for libs/schematic/api-description/build/openapi.yaml:


libs/schematic/api-description/build/openapi.yaml passed the validator
```