### PR TITLE
fix(sage-monorepo): update actions/upload-artifact version

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -68,7 +68,7 @@ jobs:
           wait-for-processing: true
 
       - name: Detain results for debug if needed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: trivy-results-${{ matrix.image }}-edge.sarif
           path: trivy-results-${{ matrix.image }}-edge.sarif


### PR DESCRIPTION
## Description

Update actions/upload-artifact to v4, since v3 is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). For example, see failing workflow [here](https://github.com/Sage-Bionetworks/sage-monorepo/actions/runs/12695095805/job/35386933297?pr=2956).

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/0498d23e-f4ef-4ba5-a609-fbffaf09cc2f" />
