### PR TITLE
chore(sage-monorepo): enable the publication of Sage artifacts with semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'agora/v*'
       - 'openchallenges/v*'
+      - 'sage/v*'
 
 permissions:
   packages: write


### PR DESCRIPTION
## Changelog

- Enable the publication of Sage artifacts with semver tags.