### PR TITLE
fix(sage-monorepo): use ECR DB when scanning repo with Trivy

### DIFF
--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -19,6 +19,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
Same as #2904 but for the GH workflow that scans the repo with Trivy.