### PR TITLE
chore(sage-monorepo): update API docs image to `redocly/redoc:v2.1.5`

### DIFF
--- a/apps/agora/api-docs/Dockerfile
+++ b/apps/agora/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.0.0
+FROM redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8010" || exit 1

--- a/apps/model-ad/api-docs/Dockerfile
+++ b/apps/model-ad/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.0.0
+FROM redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8010" || exit 1

--- a/apps/openchallenges/api-docs/Dockerfile
+++ b/apps/openchallenges/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.0.0
+FROM redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8010" || exit 1

--- a/apps/schematic/api-docs/Dockerfile
+++ b/apps/schematic/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.0.0
+FROM redocly/redoc:v2.1.5
 
 COPY build/redoc-static.html /usr/share/nginx/html/index.html
 # COPY favicon.ico /usr/share/nginx/html/


### PR DESCRIPTION
## Notes

I had a look at all the API docs sites and they look good.