### PR TITLE
feat(sage-monorepo): adopt JS for definining OAS validation ruleset

### DIFF
--- a/libs/agora/api-description/project.json
+++ b/libs/agora/api-description/project.json
@@ -14,8 +14,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "lint-openapi --config openapi-lint-config.yaml --ruleset spectral.yaml build/openapi.yaml",
-        "cwd": "{projectRoot}"
+        "command": "lint-openapi --config tools/ibm-openapi-validator/config.yaml {projectRoot}/build/openapi.yaml"
       },
       "dependsOn": ["build"]
     },

--- a/libs/agora/api-description/spectral.yaml
+++ b/libs/agora/api-description/spectral.yaml
@@ -1,8 +1,0 @@
-extends: '@ibm-cloud/openapi-ruleset'
-rules:
-  ibm-accept-and-return-models: off
-  ibm-enum-casing-convention: off
-  ibm-parameter-casing-convention: off
-  ibm-path-segment-casing-convention: off
-  ibm-property-casing-convention: off
-  ibm-operation-summary-length: warn

--- a/tools/ibm-openapi-validator/.spectral.js
+++ b/tools/ibm-openapi-validator/.spectral.js
@@ -1,0 +1,28 @@
+const ibmCloudValidationRules = require('@ibm-cloud/openapi-ruleset');
+const { propertyCasingConvention } = require('@ibm-cloud/openapi-ruleset/src/functions');
+const { schemas } = require('@ibm-cloud/openapi-ruleset-utilities/src/collections');
+
+module.exports = {
+  extends: ibmCloudValidationRules,
+  rules: {
+    'ibm-accept-and-return-models': 'off',
+    'ibm-enum-casing-convention': 'off',
+    'ibm-operation-summary-length': 'warn',
+    'ibm-parameter-casing-convention': 'off',
+    'ibm-path-segment-casing-convention': 'off',
+    'ibm-property-casing-convention': 'off',
+    // 'ibm-path-segment-casing-convention': {
+    //   description: 'Path segments must follow camel case',
+    //   message: '{{error}}',
+    //   resolved: true,
+    //   given: schemas,
+    //   severity: 'warn',
+    //   then: {
+    //     function: propertyCasingConvention,
+    //     functionOptions: {
+    //       type: 'camel',
+    //     },
+    //   },
+    // },
+  },
+};

--- a/tools/ibm-openapi-validator/config.yaml
+++ b/tools/ibm-openapi-validator/config.yaml
@@ -4,4 +4,4 @@ limits:
   warnings: 25
 # This path to the spectral config file assumes that the validator's current working directory is
 # set to the workspace root folder.
-ruleset: tools/ibm-openapi-validator/spectral.yaml
+ruleset: tools/ibm-openapi-validator/.spectral.js

--- a/tools/ibm-openapi-validator/spectral.yaml
+++ b/tools/ibm-openapi-validator/spectral.yaml
@@ -1,8 +1,0 @@
-extends: '@ibm-cloud/openapi-ruleset'
-rules:
-  ibm-accept-and-return-models: off
-  ibm-enum-casing-convention: off
-  ibm-parameter-casing-convention: off
-  ibm-path-segment-casing-convention: off
-  ibm-property-casing-convention: off
-  ibm-operation-summary-length: warn


### PR DESCRIPTION
## Description

Switch OAS validation ruleset from YAML to JS. This will enable us to further customize rules beyond just setting them to `off` and `level`. For example, we will be able to specify that path segments should be camel case with a level set to warn, then later error.

## Changelog

- Switch OAS validation ruleset from YAML to JS
- Update the task `agora-api-description:lint` to use the monorepo-wide OAS validation config