### PR TITLE
feat(sage-monorepo): add the Tailwind CSS plugin for Prettier to ensure consistent formatting in our styles (ARCH-294)

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -3,3 +3,4 @@ printWidth: 100
 singleQuote: true
 plugins:
   - prettier-plugin-java
+  - prettier-plugin-tailwindcss

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "postcss-url": "^10.1.3",
     "prettier": "3.3.3",
     "prettier-plugin-java": "2.6.4",
+    "prettier-plugin-tailwindcss": "0.6.8",
     "primeicons": "7.0.0",
     "primeng": "17.18.8",
     "pyright": "1.1.381",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,9 @@ importers:
       prettier-plugin-java:
         specifier: 2.6.4
         version: 2.6.4
+      prettier-plugin-tailwindcss:
+        specifier: 0.6.8
+        version: 0.6.8(prettier@3.3.3)
       primeicons:
         specifier: 7.0.0
         version: 7.0.0
@@ -10231,6 +10234,61 @@ packages:
   prettier-plugin-java@2.6.4:
     resolution: {integrity: sha512-57iGIFM4xSCqzHc4G6RLeC0DJk+i6Vd1JDj5xcIe7GsWZjRSl8WWkpL0f4BB0gZ+jDZ8R1uJaxtnMgnRtzjLDQ==}
 
+  prettier-plugin-tailwindcss@0.6.8:
+    resolution: {integrity: sha512-dGu3kdm7SXPkiW4nzeWKCl3uoImdd5CTZEJGxyypEPL37Wj0HT2pLqjrvSei1nTeuQfO4PUfjeW5cTUNRLZ4sA==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig-melody': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig-melody':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -11952,8 +12010,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.0-dev.20240924:
-    resolution: {integrity: sha512-Ij5R6dGDoRwlwMv0YAF0DSKOp2gGIv0SZNybFpAm05zZ/tktjetR7IrwuurvRlDEz7v91AC3ehs2lF7lJ8F/QA==}
+  typescript@5.7.0-dev.20240926:
+    resolution: {integrity: sha512-urjGXo3L23oEcK2thBaZ71DdA6My+NeeTuNIUJfYszrplyk//HIgV1yl40S+eQcya4vwmH14dhDDDH4vl4dlng==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -21019,7 +21077,7 @@ snapshots:
     dependencies:
       semver: 7.6.2
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20240924
+      typescript: 5.7.0-dev.20240926
 
   duplexer@0.1.2: {}
 
@@ -26010,6 +26068,10 @@ snapshots:
       lodash: 4.17.21
       prettier: 3.2.5
 
+  prettier-plugin-tailwindcss@0.6.8(prettier@3.3.3):
+    dependencies:
+      prettier: 3.3.3
+
   prettier@2.8.8: {}
 
   prettier@3.2.5: {}
@@ -28092,7 +28154,7 @@ snapshots:
 
   typescript@5.5.4: {}
 
-  typescript@5.7.0-dev.20240924: {}
+  typescript@5.7.0-dev.20240926: {}
 
   ua-parser-js@1.0.38: {}
 


### PR DESCRIPTION
Contributes to https://sagebionetworks.jira.com/browse/ARCH-294

## Changelog

- Add the npm package `prettier-plugin-tailwindcss`

## Reference

- https://www.freecodecamp.org/news/how-to-set-up-eslint-prettier-stylelint-and-lint-staged-in-nextjs

## Preview

In `apps/sandbox/angular-app/src/app/nx-welcome.component.ts`, order the classes as shown below:

```html
<div id="learning-materials" class="shadow rounded">
```

Prettier is applied upon saving the file to order the classes in alphabetical order:

```html
<div id="learning-materials" class="rounded shadow">
```