### PR TITLE
feat(agora): run agora e2e on PRs when approved by authorized user (SMR-17)

### DIFF
--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -1,20 +1,33 @@
 name: Run e2e tests for Agora
 
-on: push
+on:
+  push:
+  # Warning: using the pull_request_target event without the cautionary measures may allow
+  # unauthorized GitHub users to open a “pwn request” and exfiltrate secrets.
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   run-agora-e2e-tests:
     # Run in Sage repo on main branch and on all branches in user-owned forks
     if: ${{ github.ref_name == 'main' || github.actor == github.repository_owner }}
+    environment: ${{ github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository && 'agora-pr' || 'agora' }}
     timeout-minutes: 60
     runs-on: ubuntu-22.04
-    environment: agora
     steps:
       - uses: actions/checkout@v4
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare
           # against.
           fetch-depth: 0
+          persist-credentials: false
+          # By default, actions/checkout@v4 will checkout the main branch instead of the merge
+          # commit when when using pull_request_target. It is currently difficult to checkout the
+          # merge commit in this context. The current solution is to checkout the PR HEAD instead
+          # and enable the branch protection rule "Require branches to be up to date before
+          # merging".
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/sonar-scan-pull-request.yml
+++ b/.github/workflows/sonar-scan-pull-request.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
           # By default, actions/checkout@v4 will checkout the main branch instead of the merge
           # commit when when using pull_request_target. It is currently difficult to checkout the
-          # merge commit in this context. The current solution is to checkout the PR HEAD insteand
+          # merge commit in this context. The current solution is to checkout the PR HEAD instead
           # and enable the branch protection rule "Require branches to be up to date before
           # merging".
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Description

Replicates the `pull_request_target` functionality of the existing `sonar-scan-pull-request` workflow, which allows a job triggered by a PR from a forked repo to access secrets when the run is approved by an authorized user.

## Related Issues

- [SMR-17](https://sagebionetworks.jira.com/browse/SMR-17)

## Validation

This PR replicates the setup of the existing sonar job, but utilizes two environments (`agora`, `agora-pr`) rather than separating into two jobs (`sonar-scan-pull-request`, `sonar-scan-push`) . Plan to validate once this PR has been merged and a new Agora PR from a forked repo is synchronized, e.g. #3015.

[SMR-17]: https://sagebionetworks.jira.com/browse/SMR-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ