### PR TITLE
fix(openchallenges): relax the healthchecks of a few services (ARCH-372)

### DIFF
--- a/apps/openchallenges/challenge-service/Dockerfile
+++ b/apps/openchallenges/challenge-service/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && rm -rf /var/lib/apt/lists/*
 
 # Requires the environment variable SERVER_PORT at runtime
-HEALTHCHECK --interval=2s --timeout=3s --retries=20 --start-period=2s \
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 --start-period=5s \
   CMD curl --fail --silent "localhost:${SERVER_PORT}/actuator/health/readiness" | jq '.status' | grep UP || exit 1
 
 USER cnb

--- a/apps/openchallenges/elasticsearch/Dockerfile
+++ b/apps/openchallenges/elasticsearch/Dockerfile
@@ -2,5 +2,5 @@ FROM elasticsearch:7.17.8
 
 COPY docker-healthcheck /usr/local/bin/
 
-HEALTHCHECK --interval=2s --timeout=3s --retries=20 --start-period=5s \
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 --start-period=5s \
   CMD ["docker-healthcheck"]

--- a/apps/openchallenges/organization-service/Dockerfile
+++ b/apps/openchallenges/organization-service/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && rm -rf /var/lib/apt/lists/*
 
 # Requires the environment variable SERVER_PORT at runtime
-HEALTHCHECK --interval=2s --timeout=3s --retries=20 --start-period=5s \
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 --start-period=5s \
   CMD curl --fail --silent "localhost:${SERVER_PORT}/actuator/health/readiness" | jq '.status' | grep UP || exit 1
 
 USER cnb


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/ARCH-372

## Changelog

- Relax the healthcheck of ES and the microservices to prevent Docker Compose from failing to start the stack locally.