### PR TITLE
fix(agora): only display auto calculated labels when specifying y-axis min/max values (AG-1656)

### DIFF
--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -254,6 +254,10 @@ export class BoxplotChart {
         axisLine: {
           show: true,
         },
+        axisLabel: {
+          showMinLabel: yAxisMin == null,
+          showMaxLabel: yAxisMax == null,
+        },
         splitLine: {
           show: false,
         },


### PR DESCRIPTION
## Description

Apache Echarts can automatically determine appropriate intervals and labels for the y-axis based on provided min/max values. By default, the min/max values are displayed as-is if the label will not overlap with other labels. However, the min/max values we provide are often not rounded or at the same interval as the rest of the axis. So, we will stop displaying the min/max labels when a min/max value is explicitly passed.

## Related Issue

- [AG-1656](https://sagebionetworks.jira.com/browse/AG-1656)

## Validation

Build agora, then run the stack - `agora-build-images; nx run agora-apex:serve-detach`.
Navigate to VGF evidence, e.g. http://localhost:8000/genes/ENSG00000128564/evidence/rna. 

.      | dev | fix 
:---:|:---:|:---:
VGF - RNA | <img width="1202" alt="dev_rna_vgf" src="https://github.com/user-attachments/assets/71bd05d0-2f14-4e82-bbcd-f5ec793d155c" /> | <img width="1166" alt="fix_rna_vgf" src="https://github.com/user-attachments/assets/7ca2dea1-6048-4e3a-821e-93a00b2cf0be" />
VGF - Protein | <img width="1158" alt="dev_protein_vgf" src="https://github.com/user-attachments/assets/0ede9d4c-f3bc-4f35-9075-a423f07410cf" /> | <img width="1147" alt="fix_protein_vgf" src="https://github.com/user-attachments/assets/f603a9b3-5218-464a-9667-c536ef1e23aa" />