### PR TITLE
fix(agora): fixing team member link styling (AG-1646)

### DIFF
--- a/libs/agora/teams/src/lib/team-member-list/team-member-list.component.scss
+++ b/libs/agora/teams/src/lib/team-member-list/team-member-list.component.scss
@@ -1,5 +1,5 @@
-@import 'libs/agora/styles/src/lib/variables';
-@import 'libs/agora/styles/src/lib/mixins';
+@use 'libs/agora/styles/src/lib/variables';
+@use 'libs/agora/styles/src/lib/mixins';
 
 .team-member-list {
   .team-member-list-inner {
@@ -42,8 +42,15 @@
     margin-bottom: 0;
     text-align: center;
 
-    // a {
-    //   @include link;
-    // }
+    a {
+      color: var(--color-link);
+      cursor: pointer;
+      text-decoration: none;
+
+      &:hover {
+        color: var(--color-link);
+        text-decoration: underline;
+      }
+    }
   }
 }

--- a/libs/agora/teams/src/lib/team-member-list/team-member-list.component.scss
+++ b/libs/agora/teams/src/lib/team-member-list/team-member-list.component.scss
@@ -43,13 +43,10 @@
     text-align: center;
 
     a {
-      color: var(--color-link);
-      cursor: pointer;
-      text-decoration: none;
+      @include mixins.link;
 
       &:hover {
-        color: var(--color-link);
-        text-decoration: underline;
+        @include mixins.link-hover;
       }
     }
   }


### PR DESCRIPTION
## Description
Team member link styling was using browser defaults.

This change fixes the styling and co-locates the hyperlink styling logic.  

Before:
![image](https://github.com/user-attachments/assets/00d28b73-a690-4bce-9a52-6cd4985c363d)

After:
![image](https://github.com/user-attachments/assets/fbf34fa3-acba-43bb-a11f-4c76cab64287)


