### PR TITLE
fix(agora): fix team members sorting (AG-1650)

### DIFF
--- a/apps/agora/api/src/models/teams.ts
+++ b/apps/agora/api/src/models/teams.ts
@@ -13,7 +13,7 @@ import { Team, TeamMember } from '@sagebionetworks/agora/api-client-angular';
 // -------------------------------------------------------------------------- //
 const TeamMemberSchema = new Schema<TeamMember>({
   name: { type: String, required: true },
-  isPrimaryInvestigator: { type: Boolean, required: true },
+  isprimaryinvestigator: { type: Boolean, required: true },
   url: String,
 });
 

--- a/libs/agora/api-client-angular/src/lib/model/teamMember.ts
+++ b/libs/agora/api-client-angular/src/lib/model/teamMember.ts
@@ -15,6 +15,6 @@
  */
 export interface TeamMember {
   name: string;
-  isPrimaryInvestigator: boolean;
+  isprimaryinvestigator: boolean;
   url?: string;
 }

--- a/libs/agora/api-description/build/openapi.yaml
+++ b/libs/agora/api-description/build/openapi.yaml
@@ -1289,13 +1289,13 @@ components:
       properties:
         name:
           type: string
-        isPrimaryInvestigator:
+        isprimaryinvestigator:
           type: boolean
         url:
           type: string
       required:
         - name
-        - isPrimaryInvestigator
+        - isprimaryinvestigator
     Team:
       type: object
       description: Team

--- a/libs/agora/api-description/src/components/schemas/TeamMember.yaml
+++ b/libs/agora/api-description/src/components/schemas/TeamMember.yaml
@@ -3,10 +3,10 @@ description: Team Member
 properties:
   name:
     type: string
-  isPrimaryInvestigator:
+  isprimaryinvestigator:
     type: boolean
   url:
     type: string
 required:
   - name
-  - isPrimaryInvestigator
+  - isprimaryinvestigator

--- a/libs/agora/teams/src/lib/team-member-list/team-member-list.component.spec.ts
+++ b/libs/agora/teams/src/lib/team-member-list/team-member-list.component.spec.ts
@@ -19,9 +19,9 @@ describe('TeamMemberListComponent', () => {
 
   describe('sort function', () => {
     it('should sort team members correctly', () => {
-      const member1: TeamMember = { name: 'John Doe', isPrimaryInvestigator: true };
-      const member2: TeamMember = { name: 'Jane Smith', isPrimaryInvestigator: false };
-      const member3: TeamMember = { name: 'Alice Johnson', isPrimaryInvestigator: true };
+      const member1: TeamMember = { name: 'John Doe', isprimaryinvestigator: true };
+      const member2: TeamMember = { name: 'Jane Smith', isprimaryinvestigator: false };
+      const member3: TeamMember = { name: 'Alice Johnson', isprimaryinvestigator: true };
 
       const mockTeam: Team = {
         team: 'Test Team',
@@ -38,8 +38,8 @@ describe('TeamMemberListComponent', () => {
       expect(mockTeam.members[2]).toEqual(member2);
 
       // Test case where primary investigators are both true
-      const member4: TeamMember = { name: 'Bob Brown', isPrimaryInvestigator: true };
-      const member5: TeamMember = { name: 'Andy Anderson', isPrimaryInvestigator: true };
+      const member4: TeamMember = { name: 'Bob Brown', isprimaryinvestigator: true };
+      const member5: TeamMember = { name: 'Andy Anderson', isprimaryinvestigator: true };
 
       mockTeam.members = [member4, member5];
 

--- a/libs/agora/teams/src/lib/team-member-list/team-member-list.component.ts
+++ b/libs/agora/teams/src/lib/team-member-list/team-member-list.component.ts
@@ -61,12 +61,11 @@ export class TeamMemberListComponent {
 
   sort(members: TeamMember[]) {
     members.sort((a, b) => {
-      if (a.isPrimaryInvestigator === b.isPrimaryInvestigator) {
-        return a.name > b.name ? 1 : -1;
-      } else if (a.isPrimaryInvestigator > b.isPrimaryInvestigator) {
-        return -1;
+      if (a.isprimaryinvestigator !== b.isprimaryinvestigator) {
+        return a.isprimaryinvestigator ? -1 : 1; // true values come first
       }
-      return 1;
+
+      return a.name.localeCompare(b.name);
     });
   }
 


### PR DESCRIPTION
### Description
Fixed bug in team member names not sorting correctly due to a property not matching the casing in MongoDB (isprimaryinvestigator).

Note: In the future, for consistency we should consider coordinating with @JessterB to use snake casing to match other properties in the database.