### PR TITLE
fix(openchallenges): remove the task `openchallenges-thumbor:publish-image`

### DIFF
--- a/apps/openchallenges/thumbor/project.json
+++ b/apps/openchallenges/thumbor/project.json
@@ -17,18 +17,6 @@
         "command": "docker/openchallenges/serve-detach.sh openchallenges-thumbor"
       }
     },
-    "publish-image": {
-      "executor": "@nx-tools/nx-container:build",
-      "options": {
-        "context": "apps/openchallenges/thumbor",
-        "metadata": {
-          "images": ["ghcr.io/sage-bionetworks/openchallenges-thumbor"],
-          "tags": ["type=edge,branch=main", "type=sha"]
-        },
-        "push": true
-      },
-      "dependsOn": ["build-image"]
-    },
     "scan-image": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Contributes to https://sagebionetworks.jira.com/browse/ARCH-336

Test if the new `build-image` task used in the main CI workflow successfully push the image to GHCR.