### PR TITLE
fix(agora): fix shared-typescript-angular-charts:test target after Angular update (AG-1610)

### DIFF
--- a/libs/shared/typescript/charts-angular/project.json
+++ b/libs/shared/typescript/charts-angular/project.json
@@ -7,7 +7,7 @@
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/libs/shared/typescript/charts-angular"],
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "libs/shared/typescript/charts-angular/jest.config.ts"
       }

--- a/libs/shared/typescript/charts-angular/project.json
+++ b/libs/shared/typescript/charts-angular/project.json
@@ -5,6 +5,13 @@
   "sourceRoot": "libs/shared/typescript/charts-angular/src",
   "prefix": "sage",
   "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/typescript/charts-angular"],
+      "options": {
+        "jestConfig": "libs/shared/typescript/charts-angular/jest.config.ts"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint"
     },

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -10,6 +10,7 @@ import { BoxplotDirective } from './boxplot.directive';
 
 const renderTestComponent = async (props: BoxplotProps) => {
   @Component({
+    imports: [BoxplotDirective],
     template: `<div
       sageBoxplot
       [points]="points"


### PR DESCRIPTION
## Description

Fixes the `shared-typescript-angular-charts:test` target that was failing after the monorepo update to Angular 19, see discussion [here](https://github.com/Sage-Bionetworks/sage-monorepo/pull/2958#discussion_r1909449657). 

Example output from `nx run shared-typescript-angular-charts:test`:

```
 PASS   shared-typescript-charts-angular  libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts (5.366 s)
  BoxplotDirective
    ✓ should render no data placeholder when no data is passed (369 ms)
    ✓ should render boxplot with static summaries (133 ms)
    ✓ should render boxplot with dynamic summaries (101 ms)

----------------------|---------|----------|---------|---------|-------------------
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------|---------|----------|---------|---------|-------------------
All files             |     100 |      100 |     100 |     100 |                   
 boxplot.directive.ts |     100 |      100 |     100 |     100 |                   
----------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        6.997 s, estimated 10 s
Ran all test suites.

—————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target test for project shared-typescript-charts-angular (196ms)
```