### PR TITLE
feat(sage-monorepo): add VS Code extension to manage Python venvs (ARCH-314)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,7 @@
         "alefragnani.Bookmarks",
         "Angular.ng-template",
         "dbaeumer.vscode-eslint",
+        "donjayamanne.python-environment-manager",
         "dorzey.vscode-sqlfluff",
         "eamodio.gitlens",
         "emeraldwalk.RunOnSave",


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/ARCH-314

## Changelog

- Add the VS Code extension [Python Environment Manager](https://marketplace.visualstudio.com/items?itemName=donjayamanne.python-environment-manager) to the dev container

## Preview

The extension lists all the venvs created in the monorepo:

<img width="372" alt="image" src="https://github.com/user-attachments/assets/4af63387-e9e1-4893-8c34-dec7afd72307">

Other features:

1. **Single-click venv activation via ⭐ icon**:
   - **Feature Description**: The user can easily activate a virtual environment by clicking a star (⭐) icon associated with the environment, instead of navigating the VS Code command palette.
   - **Purpose**: This makes the process of selecting and activating a Python interpreter more user-friendly and quicker compared to using the command palette.

2. **Installed package list with version status**:
   - **Feature Description**: The extension displays a list of installed Python packages for the currently selected virtual environment, with warnings if new versions of packages are available.
   - **Purpose**: Helps users keep track of installed packages and ensures they can update outdated dependencies with ease.

3. **Display all installed Python versions**:
   - **Feature Description**: The extension lists all installed Python versions on the system. 
   - **Purpose**: This assists users in reviewing and minimizing the number of different Python versions installed, which can streamline the setup and reduce CI workflow runtimes.