### PR TITLE
fix(agora): float download button and modal-link right (AG-1658), round buttons (AG-1701), fix icons, style dropdowns

### DIFF
--- a/apps/agora/app/src/app/myPrimeNGPreset.ts
+++ b/apps/agora/app/src/app/myPrimeNGPreset.ts
@@ -4074,11 +4074,11 @@ export const MyPreset = definePreset(Lara, {
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',
         focusRing: {
-          width: '{form.field.focus.ring.width}',
-          style: '{form.field.focus.ring.style}',
-          color: '{form.field.focus.ring.color}',
-          offset: '{form.field.focus.ring.offset}',
-          shadow: '{form.field.focus.ring.shadow}',
+          width: '0',
+          style: 'none',
+          color: 'transparent',
+          offset: '0',
+          shadow: 'none',
         },
         transitionDuration: '{form.field.transition.duration}',
         sm: {

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component.html
@@ -28,12 +28,12 @@
     <div>
       @if (activePane > 0) {
         <button class="gct-how-to-panel-previous" (click)="previous()">
-          <i class="fa-solid fa-angle-left"></i> Back
+          <fa-icon [icon]="faAngleLeft"></fa-icon> Back
         </button>
       }
       @if (activePane !== panes.length - 1) {
         <button class="gct-how-to-panel-next" (click)="next()">
-          Next <i class="fa-solid fa-angle-right"></i>
+          Next <fa-icon [icon]="faAngleRight"></fa-icon>
         </button>
       }
       @if (activePane === panes.length - 1) {

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component.ts
@@ -1,14 +1,16 @@
 // -------------------------------------------------------------------------- //
 // External
 // -------------------------------------------------------------------------- //
+import { CommonModule } from '@angular/common';
 import { Component, inject, OnInit, ViewEncapsulation } from '@angular/core';
-import { CookieService } from 'ngx-cookie-service';
+import { FormsModule } from '@angular/forms';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
+import { LoadingIconComponent } from '@sagebionetworks/agora/shared';
+import { CookieService } from 'ngx-cookie-service';
 import { CheckboxModule } from 'primeng/checkbox';
 import { DialogModule } from 'primeng/dialog';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { LoadingIconComponent } from '@sagebionetworks/agora/shared';
 
 // -------------------------------------------------------------------------- //
 // Internal
@@ -25,7 +27,14 @@ interface Pane {
 // -------------------------------------------------------------------------- //
 @Component({
   selector: 'agora-gene-comparison-tool-how-to-panel',
-  imports: [CommonModule, FormsModule, CheckboxModule, DialogModule, LoadingIconComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    CheckboxModule,
+    DialogModule,
+    FontAwesomeModule,
+    LoadingIconComponent,
+  ],
   providers: [CookieService],
   templateUrl: './gene-comparison-tool-how-to-panel.component.html',
   styleUrls: ['./gene-comparison-tool-how-to-panel.component.scss'],
@@ -38,6 +47,8 @@ export class GeneComparisonToolHowToPanelComponent implements OnInit {
   isActive = false;
   willHide = false;
   willHideCookieName = 'gct_hide_how_to';
+  faAngleRight = faAngleRight;
+  faAngleLeft = faAngleLeft;
 
   panes: Pane[] = [
     {

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
@@ -8,9 +8,10 @@
     <div class="gct-header">
       <div class="gct-header-inner">
         <div class="gct-header-left">
-          <button
-            class="btn btn-rounded btn-primary"
+          <p-button
             (click)="filterPanel.toggle()"
+            size="small"
+            rounded="true"
             pTooltip="Filter genes by Nominations, Teams, Cohort, and more"
             tooltipPosition="right"
             tooltipStyleClass="tooltip"
@@ -28,21 +29,23 @@
               />
             </svg>
             Filter Genes
-          </button>
+          </p-button>
         </div>
         <div class="gct-header-middle">
           <h1 class="gct-heading h2">Gene Comparison Tool</h1>
         </div>
         <div class="gct-header-right">
-          <button
-            class="btn btn-rounded btn-outlined-primary"
+          <p-button
+            size="small"
+            rounded="true"
+            variant="outlined"
             (click)="copyUrl()"
             pTooltip="Copy the URL that captures the table's current filters, sorting, and pinned genes"
             tooltipPosition="left"
             tooltipStyleClass="tooltip"
           >
             Share URL
-          </button>
+          </p-button>
         </div>
       </div>
     </div>

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
@@ -106,11 +106,11 @@
               <div class="gct-controls-right-top">
                 <div class="gct-category-selector">
                   <div>
-                    <p-dropdown
+                    <p-select
                       [options]="categories"
                       [(ngModel)]="category"
                       (onChange)="onCategoryChange()"
-                    ></p-dropdown>
+                    ></p-select>
                   </div>
                   <div>
                     <agora-overlay-panel-link
@@ -227,12 +227,12 @@
               <div class="gct-controls-right-bottom">
                 <div class="gct-filter-label">{{ subCategoryLabel }}</div>
                 <div class="gct-sub-category-selector">
-                  <p-dropdown
+                  <p-select
                     id="subCategory"
                     [options]="subCategories"
                     [(ngModel)]="subCategory"
                     (onChange)="onSubCategoryChange()"
-                  ></p-dropdown>
+                  ></p-select>
                 </div>
               </div>
             </div>

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
@@ -128,28 +128,24 @@
       font-weight: 900;
     }
 
-    .p-dropdown {
+    .p-select {
       padding: 0;
       border: none;
       background-color: transparent;
 
-      .p-dropdown-label {
+      .p-select-label {
         padding-left: 0;
         font-size: 14px;
         font-weight: 400;
         color: var(--color-text);
       }
 
-      .p-dropdown-trigger {
-        margin-left: 8px;
-      }
-
-      .p-dropdown-trigger-icon {
+      .p-select-dropdown-icon {
         font-size: 14px;
         color: var(--color-text);
       }
 
-      .p-dropdown-panel {
+      .p-select-list-container {
         background-color: #fff;
         box-shadow: 0 1px 10px 0 rgb(0 0 0 / 15%);
         border-radius: 5px;
@@ -195,7 +191,7 @@
       }
 
       &:hover {
-        .p-dropdown-trigger-icon {
+        .p-select-dropdown-icon {
           color: var(--color-action-primary);
         }
       }
@@ -226,12 +222,12 @@
       }
     }
 
-    .p-dropdown-label {
+    .p-select-label {
       text-transform: uppercase;
       font-weight: 700 !important;
     }
 
-    .p-dropdown-panel {
+    .p-select-panel {
       ul {
         li {
           span {

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -47,9 +47,9 @@ import { GeneComparisonToolScorePanelComponent } from './components/gene-compari
 import { FormsModule } from '@angular/forms';
 import { OverlayPanelLinkComponent } from '@sagebionetworks/agora/genes';
 import { LoadingIconComponent, SvgIconComponent } from '@sagebionetworks/agora/shared';
-import { DropdownModule } from 'primeng/dropdown';
 import { InputSwitchModule } from 'primeng/inputswitch';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
+import { SelectModule } from 'primeng/select';
 import { GeneComparisonToolFilterListComponent } from './components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component';
 import { GeneComparisonToolHowToPanelComponent } from './components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component';
 import { GeneComparisonToolLegendPanelComponent } from './components/gene-comparison-tool-legend-panel/gene-comparison-tool-legend-panel.component';
@@ -63,7 +63,7 @@ import { GeneComparisonToolLegendPanelComponent } from './components/gene-compar
     RouterModule,
     TableModule,
     TooltipModule,
-    DropdownModule,
+    SelectModule,
     InputSwitchModule,
     OverlayPanelLinkComponent,
     OverlayPanelModule,

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -26,37 +26,39 @@ import {
 import { HelperService } from '@sagebionetworks/agora/services';
 import { cloneDeep } from 'lodash';
 import { FilterService, MessageService, SortEvent } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
 import { Table, TableModule } from 'primeng/table';
 import { TooltipModule } from 'primeng/tooltip';
 import { combineLatest, Subscription } from 'rxjs';
 
-import * as variables from './gene-comparison-tool.variables';
 import * as helpers from './gene-comparison-tool.helpers';
+import * as variables from './gene-comparison-tool.variables';
 
-import { GeneComparisonToolScorePanelComponent as ScorePanelComponent } from './components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component';
 import { GeneComparisonToolDetailsPanelComponent as DetailsPanelComponent } from './components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component';
 import { GeneComparisonToolFilterPanelComponent as FilterPanelComponent } from './components/gene-comparison-tool-filter-panel/gene-comparison-tool-filter-panel.component';
 import { GeneComparisonToolPinnedGenesModalComponent as PinnedGenesModalComponent } from './components/gene-comparison-tool-pinned-genes-modal/gene-comparison-tool-pinned-genes-modal.component';
+import { GeneComparisonToolScorePanelComponent as ScorePanelComponent } from './components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component';
 
-import { GeneComparisonToolScorePanelComponent } from './components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component';
 import { GeneComparisonToolDetailsPanelComponent } from './components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component';
 import { GeneComparisonToolFilterPanelComponent } from './components/gene-comparison-tool-filter-panel/gene-comparison-tool-filter-panel.component';
 import { GeneComparisonToolPinnedGenesModalComponent } from './components/gene-comparison-tool-pinned-genes-modal/gene-comparison-tool-pinned-genes-modal.component';
+import { GeneComparisonToolScorePanelComponent } from './components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component';
 
+import { FormsModule } from '@angular/forms';
+import { OverlayPanelLinkComponent } from '@sagebionetworks/agora/genes';
+import { LoadingIconComponent, SvgIconComponent } from '@sagebionetworks/agora/shared';
 import { DropdownModule } from 'primeng/dropdown';
 import { InputSwitchModule } from 'primeng/inputswitch';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
-import { FormsModule } from '@angular/forms';
+import { GeneComparisonToolFilterListComponent } from './components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component';
 import { GeneComparisonToolHowToPanelComponent } from './components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component';
 import { GeneComparisonToolLegendPanelComponent } from './components/gene-comparison-tool-legend-panel/gene-comparison-tool-legend-panel.component';
-import { GeneComparisonToolFilterListComponent } from './components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component';
-import { OverlayPanelLinkComponent } from '@sagebionetworks/agora/genes';
-import { LoadingIconComponent, SvgIconComponent } from '@sagebionetworks/agora/shared';
 
 @Component({
   selector: 'agora-gene-comparison-tool',
   imports: [
     CommonModule,
+    ButtonModule,
     FormsModule,
     RouterModule,
     TableModule,

--- a/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.html
+++ b/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.html
@@ -1,6 +1,6 @@
-<button type="button" class="btn btn-rounded btn-primary" (click)="op.toggle($event)">
+<p-button type="button" rounded="true" size="small" (click)="op.toggle($event)">
   <fa-icon [icon]="downloadIcon"></fa-icon>
-</button>
+</p-button>
 <p-overlayPanel
   #op
   styleClass="download-dom-image-panel"
@@ -11,24 +11,18 @@
     {{ heading }}
   </div>
   <div class="download-dom-image-body">
-    <div *ngFor="let type of types">
-      <p-radioButton
+    <div class="download-dom-image-option" *ngFor="let type of types">
+      <p-radiobutton
         value="{{ type.value }}"
-        inputId="download-radio"
+        inputId="download-radio-{{ type.label }}"
         [(ngModel)]="selectedType"
-      ></p-radioButton>
-      <label for="download-radio">{{ type.label }}</label>
+      ></p-radiobutton>
+      <label for="download-radio-{{ type.label }}">{{ type.label }}</label>
     </div>
     <div>
-      <button
-        pButton
-        type="button"
-        label="Download"
-        class="btn-rounded btn-primary"
-        (click)="download()"
-      >
+      <p-button label="Download" rounded="true" size="small" (click)="download()">
         <fa-icon *ngIf="isLoading" [icon]="spinnerIcon" animation="spin"></fa-icon>
-      </button>
+      </p-button>
       <div *ngIf="error" class="download-dom-image-error">{{ error }}</div>
     </div>
   </div>

--- a/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.scss
+++ b/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.scss
@@ -10,6 +10,10 @@
 .download-dom-image-panel {
   margin-top: 5px;
 
+  .download-dom-image-option {
+    display: flex;
+  }
+
   .p-overlaypanel-content {
     width: 290px;
     padding: 25px;

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
@@ -8,7 +8,7 @@
             class="gene-details-nav-scroll gene-details-nav-scroll-prev"
             (click)="slideNavigation(-1)"
           >
-            <i class="fa-solid fa-angle-left"></i>
+            <fa-icon [icon]="faAngleLeft"></fa-icon>
           </button>
         }
         <div class="gene-details-nav-container">
@@ -54,7 +54,7 @@
             class="gene-details-nav-scroll gene-details-nav-scroll-next"
             (click)="slideNavigation(1)"
           >
-            <i class="fa-solid fa-angle-right"></i>
+            <fa-icon [icon]="faAngleRight"></fa-icon>
           </button>
         }
       </div>

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
@@ -1,25 +1,27 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
+import { CommonModule, Location } from '@angular/common';
 import {
-  Component,
-  OnInit,
+  AfterViewChecked,
   AfterViewInit,
+  Component,
   HostListener,
   inject,
-  AfterViewChecked,
+  OnInit,
 } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
-import { CommonModule, Location } from '@angular/common';
 
-import { HelperService } from '@sagebionetworks/agora/services';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
 import { Gene, GenesService } from '@sagebionetworks/agora/api-client-angular';
-import { GeneSoeComponent } from '../gene-soe/gene-soe.component';
-import { GeneHeroComponent } from '../gene-hero/gene-hero.component';
-import { GeneEvidenceRnaComponent } from '../gene-evidence-rna/gene-evidence-rna.component';
-import { GeneResourcesComponent } from '../gene-resources/gene-resources.component';
-import { GeneEvidenceProteomicsComponent } from '../gene-evidence-proteomics/gene-evidence-proteomics.component';
+import { HelperService } from '@sagebionetworks/agora/services';
 import { GeneEvidenceMetabolomicsComponent } from '../gene-evidence-metabolomics/gene-evidence-metabolomics.component';
+import { GeneEvidenceProteomicsComponent } from '../gene-evidence-proteomics/gene-evidence-proteomics.component';
+import { GeneEvidenceRnaComponent } from '../gene-evidence-rna/gene-evidence-rna.component';
 import { ExperimentalValidationComponent } from '../gene-experimental-validation/gene-experimental-validation.component';
+import { GeneHeroComponent } from '../gene-hero/gene-hero.component';
 import { GeneNominationsComponent } from '../gene-nominations/gene-nominations.component';
+import { GeneResourcesComponent } from '../gene-resources/gene-resources.component';
+import { GeneSoeComponent } from '../gene-soe/gene-soe.component';
 
 interface Panel {
   name: string;
@@ -40,6 +42,7 @@ interface Panel {
     ExperimentalValidationComponent,
     GeneNominationsComponent,
     GeneResourcesComponent,
+    FontAwesomeModule,
   ],
   providers: [HelperService, GenesService],
   templateUrl: './gene-details.component.html',
@@ -51,6 +54,9 @@ export class GeneDetailsComponent implements OnInit, AfterViewInit, AfterViewChe
   location = inject(Location);
   helperService = inject(HelperService);
   geneService = inject(GenesService);
+
+  faAngleRight = faAngleRight;
+  faAngleLeft = faAngleLeft;
 
   gene: Gene | undefined;
 

--- a/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.html
+++ b/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.html
@@ -1,9 +1,10 @@
 <div class="gene-model-selector">
-  <p-dropdown
+  <p-select
     [options]="_options"
     optionLabel="name"
     [(ngModel)]="selected"
     (onChange)="_onChange()"
     placeholder="Select a model"
-  ></p-dropdown>
+    fluid="true"
+  ></p-select>
 </div>

--- a/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.ts
@@ -1,8 +1,8 @@
-import { Component, Input, Output, EventEmitter, OnInit, inject } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { removeParenthesis } from '@sagebionetworks/agora/util';
-import { DropdownModule } from 'primeng/dropdown';
+import { SelectModule } from 'primeng/select';
 
 interface Option {
   name: string;
@@ -11,7 +11,7 @@ interface Option {
 
 @Component({
   selector: 'agora-gene-model-selector',
-  imports: [FormsModule, DropdownModule],
+  imports: [FormsModule, SelectModule],
   templateUrl: './gene-model-selector.component.html',
   styleUrls: ['./gene-model-selector.component.scss'],
 })

--- a/libs/agora/genes/src/lib/components/gene-protein-selector/gene-protein-selector.component.html
+++ b/libs/agora/genes/src/lib/components/gene-protein-selector/gene-protein-selector.component.html
@@ -1,9 +1,10 @@
 <div class="gene-protein-selector">
-  <p-dropdown
+  <p-select
     [options]="_options"
     optionLabel="name"
     [(ngModel)]="selected"
     (onChange)="_onChange()"
     placeholder="Select a protein"
-  ></p-dropdown>
+    fluid="true"
+  ></p-select>
 </div>

--- a/libs/agora/genes/src/lib/components/gene-protein-selector/gene-protein-selector.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-protein-selector/gene-protein-selector.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { DropdownModule } from 'primeng/dropdown';
+import { SelectModule } from 'primeng/select';
 
 interface Option {
   name: string;
@@ -9,7 +9,7 @@ interface Option {
 
 @Component({
   selector: 'agora-gene-protein-selector',
-  imports: [FormsModule, DropdownModule],
+  imports: [FormsModule, SelectModule],
   templateUrl: './gene-protein-selector.component.html',
   styleUrls: ['./gene-protein-selector.component.scss'],
 })

--- a/libs/agora/shared/src/lib/modal-link/modal-link.component.scss
+++ b/libs/agora/shared/src/lib/modal-link/modal-link.component.scss
@@ -1,7 +1,7 @@
 @import 'libs/agora/styles/src/lib/variables';
 @import 'libs/agora/styles/src/lib/mixins';
 
-modal-link,
+agora-modal-link,
 .modal-link {
   display: inline-block;
 }

--- a/libs/agora/styles/src/lib/components/_dropdown.scss
+++ b/libs/agora/styles/src/lib/components/_dropdown.scss
@@ -1,10 +1,10 @@
-div.p-dropdown {
+div.p-select {
   display: flex;
   padding: 12px 20px 12px 30px;
   background-color: var(--color-gray-100);
   border: 1px solid var(--color-gray-300);
 
-  .p-dropdown-panel {
+  .p-select-list-container {
     border: 1px solid var(--color-gray-300);
     background-color: #fff;
     border-radius: 0 0 5px 5px;
@@ -20,12 +20,12 @@ div.p-dropdown {
     }
   }
 
-  .p-dropdown-trigger {
+  .p-select-dropdown {
     margin-left: 30px;
   }
 
   &:hover {
-    .p-dropdown-trigger-icon {
+    .p-select-dropdown-icon {
       color: var(--color-action-primary);
     }
   }

--- a/libs/agora/styles/src/lib/components/_radio.scss
+++ b/libs/agora/styles/src/lib/components/_radio.scss
@@ -50,6 +50,10 @@ p-radiobutton {
     }
   }
 
+  /* 
+    In PrimeNG v19, the radiobutton label does not have this class and is not a child of p-radiobutton, 
+    so this style does not apply to the label. TODO: move this style into the preset.
+  */
   .p-radiobutton-label {
     font-size: 16px;
     color: var(--color-text);

--- a/libs/agora/styles/src/lib/components/_typography.scss
+++ b/libs/agora/styles/src/lib/components/_typography.scss
@@ -30,23 +30,23 @@ h3,
 h4,
 h5,
 h6 {
-  download-dom-image {
+  agora-download-dom-image {
     float: right;
   }
 
-  modal-link {
+  agora-modal-link {
     float: right;
   }
 }
 
 h2 {
-  modal-link {
+  agora-modal-link {
     transform: translateY(-3px);
   }
 }
 
 h3 {
-  download-dom-image {
+  agora-download-dom-image {
     transform: translateY(-4px);
   }
 }


### PR DESCRIPTION
## Description

We recently transitioned to using PrimeNG to v19 and a preset theme, which broke some existing styling. 

## Related Issues

- [AG-1658](https://sagebionetworks.jira.com/browse/AG-1658)
- [AG-1701](https://sagebionetworks.jira.com/browse/AG-1701)

## Changelog

- Floats download button and modal-link to the right
- Converts p-dropdown to p-select and updates styles accordingly
- Updates p-select preset style to remove focus style to match current dev style
- Makes dropdowns on gene RNA and protein evidence pages full width
- Fixes font awesome icon imports
- Rounds GCT buttons

## Validation

page | change | current dev | new dev | fix
:---:|:---:|:---:|:---:|:---:
GCT help | font awesome icon | <img width="621" alt="gct_help_currentdev" src="https://github.com/user-attachments/assets/88c4b596-4bf0-49c3-b21f-2beaea86a63f" /> | <img width="620" alt="gct_help_newdev" src="https://github.com/user-attachments/assets/403d6218-1337-4196-8056-1cabbffa6547" /> | <img width="602" alt="gct_help_fix" src="https://github.com/user-attachments/assets/a2b4981f-ecd3-46ee-8fc0-fe538e18ed36" />
GCT | button shape, dropdown style | <img width="1379" alt="gct_currentdev" src="https://github.com/user-attachments/assets/b2688df4-dff3-40f3-b165-cd55c9864630" /> | <img width="1356" alt="gct_newdev" src="https://github.com/user-attachments/assets/e8b90704-7b73-43d9-822b-e7ff3e27c2f6" /> | <img width="1361" alt="gct_fix" src="https://github.com/user-attachments/assets/5d79deb0-1530-4794-b7b3-26604f424ea8" />
gene details | download and modal link alignment, button shape, radiobutton label alignment | <img width="1292" alt="download_dropdown_currentdev" src="https://github.com/user-attachments/assets/76e15f14-5f93-4ce0-b229-976b7e3aa896" /> | <img width="1200" alt="download_dropdown_newdev" src="https://github.com/user-attachments/assets/bbf69abb-72de-4b8e-b619-de00287ae6d6" /> | <img width="1221" alt="download_dropdown_fix" src="https://github.com/user-attachments/assets/98f5ecd3-eac3-490c-bad9-07a5c7789215" />

GCT dropdown styling: 

Current dev: 

https://github.com/user-attachments/assets/93854cf0-ae51-4597-8632-7cb4c4c0ada6

New dev:

https://github.com/user-attachments/assets/83326d84-ba6d-4484-bb5a-20cdab49b89d

Fix:

https://github.com/user-attachments/assets/14638e39-72f0-41d8-9aeb-0cf316c909f8


[AG-1658]: https://sagebionetworks.jira.com/browse/AG-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1701]: https://sagebionetworks.jira.com/browse/AG-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ