### PR TITLE
fix(openchallenges): specify older version of python to match pyproject

### DIFF
--- a/apps/openchallenges/data-lambda/Dockerfile
+++ b/apps/openchallenges/data-lambda/Dockerfile
@@ -7,12 +7,12 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 RUN poetry export --without-hashes --format=requirements.txt > requirements.txt
 
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/python:3.11
 
 COPY --from=builder /app/requirements.txt ${LAMBDA_TASK_ROOT}/
 COPY openchallenges_data_lambda/app.py ${LAMBDA_TASK_ROOT}/
 
-RUN python3.13 -m pip install --no-cache-dir -r requirements.txt -t .
+RUN python3.11 -m pip install --no-cache-dir -r requirements.txt -t .
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["app.lambda_handler"]


### PR DESCRIPTION
## Changelog
* Due to #2978, update Dockerfile so that v3.11 is used to install dependencies

## Preview

**Before Dockerfile update**

```
$ nx run openchallenges-data-lambda:invoke --event events/event.json

> nx run openchallenges-data-lambda:invoke --event events/event.json

> curl -X POST 'http://localhost:9000/2015-03-31/functions/function/invocations' --data @events/event.json

{"errorMessage": "Unable to import module 'app': No module named 'gspread'", "errorType": "Runtime.ImportModuleError", "requestId": "", "stackTrace": []}
```

**After**

```
$ nx run openchallenges-data-lambda:invoke --event events/event.json

> nx run openchallenges-data-lambda:invoke --event events/event.json

> curl -X POST 'http://localhost:9000/2015-03-31/functions/function/invocations' --data @events/event.json

{"statusCode": 200, "body": "{\"message\": \"Data successfully pulled from OC Data google sheet.\"}"}

```