### PR TITLE
fix(agora): align boxplot y-axis and x-axis end with other charts (AG-1659)

### DIFF
--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -184,6 +184,11 @@ export class BoxplotChart {
     });
 
     const option: EChartsOption = {
+      grid: {
+        left: 25,
+        right: 20,
+        containLabel: true,
+      },
       title: [
         {
           text: title,


### PR DESCRIPTION
## Description

Aligns the boxplot y-axis and x-axis end with other charts

## Related Issues

- [AG-1659](https://sagebionetworks.jira.com/browse/AG-1659)

## Validation

Run agora: `agora-build-images && nx run agora-apex:serve-detach`
Navigate to RNA genes page: http://localhost:8000/genes/ENSG00000171862/evidence/rna

![AG-1659](https://github.com/user-attachments/assets/29badfd1-cbef-477c-8249-d061d916ed2d)


[AG-1659]: https://sagebionetworks.jira.com/browse/AG-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1659]: https://sagebionetworks.jira.com/browse/AG-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ