### PR TITLE
feat(agora): run agora e2e tests in CI (AG-1623)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 
 /apps/agora/ @Sage-Bionetworks/sage-monorepo-agora
 /libs/agora/ @Sage-Bionetworks/sage-monorepo-agora
+/.github/workflows/e2e-agora.yaml @Sage-Bionetworks/sage-monorepo-agora
 
 /libs/shared/ @tschaffter
 

--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -8,8 +8,7 @@ jobs:
     if: ${{ github.ref_name == 'main' || github.actor == github.repository_owner }}
     timeout-minutes: 60
     runs-on: ubuntu-22.04
-    env:
-      CI: true
+    environment: agora
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -1,0 +1,76 @@
+name: Run e2e tests for Agora
+
+on: push
+
+jobs:
+  run-agora-e2e-tests:
+    # Run in Sage repo on main branch and on all branches in user-owned forks
+    if: ${{ github.ref_name == 'main' || github.actor == github.repository_owner }}
+    timeout-minutes: 60
+    runs-on: ubuntu-22.04
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # We need to fetch all branches and commits so that Nx affected has a base to compare
+          # against.
+          fetch-depth: 0
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Set up the dev container
+        uses: ./.github/actions/setup-dev-container
+
+      - name: Check if Agora was affected
+        id: agora_affected
+        run: |
+          AFFECTED=$(devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && nx show projects --affected --with-target e2e | grep -q 'agora' && echo 'true' || echo 'false'")
+          echo "AFFECTED=${AFFECTED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Install Playwright Browsers
+        if: steps.agora_affected.outputs.AFFECTED == 'true'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && npx playwright install --with-deps"
+
+      - name: Build Agora
+        if: steps.agora_affected.outputs.AFFECTED == 'true'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && agora-build-images"
+
+      - name: Write Synapse PAT for Agora
+        if: steps.agora_affected.outputs.AFFECTED == 'true'
+        run: |
+          sed -i "s/^SYNAPSE_AUTH_TOKEN=.*/SYNAPSE_AUTH_TOKEN=\"${{ secrets.AGORA_DATA_SYNAPSE_AUTH_TOKEN }}\"/" apps/agora/data/.env
+
+      - name: Start Agora
+        if: steps.agora_affected.outputs.AFFECTED == 'true'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && nx run agora-apex:serve-detach"
+
+      - name: Run Agora e2e tests
+        if: steps.agora_affected.outputs.AFFECTED == 'true'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && nx run agora-app:e2e"
+
+      - name: Stop Agora
+        if: steps.agora_affected.outputs.AFFECTED == 'true'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && workspace-docker-stop"
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && steps.agora_affected.outputs.AFFECTED == 'true'}}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 5
+
+      - name: Remove the dev container
+        run: docker rm -f sage_devcontainer

--- a/apps/agora/app/playwright.config.ts
+++ b/apps/agora/app/playwright.config.ts
@@ -7,12 +7,6 @@ const port = 8000;
 export const baseURL = process.env['BASE_URL'] || `http://localhost:${port}`;
 
 /**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
-
-/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({


### PR DESCRIPTION
## Description

Adds a GHA workflow to run Agora's e2e tests on push to main in Sage's sage-monorepo and on push to any branch in user owned forks of sage-monorepo.

## Related Issues

- [AG-1623](https://sagebionetworks.jira.com/browse/AG-1623)

## Validation

See a successful workflow run [in my fork](https://github.com/hallieswan/sage-monorepo/actions/runs/13319316907).
View report by: 1) downloading "playwright-report" artifact, 2) opening zip, 3) opening index.html file in browser.

To run the workflow in sage-monorepo (or your own fork): 
1. Create a new Synapse PAT with view/download permissions for the `synapse-service-agora-e2e` user 
2. Add the PAT as an Actions Secret named `AGORA_DATA_SYNAPSE_AUTH_TOKEN` to sage-monorepo

## Note

Job speed is greatly impacted by time to download data from Synapse in the "Start Agora" step, but improving the speed is outside the scope of this ticket. If desired, we could open another ticket to address.

[AG-1623]: https://sagebionetworks.jira.com/browse/AG-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ