### PR TITLE
fix(openchallenges): display Material icons on the app

### DIFF
--- a/libs/openchallenges/themes/src/_index.scss
+++ b/libs/openchallenges/themes/src/_index.scss
@@ -6,6 +6,7 @@
 @use 'openchallenges/team/src/lib-theme' as openchallenges-team;
 @use 'openchallenges/challenge-search/src/lib-theme' as challenge-search;
 @use 'openchallenges/not-found/src/lib-theme' as not-found;
+@import 'https://fonts.googleapis.com/icon?family=Material+Icons';
 
 @mixin theme($theme) {
   @include openchallenges-challenge.theme($theme);


### PR DESCRIPTION
Fixes #2950 

## Changelog

* Add an import for the Material icons font to the main scss

## Preview

**Before**
![image](https://github.com/user-attachments/assets/270d53be-ced1-4e01-a078-4c4358888ccb)

**After**
![Screenshot 2024-12-18 at 2 39 17 PM](https://github.com/user-attachments/assets/15bc236a-0688-43ba-b2f6-797f0ffbfb45)
