### PR TITLE
fix(sage-monorepo): replace the task `publish-image` by `build-image` in CI worflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,12 @@ jobs:
       #     devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
       #       && nx affected --target=sonar"
 
-      - name: Publish the images of the affected projects
+      - name: Build and publish the images of the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && export VERSION=edge \
             && echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin \
-            && nx affected --target=publish-image"
+            && nx affected --target=build-image --configuration=ci"
 
       - name: Remove the dev container
         run: docker rm -f sage_devcontainer


### PR DESCRIPTION
Contributes to https://sagebionetworks.jira.com/browse/ARCH-336