### PR TITLE
feat(agora): centralize the task definition `build-image` (ARCH-307)

### DIFF
--- a/apps/agora/apex/project.json
+++ b/apps/agora/apex/project.json
@@ -16,17 +16,6 @@
         "command": "docker/agora/serve-detach.sh agora-apex"
       }
     },
-    "build-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": "apps/agora/apex",
-        "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/agora-apex"],
-          "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
-        },
-        "push": false
-      }
-    },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {

--- a/apps/agora/api-docs/project.json
+++ b/apps/agora/api-docs/project.json
@@ -30,18 +30,6 @@
         "command": "docker/agora/serve-detach.sh agora-api-docs"
       }
     },
-    "build-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": "apps/agora/api-docs",
-        "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/agora-api-docs"],
-          "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
-        },
-        "push": false
-      },
-      "dependsOn": ["build"]
-    },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {

--- a/apps/agora/api/project.json
+++ b/apps/agora/api/project.json
@@ -60,18 +60,6 @@
         "fix": true
       }
     },
-    "build-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": ".",
-        "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/agora-api"],
-          "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
-        },
-        "push": false
-      },
-      "dependsOn": ["build"]
-    },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {

--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -156,18 +156,6 @@
       },
       "defaultConfiguration": "development"
     },
-    "build-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": ".",
-        "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/agora-app"],
-          "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
-        },
-        "push": false
-      },
-      "dependsOn": ["server"]
-    },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {

--- a/apps/agora/data/project.json
+++ b/apps/agora/data/project.json
@@ -31,22 +31,6 @@
         "command": "docker/agora/serve-detach.sh {projectName}"
       }
     },
-    "build-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": "{projectRoot}",
-        "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/{projectName}"],
-          "tags": [
-            "type=edge,branch=main",
-            "type=raw,value=local",
-            "type=sha",
-            "type=raw,value=$DATA_FILE.$DATA_VERSION"
-          ]
-        },
-        "push": false
-      }
-    },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {

--- a/apps/agora/mongo/project.json
+++ b/apps/agora/mongo/project.json
@@ -18,17 +18,6 @@
         "command": "docker/agora/serve-detach.sh {projectName}"
       }
     },
-    "build-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": "apps/agora/mongo",
-        "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/{projectName}"],
-          "tags": ["type=edge,branch=main", "type=raw,value=local", "type=sha"]
-        },
-        "push": false
-      }
-    },
     "publish-image": {
       "executor": "@nx-tools/nx-container:build",
       "options": {

--- a/libs/sage-monorepo/nx-plugin/src/plugins/plugin.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/plugin.ts
@@ -23,7 +23,7 @@ import { inferProjectMetadata } from './project-metadata';
 function readProjectCOnfigurationsCache(
   cachePath: string,
 ): Record<string, SageMonorepoProjectConfiguration> {
-  console.log(`cachePath: ${cachePath}`);
+  // console.log(`cachePath: ${cachePath}`);
   return existsSync(cachePath) ? readJsonFile(cachePath) : {};
 }
 
@@ -34,7 +34,7 @@ function writeProjectConfigurationsToCache(
   writeJsonFile(cachePath, results);
 }
 
-const projectFilePattern = '{apps,libs}/openchallenges/**/project.json';
+const projectFilePattern = '{apps,libs}/{openchallenges,agora}/**/project.json';
 
 export const createNodesV2: CreateNodesV2<SageMonorepoPluginOptions> = [
   projectFilePattern,

--- a/libs/sage-monorepo/nx-plugin/src/plugins/plugin.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/plugin.ts
@@ -20,7 +20,7 @@ import { buildProjectConfiguration } from './build-project-configuration';
 import { ProjectConfigurationBuilderOptions } from './project-configuration-builder-options';
 import { inferProjectMetadata } from './project-metadata';
 
-function readProjectCOnfigurationsCache(
+function readProjectConfigurationsCache(
   cachePath: string,
 ): Record<string, SageMonorepoProjectConfiguration> {
   // console.log(`cachePath: ${cachePath}`);
@@ -44,7 +44,7 @@ export const createNodesV2: CreateNodesV2<SageMonorepoPluginOptions> = [
 
     // Reads the cached targets for all the projects
     const cachePath = join(workspaceDataDirectory, `sage-monorepo-${optionsHash}.hash`);
-    const projectConfigurationsCache = readProjectCOnfigurationsCache(cachePath);
+    const projectConfigurationsCache = readProjectConfigurationsCache(cachePath);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) => {

--- a/libs/sage-monorepo/nx-plugin/src/plugins/project-metadata.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/project-metadata.ts
@@ -46,6 +46,7 @@ function inferProjectType(projectRoot: string): ProjectType {
   } else if (projectRoot.startsWith('libs/')) {
     return 'library';
   }
+
   throw new Error(`Unknown project type for project root: ${projectRoot}`);
 }
 
@@ -55,16 +56,19 @@ function inferBuilder(
 ): Builder | null {
   if (siblingFiles.includes('poetry.lock')) return 'poetry';
   if (siblingFiles.includes('build.gradle')) return 'gradle';
-  if (
-    localProjectConfiguration?.targets?.['build']?.executor ===
-    '@angular-devkit/build-angular:browser'
-  ) {
+
+  const executor = localProjectConfiguration?.targets?.['build']?.executor ?? '';
+  const webpackExecutors = ['@angular-devkit/build-angular:browser', '@nx/webpack:webpack'];
+
+  if (webpackExecutors.includes(executor)) {
     return 'webpack';
   }
+
   return null;
 }
 
 function inferContainerType(siblingFiles: string[]): ContainerType | null {
   if (siblingFiles.includes('Dockerfile')) return 'Docker';
+
   return null;
 }


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/ARCH-307

## Changelog

- Update the Nx plugin to support Agora apps
- Remove the task `build-image` from the `project.json` files

## Preview

The Agora apps can still be dockerized even if their `project.json` files no longer define the task `build-image`, which is now defined in the Sage Monorepo Nx plugin.

```console
$ agora-build-images
$ docker images
REPOSITORY                                TAG           IMAGE ID       CREATED          SIZE
ghcr.io/sage-bionetworks/agora-data       local         fa10d1fc58fb   5 seconds ago    219MB
ghcr.io/sage-bionetworks/agora-data       sha-f70dfb0   fa10d1fc58fb   5 seconds ago    219MB
ghcr.io/sage-bionetworks/agora-api        local         95eb65d77850   26 seconds ago   141MB
ghcr.io/sage-bionetworks/agora-api        sha-f70dfb0   95eb65d77850   26 seconds ago   141MB
ghcr.io/sage-bionetworks/agora-app        local         00c92e252e9b   31 seconds ago   203MB
ghcr.io/sage-bionetworks/agora-app        sha-f70dfb0   00c92e252e9b   31 seconds ago   203MB
ghcr.io/sage-bionetworks/agora-api-docs   local         a7c7cc7b2308   49 seconds ago   57.2MB
ghcr.io/sage-bionetworks/agora-api-docs   sha-f70dfb0   a7c7cc7b2308   49 seconds ago   57.2MB
ghcr.io/sage-bionetworks/agora-apex       local         ad4141811ecd   4 months ago     49.2MB
ghcr.io/sage-bionetworks/agora-apex       sha-f70dfb0   ad4141811ecd   4 months ago     49.2MB
ghcr.io/sage-bionetworks/agora-mongo      local         449de6550138   22 months ago    700MB
ghcr.io/sage-bionetworks/agora-mongo      sha-f70dfb0   449de6550138   22 months ago    700MB
```