### PR TITLE
fix(sage-monorepo): try again `semver` in the release workflow

### DIFF
--- a/apps/openchallenges/apex/project.json
+++ b/apps/openchallenges/apex/project.json
@@ -32,7 +32,7 @@
         "ci": {
           "metadata": {
             "images": ["ghcr.io/sage-bionetworks/{projectName}"],
-            "tags": ["type=raw,value=${VERSION}", "type=sha"]
+            "tags": ["type=semver,pattern={{version}},value=${VERSION}", "type=sha"]
           }
         }
       },


### PR DESCRIPTION
## Notes

- `metadata.images` must be specified in any configuration that defines `metadata.tags`