### PR TITLE
fix(agora): ensure correct ref is checked out and that buildx works (SMR-17)

### DIFF
--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -27,7 +27,12 @@ jobs:
           # merge commit in this context. The current solution is to checkout the PR HEAD instead
           # and enable the branch protection rule "Require branches to be up to date before
           # merging".
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.sha || github.ref }}
+
+      - name:
+          Switch from the detached HEAD of the merge commit to a new branch
+          # Buildx does not work on a detached HEAD
+        run: git switch -c new-branch
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v4


### PR DESCRIPTION
## Description

The Agora e2e workflow [failed to build Agora](https://github.com/Sage-Bionetworks/sage-monorepo/actions/runs/13442764721/job/37560942742?pr=3015) because `NX   Cannot find detached HEAD ref in "HEAD"`. We need to checkout a branch so buildx works, as demonstrated in the [ci pull request job](https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/.github/workflows/ci.yml#L89-L98). 

We also need to ensure that the correct ref is checked out when pushing to main.