### PR TITLE
fix(agora): only show agora's e2e workflow as waiting on PRs that affect agora (SMR-19)

### DIFF
--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -8,9 +8,50 @@ on:
     types: [opened, synchronize, reopened, labeled]
 
 jobs:
-  run-agora-e2e-tests:
+  check-agora-affected:
     # Run in Sage repo on main branch and on all branches in user-owned forks
     if: ${{ github.ref_name == 'main' || github.actor == github.repository_owner }}
+    runs-on: ubuntu-22.04
+    outputs:
+      agora_affected: ${{ steps.agora_affected.outputs.AFFECTED }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # We need to fetch all branches and commits so that Nx affected has a base to compare
+          # against.
+          fetch-depth: 0
+          persist-credentials: false
+          # By default, actions/checkout@v4 will checkout the main branch instead of the merge
+          # commit when when using pull_request_target. It is currently difficult to checkout the
+          # merge commit in this context. The current solution is to checkout the PR HEAD instead
+          # and enable the branch protection rule "Require branches to be up to date before
+          # merging".
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.sha || github.ref }}
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v4
+
+      - name: Set up the dev container
+        id: setup-dev-container
+        uses: ./.github/actions/setup-dev-container
+
+      - name: Check if Agora was affected
+        id: agora_affected
+        run: |
+          IFS=',' read -ra PROJECTS <<< "${{ steps.setup-dev-container.outputs.affected_projects }}"
+          for project in "${PROJECTS[@]}"; do
+            if [[ "$project" == agora-* ]]; then
+              echo "AFFECTED=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          done
+          echo "AFFECTED=false" >> "${GITHUB_OUTPUT}"
+
+      - name: Remove the dev container
+        run: docker rm -f sage_devcontainer
+  run-agora-e2e-tests:
+    needs: check-agora-affected
+    if: needs.check-agora-affected.outputs.agora_affected == 'true'
     environment: ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository && 'agora-pr' || 'agora' }}
     timeout-minutes: 60
@@ -41,61 +82,42 @@ jobs:
         id: setup-dev-container
         uses: ./.github/actions/setup-dev-container
 
-      - name: Check if Agora was affected
-        id: agora_affected
-        run: |
-          IFS=',' read -ra PROJECTS <<< "${{ steps.setup-dev-container.outputs.affected_projects }}"
-          for project in "${PROJECTS[@]}"; do
-            if [[ "$project" == agora-* ]]; then
-              echo "AFFECTED=true" >> "${GITHUB_OUTPUT}"
-              exit 0
-            fi
-          done
-          echo "AFFECTED=false" >> "${GITHUB_OUTPUT}"
-
       - name: Install Playwright Browsers
-        if: steps.agora_affected.outputs.AFFECTED == 'true'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && npx playwright install --with-deps"
 
       - name: Setup Agora
-        if: steps.agora_affected.outputs.AFFECTED == 'true'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && bash ./tools/setup-projects.sh agora"
 
       - name: Build Agora
-        if: steps.agora_affected.outputs.AFFECTED == 'true'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && agora-build-images"
 
       - name: Write Synapse PAT for Agora
-        if: steps.agora_affected.outputs.AFFECTED == 'true'
         run: |
           sed -i "s/^SYNAPSE_AUTH_TOKEN=.*/SYNAPSE_AUTH_TOKEN=\"${{ secrets.AGORA_DATA_SYNAPSE_AUTH_TOKEN }}\"/" apps/agora/data/.env
 
       - name: Start Agora
-        if: steps.agora_affected.outputs.AFFECTED == 'true'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && nx run agora-apex:serve-detach"
 
       - name: Run Agora e2e tests
-        if: steps.agora_affected.outputs.AFFECTED == 'true'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && nx run agora-app:e2e"
 
       - name: Stop Agora
-        if: steps.agora_affected.outputs.AFFECTED == 'true'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && workspace-docker-stop"
 
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && steps.agora_affected.outputs.AFFECTED == 'true'}}
+        if: ${{ !cancelled() }}
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.ref_name == 'main' || github.actor == github.repository_owner }}
     runs-on: ubuntu-22.04
     outputs:
-      agora_affected: ${{ steps.agora_affected.outputs.AFFECTED }}
+      agora_affected: ${{ steps.agora_affected.outputs.affected }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,17 +41,22 @@ jobs:
           IFS=',' read -ra PROJECTS <<< "${{ steps.setup-dev-container.outputs.affected_projects }}"
           for project in "${PROJECTS[@]}"; do
             if [[ "$project" == agora-* ]]; then
-              echo "AFFECTED=true" >> "${GITHUB_OUTPUT}"
+              echo "affected=true" >> "${GITHUB_OUTPUT}"
               exit 0
             fi
           done
-          echo "AFFECTED=false" >> "${GITHUB_OUTPUT}"
+          echo "affected=false" >> "${GITHUB_OUTPUT}"
 
       - name: Remove the dev container
         run: docker rm -f sage_devcontainer
+
   run-agora-e2e-tests:
     needs: check-agora-affected
     if: needs.check-agora-affected.outputs.agora_affected == 'true'
+    # The agora and agora-pr environments contain the same secrets. However, the agora environment
+    # will run workflows automatically and should only be used when the workflow is running against
+    # trusted code. The agora-pr environment requires an authorized user's approval to run the
+    # workflow, so should be used when running against untrused code, e.g. PRs from forked repos.
     environment: ${{ github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name != github.repository && 'agora-pr' || 'agora' }}
     timeout-minutes: 60


### PR DESCRIPTION
## Description

We should only show Agora's e2e workflow as "waiting" on PRs that affect Agora.

## Validation

Here is a run in [my fork](https://github.com/hallieswan/sage-monorepo/actions/runs/13554103650/attempts/1) that shows the two jobs and that Agora e2e tests run when Agora is affected.