### PR TITLE
chore(agora): use edge for app version and tag name placeholder, update data version to align with agora-data-manger (AG-1681)

### DIFF
--- a/apps/agora/app/.env.example
+++ b/apps/agora/app/.env.example
@@ -1,6 +1,6 @@
 API_DOCS_URL="http://localhost:8000/api-docs"
-APP_VERSION="4.0.0"
+APP_VERSION="edge"
 CSR_API_URL="http://localhost:8000/api/v1"
 SSR_API_URL="http://agora-api:3333/v1"
 ROLLBAR_TOKEN="e788198867474855a996485580b08d03"
-TAG_NAME="agora/v4.0.0-rc1"
+TAG_NAME="edge"

--- a/apps/agora/app/src/config/config.json
+++ b/apps/agora/app/src/config/config.json
@@ -1,7 +1,7 @@
 {
   "apiDocsUrl": "http://localhost:8000/api-docs",
-  "appVersion": "4.0.0",
+  "appVersion": "edge",
   "csrApiUrl": "http://localhost:3333/v1",
   "ssrApiUrl": "http://agora-api:3333/v1",
-  "tagName": "agora/v4.0.0-rc1"
+  "tagName": "edge"
 }

--- a/apps/agora/data/.env.example
+++ b/apps/agora/data/.env.example
@@ -7,6 +7,6 @@ DB_HOST="agora-mongo" # must match mongo service name
 
 # specifies data release manifest and team images folder
 DATA_FILE="syn13363290"
-DATA_VERSION="71"
+DATA_VERSION="72"
 TEAM_IMAGES_ID="syn12861877"
 SYNAPSE_AUTH_TOKEN="agora-service-user-pat-here"


### PR DESCRIPTION
## Description

`agora-app` displays two values for the Site Version in the footer: an app version and a commit SHA (looked up using a tag name). These values are set to the current release in [the infra code](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/blob/dev/app.py#L140-L145). However, keeping the example values in `.env.example` and `config.json` aligned with the actual latest release adds extra overhead. Instead, we would like to use "edge" as the placeholder in these files.

Separately, the data manifest version was recently updated in [agora-data-manager](https://github.com/Sage-Bionetworks/agora-data-manager/pull/133). This PR updates the `agora-data` value to match.

## Related Issues

- [AG-1681](https://sagebionetworks.jira.com/browse/AG-1681)

## Validation

Update `APP_VERSION` and `TAG_NAME` in `apps/agora/app/.env` to match the values in `.env.example`. 
Update `DATA_VERSION` in `apps/agora/data.env` to "72".
Run agora: `agora-build-images && nx run agora-apex:serve-detach`.
View the footer: 
<img width="420" alt="AG-1681" src="https://github.com/user-attachments/assets/034bd089-5c90-4003-9e60-85af120e0e97" />

Note: since "edge" is not a git tag in sage-monorepo, the commit SHA is not displayed in the footer. The dev can change the value to an actual git tag if they would like to see the SHA displayed.

[AG-1681]: https://sagebionetworks.jira.com/browse/AG-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ