### PR TITLE
fix(agora): increase boxplot height and allow boxes to take up more space as in current agora (AG-1678)

### DIFF
--- a/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.html
+++ b/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.html
@@ -1,5 +1,6 @@
 <div
   sageBoxplot
+  [style.height]="plotHeight"
   [points]="points"
   [summaries]="summaries"
   [title]="heading"

--- a/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.ts
+++ b/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.ts
@@ -30,6 +30,7 @@ export class BoxPlotComponent {
   xAxisCategoryToTooltipText: Record<string, string> | undefined = {};
   isInitialized = false;
   pointTooltipFormatter: ((pt: CategoryPoint) => string) | undefined;
+  plotHeight = '480px';
 
   get data(): boxPlotChartItem[] {
     return this._data;
@@ -60,6 +61,7 @@ export class BoxPlotComponent {
       return;
     }
 
+    if (this.heading !== '') this.plotHeight = '520px';
     this.initData();
     this.isInitialized = true;
   }

--- a/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.ts
+++ b/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.ts
@@ -30,7 +30,6 @@ export class BoxPlotComponent {
   xAxisCategoryToTooltipText: Record<string, string> | undefined = {};
   isInitialized = false;
   pointTooltipFormatter: ((pt: CategoryPoint) => string) | undefined;
-  plotHeight = '480px';
 
   get data(): boxPlotChartItem[] {
     return this._data;
@@ -45,6 +44,7 @@ export class BoxPlotComponent {
   @Input() yAxisLabel = 'LOG 2 FOLD CHANGE';
   @Input() yAxisMin: number | undefined;
   @Input() yAxisMax: number | undefined;
+  @Input() plotHeight = '480px';
 
   reset() {
     this.points = [];
@@ -61,7 +61,6 @@ export class BoxPlotComponent {
       return;
     }
 
-    if (this.heading !== '') this.plotHeight = '520px';
     this.initData();
     this.isInitialized = true;
   }

--- a/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.html
+++ b/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.html
@@ -97,6 +97,7 @@
               [yAxisMax]="differentialExpressionYAxisMax"
               [heading]="selectedStatisticalModel"
               [data]="differentialExpressionChartData"
+              plotHeight="520px"
             ></agora-box-plot-chart>
           </div>
         </div>

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -184,29 +184,34 @@ export class BoxplotChart {
       },
     });
 
+    const titles = [
+      // Add x-axis title as a title rather than xAxis.name, because
+      // setting via xAxis.name causes cursor to change to pointer when
+      // x-axis label tooltips are used
+      {
+        text: xAxisTitle,
+        textStyle: titleTextStyle,
+        left: 'center',
+        top: 'bottom',
+      },
+    ];
+    if (title) {
+      titles.push({
+        text: title,
+        left: 'center',
+        top: 'top',
+        textStyle: titleTextStyle,
+      });
+    }
+
     const option: EChartsOption = {
       grid: {
+        top: title ? 60 : 20,
         left: 25,
         right: 20,
         containLabel: true,
       },
-      title: [
-        {
-          text: title,
-          left: 'center',
-          top: 'top',
-          textStyle: titleTextStyle,
-        },
-        // Add x-axis title as a title rather than xAxis.name, because
-        // setting via xAxis.name causes cursor to change to pointer when
-        // x-axis label tooltips are used
-        {
-          text: xAxisTitle,
-          textStyle: titleTextStyle,
-          left: 'center',
-          top: 'bottom',
-        },
-      ],
+      title: titles,
       aria: {
         enabled: true,
       },

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -127,6 +127,7 @@ export class BoxplotChart {
       type: 'boxplot',
       z: 1,
       itemStyle: boxplotStyle,
+      boxWidth: [7, 115],
       silent: true,
       tooltip: {
         show: false,


### PR DESCRIPTION
## Description

Increases max width of each boxplot and overall height of boxplot chart to more closely align with current Agora boxplot chart.

## Related Issues

- [AG-1678](https://sagebionetworks.jira.com/browse/AG-1678)

## Validation

Build and run agora: `agora-build-images && nx run agora-apex:serve-detach`.

Navigate to RNA boxplot to see increased plot height: http://localhost:8000/genes/ENSG00000171862/evidence/rna

Navigate to Protein boxplot to see increased boxplot width: http://localhost:8000/genes/ENSG00000178209/evidence/protein

type | current agora | new agora | fixed new agora
:---:|:---:|:---:|:---:
RNA | <img width="1543" alt="develop-rna" src="https://github.com/user-attachments/assets/fd503c06-055f-43e2-92bd-b5f28b872c46" /> | <img width="1544" alt="newdevelop-rna" src="https://github.com/user-attachments/assets/91fb63d6-4d13-42b7-a8da-82b33b046802" /> | <img width="1543" alt="fix-rna" src="https://github.com/user-attachments/assets/90dcb5b2-c01f-4ec8-bcda-4c7ff0c3269f" />
Protein | <img width="1547" alt="develop-protein" src="https://github.com/user-attachments/assets/625c9298-27dc-4a0b-9147-c61be70ad164" /> | <img width="1545" alt="newdevelop-protein" src="https://github.com/user-attachments/assets/805b0623-fa87-43a3-aa7a-35479dff6261" /> | <img width="1554" alt="fix-protein" src="https://github.com/user-attachments/assets/5782b075-06cf-4a16-90d0-5c303c56fee4" />








[AG-1678]: https://sagebionetworks.jira.com/browse/AG-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ