### PR TITLE
feat(sage-monorepo): add AWS SAM CLI to the devcontainer (ARCH-350)

### DIFF
--- a/tools/devcontainers/sage/.devcontainer/Dockerfile
+++ b/tools/devcontainers/sage/.devcontainer/Dockerfile
@@ -117,6 +117,13 @@ RUN curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscl
   && dpkg -i /tmp/session-manager-plugin.deb \
   && rm -fr /tmp/session-manager-plugin.deb
 
+# Install AWS SAM CLI
+RUN curl -Lo aws-sam-cli-linux-x86_64.zip https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip \
+  && unzip aws-sam-cli-linux-x86_64.zip -d sam-installation \
+  && ./sam-installation/install \
+  && rm -rf aws-sam-cli-linux-x86_64.zip sam-installation \
+  && sam --version
+
 # Install the devcontainer CLI
 RUN npm install -g "@devcontainers/cli@${devcontainerCliVersion}"
 


### PR DESCRIPTION
Closes [ARCH-350](https://sagebionetworks.jira.com/browse/ARCH-350)

## Preview

```console
devcontainer up --workspace-folder .
devcontainer exec --workspace-folder . sam --version
SAM CLI, version 1.131.0
```

[ARCH-350]: https://sagebionetworks.jira.com/browse/ARCH-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ