### PR TITLE
chore(sage-monorepo): disable pnpm cache in CI workflow to troubleshoot error

### DIFF
--- a/.github/actions/setup-dev-container/action.yml
+++ b/.github/actions/setup-dev-container/action.yml
@@ -3,13 +3,13 @@ description: 'Installs the dev container CLI, fetches caches (if exist), and sta
 runs:
   using: 'composite'
   steps:
-    - name: Set up pnpm cache
-      uses: actions/cache@v3
-      with:
-        path: '/tmp/.pnpm-store'
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+    # - name: Set up pnpm cache
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: '/tmp/.pnpm-store'
+    #     key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-pnpm-store-
 
     - name: Set up Renv cache
       uses: actions/cache@v3


### PR DESCRIPTION
This is an attempt at troubleshooting why the CI workflow fails in #2884