### PR TITLE
fix(sage-monorepo): remove Nx Console extension for VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,6 @@
         "mtxr.sqltools-driver-pg",
         "mtxr.sqltools",
         "njpwerner.autodocstring",
-        "nrwl.angular-console",
         "Orta.vscode-jest",
         "pranaygp.vscode-css-peek",
         "ritwickdey.LiveServer",


### PR DESCRIPTION
## Changelog

- Remove the Nx Console extension for VS Code because of its high CPU usage.

This may be a one off issue but since we are not actively using this extension, it's better to remove it to keep the dev environment lean.

![image](https://github.com/user-attachments/assets/7fc16c72-44a1-4d4a-855c-4950c44a555f)
