### PR TITLE
chore: decouple setup dev container from preparing projects (SMR-18)

### DIFF
--- a/.github/actions/setup-dev-container/action.yml
+++ b/.github/actions/setup-dev-container/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'ubuntu'
 outputs:
   affected_projects:
-    description: 'The list of affected Nx projects.'
+    description: 'The list of affected Nx projects as a comma separated string.'
     value: ${{ steps.get-affected-projects.outputs.affected_projects }}
 runs:
   using: 'composite'

--- a/.github/actions/setup-dev-container/action.yml
+++ b/.github/actions/setup-dev-container/action.yml
@@ -92,4 +92,4 @@ runs:
           . ./dev-env.sh && nx show projects --affected --sep ','")
         echo "Affected projects: $AFFECTED_PROJECTS"
         echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_ENV
-        echo "::set-output name=affected_projects::$AFFECTED_PROJECTS"
+        echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-dev-container/action.yml
+++ b/.github/actions/setup-dev-container/action.yml
@@ -5,10 +5,10 @@ inputs:
     description: 'The dev container user.'
     required: false
     default: 'ubuntu'
-  outputs:
-    affected_projects:
-      description: 'The list of affected Nx projects.'
-      value: ${{ steps.get-affected-projects.outputs.affected_projects }}
+outputs:
+  affected_projects:
+    description: 'The list of affected Nx projects.'
+    value: ${{ steps.get-affected-projects.outputs.affected_projects }}
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/setup-dev-container/action.yml
+++ b/.github/actions/setup-dev-container/action.yml
@@ -88,7 +88,8 @@ runs:
       id: get-affected-projects
       shell: bash
       run: |
-        AFFECTED_PROJECTS=$(devcontainer exec --workspace-folder ../sage-monorepo bash -c "nx show projects --affected --sep ','")
+        AFFECTED_PROJECTS=$(devcontainer exec --workspace-folder ../sage-monorepo bash -c "
+          . ./dev-env.sh && nx show projects --affected --sep ','")
         echo "Affected projects: $AFFECTED_PROJECTS"
         echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_ENV
         echo "::set-output name=affected_projects::$AFFECTED_PROJECTS"

--- a/.github/actions/setup-dev-container/action.yml
+++ b/.github/actions/setup-dev-container/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'The dev container user.'
     required: false
     default: 'ubuntu'
+  outputs:
+    affected_projects:
+      description: 'The list of affected Nx projects.'
+      value: ${{ steps.get-affected-projects.outputs.affected_projects }}
 runs:
   using: 'composite'
   steps:
@@ -78,4 +82,13 @@ runs:
             /home/${DEVCONTAINER_USER}/.local \
             /home/${DEVCONTAINER_USER}/.gradle \
           && . ./dev-env.sh \
-          && workspace-install-affected"
+          && workspace-install-nodejs-dependencies"
+
+    - name: Get affected Nx projects
+      id: get-affected-projects
+      shell: bash
+      run: |
+        AFFECTED_PROJECTS=$(devcontainer exec --workspace-folder ../sage-monorepo bash -c "nx show projects --affected --sep ','")
+        echo "Affected projects: $AFFECTED_PROJECTS"
+        echo "affected_projects=$AFFECTED_PROJECTS" >> $GITHUB_ENV
+        echo "::set-output name=affected_projects::$AFFECTED_PROJECTS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container
 
+      - name: Prepare the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && workspace-install-affected"
+
       - name: Lint the affected projects
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
@@ -102,6 +107,11 @@ jobs:
 
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container
+
+      - name: Prepare the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && workspace-install-affected"
 
       - name: Lint the affected projects
         run: |

--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -38,14 +38,20 @@ jobs:
         uses: nrwl/nx-set-shas@v4
 
       - name: Set up the dev container
+        id: setup-dev-container
         uses: ./.github/actions/setup-dev-container
 
       - name: Check if Agora was affected
         id: agora_affected
         run: |
-          AFFECTED=$(devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
-              && nx show projects --affected | grep -q 'agora' && echo 'true' || echo 'false'")
-          echo "AFFECTED=${AFFECTED}" >> "${GITHUB_OUTPUT}"
+          IFS=',' read -ra PROJECTS <<< "${{ steps.setup-dev-container.outputs.affected_projects }}"
+          for project in "${PROJECTS[@]}"; do
+            if [[ "$project" == agora-* ]]; then
+              echo "AFFECTED=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          done
+          echo "AFFECTED=false" >> "${GITHUB_OUTPUT}"
 
       - name: Install Playwright Browsers
         if: steps.agora_affected.outputs.AFFECTED == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Set up the dev container
         uses: ./.github/actions/setup-dev-container
 
+        # TODO: Identify the projects that actually need to be prepared. Here I'm not expecting any
+        # affected project since this workflow does not affect projects. For now I'm keeping the
+        # same behavior as before this change.
+      - name: Prepare the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && workspace-install-affected"
+
       - name: Build the Docker images for the specified product
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \

--- a/.github/workflows/sonar-scan-pull-request.yml
+++ b/.github/workflows/sonar-scan-pull-request.yml
@@ -34,6 +34,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         uses: ./.github/actions/setup-dev-container
 
+      - name: Prepare the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && workspace-install-affected"
+
       - name: Scan the affected projects with Sonar
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \

--- a/.github/workflows/sonar-scan-push.yml
+++ b/.github/workflows/sonar-scan-push.yml
@@ -28,6 +28,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         uses: ./.github/actions/setup-dev-container
 
+      - name: Prepare the affected projects
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+            && workspace-install-affected"
+
       - name: Scan the affected projects with Sonar
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-18

## Changelog

- Remove the preparation of affected projects from `setup-dev-container`.
- Update the `setup-dev-container` to return the list of affected projects.
- Update the Agora e2e workflow to use the list of affected projects from `setup-dev-container`.