### PR TITLE
chore(sage-monorepo): remove Nx custom task runner to avoid repeating deprecation warnings

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,15 +1,4 @@
 {
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx/tasks-runners/default",
-      "options": {
-        "canTrackAnalytics": false,
-        "showUsageWarnings": true,
-        "scan": true,
-        "cacheableOperations": ["build-storybook"]
-      }
-    }
-  },
   "generators": {
     "@nx/angular:application": {
       "e2eTestRunner": "cypress",


### PR DESCRIPTION
References:

- https://nx.dev/deprecated/legacy-cache
- https://github.com/nrwl/nx/issues/28434