### PR TITLE
feat(agora): configure agora-app dev server proxy to handle agora-api requests (AG-1707)

### DIFF
--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -77,6 +77,9 @@
     },
     "serve": {
       "executor": "@angular-devkit/build-angular:dev-server",
+      "options": {
+        "proxyConfig": "{projectRoot}/src/proxy.conf.json"
+      },
       "configurations": {
         "production": {
           "buildTarget": "agora-app:build:production"

--- a/apps/agora/app/src/config/config.json
+++ b/apps/agora/app/src/config/config.json
@@ -1,7 +1,7 @@
 {
   "apiDocsUrl": "http://localhost:8000/api-docs",
   "appVersion": "edge",
-  "csrApiUrl": "http://localhost:3333/v1",
+  "csrApiUrl": "http://localhost:4200/v1",
   "ssrApiUrl": "http://agora-api:3333/v1",
   "tagName": "edge"
 }

--- a/apps/agora/app/src/proxy.conf.json
+++ b/apps/agora/app/src/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+  "/v1": {
+    "target": "http://localhost:3333",
+    "secure": false
+  }
+}


### PR DESCRIPTION
## Description

We would like to take advantage of live reloading when developing locally in Agora by serving the app with the development server and running all other services in their Docker containers. However, the app requests to the API result in CORS errors. This PR configures the [Angular development server proxy](https://angular.dev/tools/cli/serve) to handle API requests.

## Related Issue

- [AG-1707](https://sagebionetworks.jira.com/browse/AG-1707)

## Validation

Setup: 
- Build and run containerized stack: `agora-build-images && nx run agora-apex:serve-detach`
- Remove app container: `docker rm -f agora-app`
- Start app with dev server: `nx run agora-app:serve`
- View homepage at https://localhost:4200

Validate app can fetch data from API: 
- data version and file id should be displayed in footer, e.g. something like this: 
  <img width="390" alt="image" src="https://github.com/user-attachments/assets/81f5c50b-c9a6-49ed-812e-c429b90a2666" />
- No CORS errors in the browser console

Validate live reloading: 
- Make a change to copy in the homepage template here: `libs/agora/home/src/lib/home.component.html`
- Save file
- App should re-compile and browser page should reload and show changed homepage copy

[AG-1707]: https://sagebionetworks.jira.com/browse/AG-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ