### PR TITLE
chore(model-ad): validate MODEL-AD OpenAPI description using workspace-level configuration 

### DIFF
--- a/libs/agora/api-description/openapi-lint-config.yaml
+++ b/libs/agora/api-description/openapi-lint-config.yaml
@@ -1,4 +1,0 @@
-errorsOnly: true
-summaryOnly: false
-limits:
-  warnings: 25

--- a/libs/model-ad/api-description/openapi-lint-config.yaml
+++ b/libs/model-ad/api-description/openapi-lint-config.yaml
@@ -1,4 +1,0 @@
-errorsOnly: true
-summaryOnly: false
-limits:
-  warnings: 25

--- a/libs/model-ad/api-description/project.json
+++ b/libs/model-ad/api-description/project.json
@@ -14,8 +14,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "lint-openapi --config openapi-lint-config.yaml --ruleset spectral.yaml build/openapi.yaml",
-        "cwd": "{projectRoot}"
+        "command": "lint-openapi --config tools/ibm-openapi-validator/config.yaml {projectRoot}/build/openapi.yaml"
       },
       "dependsOn": ["build"]
     },

--- a/libs/model-ad/api-description/spectral.yaml
+++ b/libs/model-ad/api-description/spectral.yaml
@@ -1,8 +1,0 @@
-extends: '@ibm-cloud/openapi-ruleset'
-rules:
-  ibm-accept-and-return-models: off
-  ibm-enum-casing-convention: off
-  ibm-parameter-casing-convention: off
-  ibm-path-segment-casing-convention: off
-  ibm-property-casing-convention: off
-  ibm-operation-summary-length: warn


### PR DESCRIPTION
## Changelog

- Validate MODEL-AD OpenAPI description using workspace-level configuration
- Remove the local config of the validator from `model-ad-api-description`

## Configuration

The workspace-level configuration and ruleset of the OpenAPI validator can be found here:

- `tools/ibm-openapi-validator/config.yaml`
- `tools/ibm-openapi-validator/spectral.yaml` (ruleset)

## Preview

```console
$ nx lint model-ad-api-description

> nx run model-ad-api-description:build

> redocly bundle --output build/openapi.yaml src/openapi.yaml

bundling src/openapi.yaml...
📦 Created a bundle for src/openapi.yaml at build/openapi.yaml 44ms.

> nx run model-ad-api-description:lint

> lint-openapi --config tools/ibm-openapi-validator/config.yaml libs/model-ad/api-description/build/openapi.yaml

IBM OpenAPI Validator (validator: 1.22.1), @Copyright IBM Corporation 2017, 2024.

Validation Results for libs/model-ad/api-description/build/openapi.yaml:


libs/model-ad/api-description/build/openapi.yaml passed the validator
```