### PR TITLE
fix(sage-monorepo): fix `schematic-api:build-image` issue by using a non-moving tag (FDS-2453)

### DIFF
--- a/apps/schematic/api/Dockerfile
+++ b/apps/schematic/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.10
+FROM tiangolo/uwsgi-nginx-flask:python3.10-2024-09-16
 
 # add label
 LABEL org.opencontainers.image.authors='Milen Nikolov <milen.nikolov@sagebase.org>, Andrew Lamb <andrew.lamb@sagebase.org>, Mialy DeFelice <mialy.defelice@sagebase.org>, Gianna Jordan <gianna.jordan@sagebase.org>, Lingling Peng <lingling.peng@sagebase.org>'


### PR DESCRIPTION
Fixes https://sagebionetworks.jira.com/browse/FDS-2453

## Description

The task `schematic-api:build-image` failed 3-4 hours ago. I realized that this is because 1) the base image has been updated around that time and 2) the project is using a moving tag (`python3.10`).

The underlying issue seems to be that the base image comes with a newer version of Python (3.10.15) not compatible with the version specified by the project (3.10.14). Ideally, we should be able to specify the version of Python to use in the Dockerfile, e.g. using pyenv. This would provide some flexibility so that the version used by the project is not imposed by the Python version running in the Docker image. For instance, it's preferable to use one of the Python version pre-installed in the Sage monorepo dev container for running tasks faster locally and in the CI workflow.

![image](https://github.com/user-attachments/assets/d33fee84-fdc7-486a-9f0d-6cc37721aacb)

## Changelog

- Specify a non-moving tag for the base Docker image of `schematic-api`

Cc: @andrewelamb @linglp 