### PR TITLE
chore: fix critical CVEs in the dev container Docker image (SMR-1)

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ ARG nodeVersionMajor="22"
 # https://pypi.org/project/pipenv/
 ARG pipenvVersion="2024.4.0"
 # https://github.com/pnpm/pnpm/releases
-ARG pnpmVersion="9.15.2"
+ARG pnpmVersion="9.15.4"
 # List of Python versions separated by spaces
 ARG pyenvPythonVersions="3.13.1"
 # https://github.com/SonarSource/sonar-scanner-cli/releases

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -10,16 +10,17 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {
-      "version": "27.4.1"
+      "version": "27.5.1",
+      "installDockerComposeSwitch": false
     },
     "ghcr.io/devcontainers/features/go:1.3.1": {
-      "version": "1.23",
+      "version": "1.23.5",
       "golangciLintVersion": "1.63.4"
     },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1.2.0": {
-      "version": "1.32",
-      "helm": "3.16.4",
-      "minikube": "1.34.0"
+      "version": "1.32.1",
+      "helm": "3.17.0",
+      "minikube": "1.35.0"
     }
   },
   "remoteUser": "ubuntu",


### PR DESCRIPTION
Contributes to https://sagebionetworks.jira.com/browse/SMR-1

## Preview

Build the dev container Docker image locally.

```console
devcontainer build   --workspace-folder .github   --image-name ghcr.io/sage-bionetworks/sage-monorepo-devcontainer:local
```

Scan the image for CVEs.

```console
$ trivy image --severity CRITICAL ghcr.io/sage-bionetworks/sage-monorepo-devcontainer:local
2025-01-27T21:44:23Z    INFO    [vuln] Vulnerability scanning is enabled
2025-01-27T21:44:23Z    INFO    [secret] Secret scanning is enabled
2025-01-27T21:44:23Z    INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-01-27T21:44:23Z    INFO    [secret] Please see also https://aquasecurity.github.io/trivy/v0.54/docs/scanner/secret#recommendation for faster secret detection
2025-01-27T21:45:28Z    INFO    Detected OS     family="ubuntu" version="24.04"
2025-01-27T21:45:28Z    INFO    [ubuntu] Detecting vulnerabilities...   os_version="24.04" pkg_num=541
2025-01-27T21:45:28Z    INFO    Number of language-specific files       num=40
2025-01-27T21:45:28Z    INFO    [gobinary] Detecting vulnerabilities...
2025-01-27T21:45:29Z    INFO    [python-pkg] Detecting vulnerabilities...
2025-01-27T21:45:29Z    INFO    [node-pkg] Detecting vulnerabilities...
2025-01-27T21:45:29Z    INFO    [jar] Detecting vulnerabilities...

ghcr.io/sage-bionetworks/sage-monorepo-devcontainer:local (ubuntu 24.04)

Total: 0 (CRITICAL: 0)
```