### PR TITLE
chore(sage-monorepo): remove Pyright VS Code extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,6 @@
         "mhutchie.git-graph",
         "mongodb.mongodb-vscode",
         "ms-playwright.playwright",
-        "ms-pyright.pyright",
         "ms-python.black-formatter",
         "ms-python.python",
         "ms-toolsai.jupyter",


### PR DESCRIPTION
About Pyright VS Code extension:

> For most VS Code users, we recommend using the Pylance extension rather than Pyright. Pylance incorporates the Pyright type checker but features additional capabilities such as semantic token highlighting and symbol indexing. When Pylance is installed, the Pyright extension will disable itself.

## References

- https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright
