### PR TITLE
chore(openchallenges): update CI for update-db-csv

### DIFF
--- a/.github/workflows/update-oc-db-csv-files.yml
+++ b/.github/workflows/update-oc-db-csv-files.yml
@@ -27,14 +27,6 @@ jobs:
           pip install gspread pandas numpy
           python3 apps/openchallenges/db-update/update_db_csv.py
 
-      # - name: Install schematic and validate files
-      #   shell: bash
-      #   run: |
-      #     python3.10 -m venv .venv
-      #     chmod 755 .venv/bin/activate
-      #     source .venv/bin/activate
-      #     pip3.10 install schematicpy
-
       - name: Get current date
         run: |
           echo "TODAY=$(date +"%Y-%m-%d")" >> $GITHUB_ENV

--- a/.github/workflows/update-oc-db-csv-files.yml
+++ b/.github/workflows/update-oc-db-csv-files.yml
@@ -32,7 +32,7 @@ jobs:
           echo "TODAY=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
 
       - name: Push changes, then create or update pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7.0.6
         with:
           title: 'chore(openchallenges): ${{ env.TODAY }} DB update'
           body: Daily OC database update(s)

--- a/.github/workflows/update-oc-db-csv-files.yml
+++ b/.github/workflows/update-oc-db-csv-files.yml
@@ -9,15 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # schematic only supports Python 3.9 and 3.10, so we will need
-      # to specifically use one of these versions.
-      - name: Install system dependencies
-        run: |
-          sudo add-apt-repository ppa:deadsnakes/ppa
-          sudo apt-get update
-          sudo apt-get install -y pip python3.10-venv libcurl4-openssl-dev
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false


### PR DESCRIPTION
Ubuntu-24.04 image will be used as the default image for `ubuntu-latest` [[ref](https://github.com/actions/runner-images/issues/10636)]

## Changelog 
* remove the need to specifically use Python 3.10, since schematic is not used (3.10 is cached in Ubuntu-24.04 anyway)
* general actions versions update

## Preview

Tested the CI update in my test repo and the changes work as expected (that is, no unintentional change to the workflow is seen):

![Screenshot 2025-01-14 at 3 20 38 PM](https://github.com/user-attachments/assets/ab1050b2-b82d-4b9d-ab2b-8b301b80818a)
