### PR TITLE
chore: publish the attestation of the dev container prebuilt image with GH

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -60,6 +60,8 @@ RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
     xz-utils tk-dev libffi-dev liblzma-dev \
     # Required by Hadolint.
     shellcheck \
+    # Required by canvas (npm package)
+    build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
   # Add Node.js repository.
   && curl -fsSL https://deb.nodesource.com/setup_${nodeVersionMajor}.x -o nodesource_setup.sh \
   && bash nodesource_setup.sh \

--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -45,6 +45,7 @@ jobs:
       # Write access to `contents` needed to upload SBOM to GitHub's dependency graph.
       contents: write
       packages: write
+      attestations: write
     env:
       # The path to the folder containing the `.devcontainer/` directory.
       DEVCONTAINER_WORKSPACE_FOLDER: .github
@@ -137,6 +138,15 @@ jobs:
               first_iteration=false
             fi
           done
+
+      - name: Attest the provenance of the Docker image build
+        uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
+        id: attest
+        env:
+          IMAGE: ${{ steps.meta_sha.outputs.tags }}
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.image_digest }}
 
       - name: Generate SBOM for Docker image
         uses: anchore/sbom-action@df80a981bc6edbc4e220a492d3cbe9f5547a6e75 # v0.17.9

--- a/.github/workflows/build-and-push-devcontainer-image.yml
+++ b/.github/workflows/build-and-push-devcontainer-image.yml
@@ -140,6 +140,7 @@ jobs:
           done
 
       - name: Attest the provenance of the Docker image build
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/attest-build-provenance@520d128f165991a6c774bcb264f323e3d70747f4 # v2.2.0
         id: attest
         env:


### PR DESCRIPTION
## Changelog

- Publish the attestation of the dev container image build with GitHub.
- Install the system dependencies needed by `canvas` on Ubuntu 24.04.