### PR TITLE
fix(agora): setup all projects when running agora e2e, not just affected projects (AG-1623)

### DIFF
--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -26,7 +26,7 @@ jobs:
         id: agora_affected
         run: |
           AFFECTED=$(devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-              && nx show projects --affected --with-target e2e | grep -q 'agora' && echo 'true' || echo 'false'")
+              && nx show projects --affected | grep -q 'agora' && echo 'true' || echo 'false'")
           echo "AFFECTED=${AFFECTED}" >> "${GITHUB_OUTPUT}"
 
       - name: Install Playwright Browsers
@@ -34,6 +34,12 @@ jobs:
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && npx playwright install --with-deps"
+
+      - name: Setup Agora
+        if: steps.agora_affected.outputs.AFFECTED == 'true'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && bash ./tools/setup-projects.sh agora"
 
       - name: Build Agora
         if: steps.agora_affected.outputs.AFFECTED == 'true'

--- a/tools/setup-projects.sh
+++ b/tools/setup-projects.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Runs tasks to set up all projects for a particular stack.
+# $1 - The stack name, e.g. agora.
+
+if [ "$#" -ne 1 ]; then
+  echo "Please pass the stack name as an argument".
+  exit
+fi
+
+stack="$1"
+echo "Running setup tasks for ${stack} projects."
+
+projects="${1}-*"
+
+nx run-many --target=create-config --projects="${projects}"
+# Projects that can be prepared in parallel
+nx run-many --target=prepare --exclude='tag:language:java' --projects="${projects}"
+# Java projects must be installed one at a time
+nx run-many --target=prepare --exclude='!tag:language:java' --parallel=1 --projects="${projects}"


### PR DESCRIPTION
## Description

The Agora e2e job failed [on merge to main](https://github.com/Sage-Bionetworks/sage-monorepo/actions/runs/13338951817/job/37260035903) because the `setup-dev-container` action only preps affected projects and only `agora-app` was marked as affected, so the config file for `agora-data` wasn’t created and the agora stack couldn’t be started. This PR adjusts the workflow to prep all agora projects, rather than the affected projects, so the full stack can be built for e2e tests to run against. 

## Related Issues

- [AG-1623](https://sagebionetworks.jira.com/browse/AG-1623)

## Changelog

- Sets up all projects in the agora stack, rather than only affected projects
- Adds a tool to run set up tasks (`create-config`, `prepare`) for all projects in a particular stack
- Changes the Agora e2e workflow to check whether any agora project is affected, rather than only those projects with an `e2e` target, so that e2e tests are run on change to any agora project

## Validation

Workflow runs in my fork [here](https://github.com/hallieswan/sage-monorepo/actions/runs/13340011145/job/37262933968).

[AG-1623]: https://sagebionetworks.jira.com/browse/AG-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ