### PR TITLE
feat(sandbox): create the `sandox-angular-lib` project (ARCH-285)

### DIFF
--- a/apps/sandbox/angular-app/src/app/app.component.html
+++ b/apps/sandbox/angular-app/src/app/app.component.html
@@ -1,1 +1,3 @@
-<app-nx-welcome></app-nx-welcome> <router-outlet></router-outlet>
+<app-nx-welcome></app-nx-welcome>
+<sandbox-angular-lib></sandbox-angular-lib>
+<router-outlet></router-outlet>

--- a/apps/sandbox/angular-app/src/app/app.component.ts
+++ b/apps/sandbox/angular-app/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { NxWelcomeComponent } from './nx-welcome.component';
-import { SandboxAngularLibComponent } from 'sandbox-angular-lib';
+import { SandboxAngularLibComponent } from '@sagebionetworks/sandbox-angular-lib';
 
 @Component({
   standalone: true,

--- a/apps/sandbox/angular-app/src/app/app.component.ts
+++ b/apps/sandbox/angular-app/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { NxWelcomeComponent } from './nx-welcome.component';
+import { SandboxAngularLibComponent } from 'sandbox-angular-lib';
 
 @Component({
   standalone: true,
-  imports: [NxWelcomeComponent, RouterModule],
+  imports: [NxWelcomeComponent, RouterModule, SandboxAngularLibComponent],
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',

--- a/libs/sandbox/angular-lib/.eslintrc.json
+++ b/libs/sandbox/angular-lib/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "lib",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "lib",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/sandbox/angular-lib/.eslintrc.json
+++ b/libs/sandbox/angular-lib/.eslintrc.json
@@ -10,7 +10,7 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "lib",
+            "prefix": "sandbox",
             "style": "camelCase"
           }
         ],
@@ -18,7 +18,7 @@
           "error",
           {
             "type": "element",
-            "prefix": "lib",
+            "prefix": "sandbox",
             "style": "kebab-case"
           }
         ]

--- a/libs/sandbox/angular-lib/README.md
+++ b/libs/sandbox/angular-lib/README.md
@@ -1,0 +1,7 @@
+# sandbox-angular-lib
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test sandbox-angular-lib` to execute the unit tests.

--- a/libs/sandbox/angular-lib/jest.config.ts
+++ b/libs/sandbox/angular-lib/jest.config.ts
@@ -1,0 +1,21 @@
+export default {
+  displayName: 'sandbox-angular-lib',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../coverage/libs/sandbox/angular-lib',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/sandbox/angular-lib/project.json
+++ b/libs/sandbox/angular-lib/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "sandbox-angular-lib",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/sandbox/angular-lib/src",
+  "prefix": "lib",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/sandbox/angular-lib/jest.config.ts"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/sandbox/angular-lib/src/index.ts
+++ b/libs/sandbox/angular-lib/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/sandbox-angular-lib/sandbox-angular-lib.component';

--- a/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.html
+++ b/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.html
@@ -1,0 +1,1 @@
+<p>sandbox-angular-lib works!</p>

--- a/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.spec.ts
+++ b/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SandboxAngularLibComponent } from './sandbox-angular-lib.component';
+
+describe('SandboxAngularLibComponent', () => {
+  let component: SandboxAngularLibComponent;
+  let fixture: ComponentFixture<SandboxAngularLibComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SandboxAngularLibComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SandboxAngularLibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.ts
+++ b/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
-  selector: 'lib-sandbox-angular-lib',
+  selector: 'sandbox-angular-lib',
   standalone: true,
   imports: [CommonModule],
   templateUrl: './sandbox-angular-lib.component.html',

--- a/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.ts
+++ b/libs/sandbox/angular-lib/src/lib/sandbox-angular-lib/sandbox-angular-lib.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'lib-sandbox-angular-lib',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './sandbox-angular-lib.component.html',
+  styleUrl: './sandbox-angular-lib.component.css',
+})
+export class SandboxAngularLibComponent {}

--- a/libs/sandbox/angular-lib/src/test-setup.ts
+++ b/libs/sandbox/angular-lib/src/test-setup.ts
@@ -1,0 +1,8 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+import 'jest-preset-angular/setup-jest';

--- a/libs/sandbox/angular-lib/tsconfig.json
+++ b/libs/sandbox/angular-lib/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/sandbox/angular-lib/tsconfig.lib.json
+++ b/libs/sandbox/angular-lib/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/**/*.spec.ts", "src/test-setup.ts", "jest.config.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/sandbox/angular-lib/tsconfig.spec.json
+++ b/libs/sandbox/angular-lib/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -68,7 +68,8 @@
       "@sagebionetworks/shared/util": ["libs/shared/typescript/util/src/index.ts"],
       "@sagebionetworks/shared/web-components": [
         "libs/shared/typescript/web-components/src/index.ts"
-      ]
+      ],
+      "sandbox-angular-lib": ["libs/sandbox/angular-lib/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -69,7 +69,7 @@
       "@sagebionetworks/shared/web-components": [
         "libs/shared/typescript/web-components/src/index.ts"
       ],
-      "sandbox-angular-lib": ["libs/sandbox/angular-lib/src/index.ts"]
+      "@sagebionetworks/sandbox-angular-lib": ["libs/sandbox/angular-lib/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/ARCH-285

## Changelog

- Add the `sandbox-angular-lib` project
- Import the single component from the lib into `sandbox-angular-app`

## References

- https://nx.dev/nx-api/angular/generators/library
- #2843

## Preview

### Create the library

```console
nx g @nx/angular:library sandbox-angular-lib \
  --directory libs/sandbox/angular-lib \
  --prefix sandbox \
  --projectNameAndRootFormat as-provided \
  --dry-run
```

Then, I prefixed the key for this project with `@sagebionetworks/` in `tsconfig.base.json` located in the root folder. This enables to import the library as `@sagebionetworks/sandbox-angular-lib`.

### Serve the app

```console
nx serve sandbox-angular-app
```

![image](https://github.com/user-attachments/assets/8e476b50-a702-4844-9732-5fa74aa95e9e)
