### PR TITLE
fix(agora):  migrate primeng overlaypanel to popover (AG-1703)

### DIFF
--- a/apps/agora/app/src/app/myPrimeNGPreset.ts
+++ b/apps/agora/app/src/app/myPrimeNGPreset.ts
@@ -1,8 +1,8 @@
 import { ApplicationConfig } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { providePrimeNG } from 'primeng/config';
-import Lara from '@primeng/themes/lara';
 import { definePreset } from '@primeng/themes';
+import Lara from '@primeng/themes/lara';
+import { providePrimeNG } from 'primeng/config';
 
 export const MyPreset = definePreset(Lara, {
   primitive: {
@@ -3757,7 +3757,7 @@ export const MyPreset = definePreset(Lara, {
         background: '{overlay.popover.background}',
         borderColor: '{overlay.popover.border.color}',
         color: '{overlay.popover.color}',
-        borderRadius: '{overlay.popover.border.radius}',
+        borderRadius: '0px',
         shadow: '{overlay.popover.shadow}',
         gutter: '10px',
         arrowOffset: '1.25rem',

--- a/libs/agora/charts/src/lib/score-barchart/score-barchart.component.scss
+++ b/libs/agora/charts/src/lib/score-barchart/score-barchart.component.scss
@@ -11,14 +11,4 @@
       cursor: pointer;
     }
   }
-
-  .bar-labels {
-    &:hover {
-      cursor: pointer;
-
-      // AG-1113: prevent label text from moving in PrimeNG OverlayPanel
-      // see: https://sagebionetworks.jira.com/browse/AG-1113
-      user-select: none;
-    }
-  }
 }

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.html
@@ -81,9 +81,9 @@
     </div>
   }
 </ng-template>
-<p-overlayPanel class="gct-details-panel" appendTo="">
+<p-popover class="gct-details-panel" appendTo="">
   <ng-container *ngTemplateOutlet="panelTemplate; context: { $implicit: _data[0] }"></ng-container>
-</p-overlayPanel>
-<p-overlayPanel class="gct-details-panel" appendTo="">
+</p-popover>
+<p-popover class="gct-details-panel" appendTo="">
   <ng-container *ngTemplateOutlet="panelTemplate; context: { $implicit: _data[1] }"></ng-container>
-</p-overlayPanel>
+</p-popover>

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.scss
@@ -1,17 +1,17 @@
 /* stylelint-disable no-descending-specificity */
 
-@import 'libs/agora/styles/src/lib/variables';
-@import 'libs/agora/styles/src/lib/mixins';
+@use 'libs/agora/styles/src/lib/variables';
+@use 'libs/agora/styles/src/lib/mixins';
 
 .gct-details-panel {
-  .p-overlaypanel {
+  .p-popover {
     width: 610px;
     max-width: 100%;
     background: #fff;
     box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
   }
 
-  .p-overlaypanel-content {
+  .p-popover-content {
     padding: 20px;
   }
 
@@ -248,7 +248,7 @@
     }
 
     a {
-      @include link;
+      @include mixins.link;
 
       display: block;
       font-size: var(--font-size-sm);

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.ts
@@ -2,20 +2,20 @@
 import { CommonModule } from '@angular/common';
 import {
   Component,
+  EventEmitter,
+  inject,
   Input,
   Output,
   ViewChildren,
   ViewEncapsulation,
-  EventEmitter,
-  inject,
 } from '@angular/core';
 import { GCTDetailsPanelData } from '@sagebionetworks/agora/models';
 import { HelperService } from '@sagebionetworks/agora/services';
-import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
+import { Popover, PopoverModule } from 'primeng/popover';
 
 @Component({
   selector: 'agora-gene-comparison-tool-details-panel',
-  imports: [CommonModule, OverlayPanelModule],
+  imports: [CommonModule, PopoverModule],
   templateUrl: './gene-comparison-tool-details-panel.component.html',
   styleUrls: ['./gene-comparison-tool-details-panel.component.scss'],
   encapsulation: ViewEncapsulation.None,
@@ -41,7 +41,7 @@ export class GeneComparisonToolDetailsPanelComponent {
   @Output() onShowLegend: EventEmitter<object> = new EventEmitter<object>();
   @Output() onNavigateToConsistencyOfChange: EventEmitter<object> = new EventEmitter<object>();
 
-  @ViewChildren(OverlayPanel) panels: any = {} as OverlayPanel;
+  @ViewChildren(Popover) panels: any = {} as Popover;
 
   getValuePosition(data: any) {
     const percentage = Math.round(((data.value - data.min) / (data.max - data.min)) * 100);

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-filter-panel/gene-comparison-tool-filter-panel.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-filter-panel/gene-comparison-tool-filter-panel.component.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable no-descending-specificity */
 
-@import 'libs/agora/styles/src/lib/variables';
-@import 'libs/agora/styles/src/lib/mixins';
+@use 'libs/agora/styles/src/lib/variables';
+@use 'libs/agora/styles/src/lib/mixins';
 
 .gct-filter-panel {
   position: absolute;
@@ -11,16 +11,16 @@
   opacity: 0;
   visibility: hidden;
   transform: translateX(-200px);
-  transition: $transition-duration;
+  transition: variables.$transition-duration;
   z-index: 500;
 
-  .p-overlaypanel {
+  .p-popover {
     background-color: #fff;
     border-radius: 0;
     box-shadow: 0 0 10px 3px rgb(0 0 0 / 15%);
   }
 
-  .p-overlaypanel-content {
+  .p-popover-content {
     padding: 30px;
   }
 
@@ -38,7 +38,7 @@
     cursor: pointer;
 
     svg path {
-      transition: $transition-duration;
+      transition: variables.$transition-duration;
     }
 
     &:hover {
@@ -87,7 +87,7 @@
         display: flex;
         width: 100%;
         padding: 10px 15px;
-        transition: $transition-duration;
+        transition: variables.$transition-duration;
         cursor: pointer;
         font-size: 18px;
 
@@ -164,7 +164,7 @@
   opacity: 0;
   visibility: hidden;
   transform: translateX(-100%);
-  transition: $transition-duration;
+  transition: variables.$transition-duration;
   overflow: auto;
   box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
 
@@ -175,10 +175,10 @@
     border: 1px solid var(--color-border);
     border-radius: 2px;
     transform: translateY(-1px);
-    transition: $transition-duration;
+    transition: variables.$transition-duration;
 
     .p-checkbox-icon {
-      transition: $transition-duration;
+      transition: variables.$transition-duration;
 
       &::before {
         display: block;
@@ -253,7 +253,7 @@
         display: flex;
         align-items: center;
         cursor: pointer;
-        transition: $transition-duration;
+        transition: variables.$transition-duration;
 
         > div {
           display: flex;

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component.html
@@ -1,4 +1,4 @@
-<p-overlayPanel class="gct-score-panel" #overlayPanel appendTo="">
+<p-popover class="gct-score-panel" #popover appendTo="">
   @if (data) {
     @if (data.geneLabel) {
       <div class="gct-score-panel-gene-label">
@@ -36,4 +36,4 @@
       <a target="_blank" href="https://forms.gle/WDXpbSB6VmdvLwhV6">Send Feedback</a>
     </div>
   }
-</p-overlayPanel>
+</p-popover>

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component.scss
@@ -1,14 +1,14 @@
-@import 'libs/agora/styles/src/lib/variables';
-@import 'libs/agora/styles/src/lib/mixins';
+@use 'libs/agora/styles/src/lib/variables';
+@use 'libs/agora/styles/src/lib/mixins';
 
 .gct-score-panel {
-  .p-overlaypanel {
+  .p-popover {
     width: 390px;
     background: #fff;
     box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
   }
 
-  .p-overlaypanel-content {
+  .p-popover-content {
     padding: 20px;
   }
 
@@ -38,7 +38,7 @@
     }
 
     a {
-      @include link;
+      @include mixins.link;
     }
   }
 }

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-score-panel/gene-comparison-tool-score-panel.component.ts
@@ -1,21 +1,21 @@
 import {
   Component,
+  EventEmitter,
   Input,
   Output,
-  ViewEncapsulation,
-  EventEmitter,
   ViewChild,
+  ViewEncapsulation,
 } from '@angular/core';
-import * as helpers from '../../gene-comparison-tool.helpers';
-import { GCTScorePanelData } from '@sagebionetworks/agora/models';
 import { OverallScoresDistribution } from '@sagebionetworks/agora/api-client-angular';
-import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
 import { ScoreBarChartComponent } from '@sagebionetworks/agora/charts';
+import { GCTScorePanelData } from '@sagebionetworks/agora/models';
 import { WikiComponent } from '@sagebionetworks/agora/shared';
+import { Popover, PopoverModule } from 'primeng/popover';
+import * as helpers from '../../gene-comparison-tool.helpers';
 
 @Component({
   selector: 'agora-gene-comparison-tool-score-panel',
-  imports: [OverlayPanelModule, WikiComponent, ScoreBarChartComponent],
+  imports: [PopoverModule, WikiComponent, ScoreBarChartComponent],
   templateUrl: './gene-comparison-tool-score-panel.component.html',
   styleUrls: ['./gene-comparison-tool-score-panel.component.scss'],
   encapsulation: ViewEncapsulation.None,
@@ -31,7 +31,7 @@ export class GeneComparisonToolScorePanelComponent {
   @Output() navigateToMethodologyEvent: EventEmitter<object> = new EventEmitter<object>();
   @Output() navigateToFeedbackEvent: EventEmitter<object> = new EventEmitter<object>();
 
-  @ViewChild('overlayPanel') overlayPanel!: OverlayPanel;
+  @ViewChild('popover') popover!: Popover;
 
   scoreDistribution: OverallScoresDistribution | undefined;
 
@@ -58,16 +58,16 @@ export class GeneComparisonToolScorePanelComponent {
       this.scoreDistribution = data.distributions.find(
         (scores) => scores.name.toUpperCase() === dataKey,
       );
-      this.overlayPanel.toggle(event);
+      this.popover.toggle(event);
     }
   }
 
   hide() {
-    this.overlayPanel.hide();
+    this.popover.hide();
   }
 
   toggle(event: Event, data?: GCTScorePanelData) {
-    if (event.target === this.event?.target && this.overlayPanel.overlayVisible) {
+    if (event.target === this.event?.target && this.popover.overlayVisible) {
       this.hide();
     } else {
       this.show(event, data);

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
@@ -139,29 +139,22 @@
                     ></p-inputSwitch>
                   </div>
                   <div>
-                    <p-overlayPanel
-                      #significanceOverlay
-                      styleClass="gct-significance-control-panel"
-                    >
-                      <ng-template pTemplate>
-                        <p class="gct-significance-control-panel-heading">
-                          Statistical significance
-                        </p>
-                        <p>Enter the P-value to use for the significance cutoff.</p>
-                        <input
-                          type="number"
-                          min="0"
-                          max="1"
-                          step="0.01"
-                          [(ngModel)]="significanceThreshold"
-                          (ngModelChange)="
-                            setSignificanceThresholdActive(significanceThresholdActive)
-                          "
-                        />
-                      </ng-template>
-                    </p-overlayPanel>
+                    <p-popover #significancePopover styleClass="gct-significance-control-panel">
+                      <p class="gct-significance-control-panel-heading">Statistical significance</p>
+                      <p>Enter the P-value to use for the significance cutoff.</p>
+                      <input
+                        type="number"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        [(ngModel)]="significanceThreshold"
+                        (ngModelChange)="
+                          setSignificanceThresholdActive(significanceThresholdActive)
+                        "
+                      />
+                    </p-popover>
                     <button
-                      (click)="significanceOverlay.toggle($event)"
+                      (click)="significancePopover.toggle($event)"
                       class="gct-significance-control-settings"
                       pTooltip="Edit significance cutoff value"
                       tooltipPosition="left"
@@ -174,41 +167,39 @@
                     </button>
                   </div>
                   <div>
-                    <p-overlayPanel #columnOverlay styleClass="gct-toggle-columns">
-                      <ng-template pTemplate>
-                        <ul id="scores-columns">
-                          <li *ngFor="let column of scoresColumns">
+                    <p-popover #columnPopover styleClass="gct-toggle-columns">
+                      <ul id="scores-columns">
+                        <li *ngFor="let column of scoresColumns">
+                          <div class="column-toggle" (click)="toggleGCTColumn(column)">
+                            <div class="column-toggle-status">
+                              <span *ngIf="column.selected" class="pi pi-check"></span>
+                            </div>
+                            <div>
+                              <span>{{ column.header }}</span>
+                            </div>
+                          </div>
+                        </li>
+                      </ul>
+                      <ul>
+                        <li *ngFor="let column of brainRegionsColumns">
+                          <ng-container *ngIf="column.visible">
                             <div class="column-toggle" (click)="toggleGCTColumn(column)">
                               <div class="column-toggle-status">
-                                <span *ngIf="column.selected" class="pi pi-check"></span>
+                                <span
+                                  *ngIf="column.selected"
+                                  class="p-checkbox-icon pi pi-check"
+                                ></span>
                               </div>
                               <div>
                                 <span>{{ column.header }}</span>
                               </div>
                             </div>
-                          </li>
-                        </ul>
-                        <ul>
-                          <li *ngFor="let column of brainRegionsColumns">
-                            <ng-container *ngIf="column.visible">
-                              <div class="column-toggle" (click)="toggleGCTColumn(column)">
-                                <div class="column-toggle-status">
-                                  <span
-                                    *ngIf="column.selected"
-                                    class="p-checkbox-icon pi pi-check"
-                                  ></span>
-                                </div>
-                                <div>
-                                  <span>{{ column.header }}</span>
-                                </div>
-                              </div>
-                            </ng-container>
-                          </li>
-                        </ul>
-                      </ng-template>
-                    </p-overlayPanel>
+                          </ng-container>
+                        </li>
+                      </ul>
+                    </p-popover>
                     <button
-                      (click)="columnOverlay.toggle($event)"
+                      (click)="columnPopover.toggle($event)"
                       pTooltip="Show/hide columns"
                       tooltipPosition="left"
                       tooltipStyleClass="tooltip"

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable no-descending-specificity */
 
-@import 'libs/agora/styles/src/lib/variables';
-@import 'libs/agora/styles/src/lib/mixins';
+@use 'libs/agora/styles/src/lib/variables';
+@use 'libs/agora/styles/src/lib/mixins';
 
 #loading {
   position: absolute;
@@ -31,7 +31,7 @@
 }
 
 .gct {
-  @include container(lg);
+  @include mixins.container(lg);
 
   color: var(--color-text);
   margin: 0 auto;
@@ -100,7 +100,7 @@
   }
 
   button {
-    @include reset-button;
+    @include mixins.reset-button;
   }
 }
 
@@ -156,7 +156,7 @@
 
           li {
             padding: 5px 15px;
-            transition: $transition-duration;
+            transition: variables.$transition-duration;
 
             span {
               white-space: nowrap;
@@ -288,7 +288,7 @@
       border: 1px solid var(--color-gray-300);
       padding: 12px 40px 12px 34px;
       width: 100%;
-      transition: $transition-duration;
+      transition: variables.$transition-duration;
       box-sizing: border-box;
       font-size: var(--font-size-xs);
       outline: none;
@@ -307,7 +307,7 @@
       cursor: pointer;
 
       svg path {
-        transition: $transition-duration;
+        transition: variables.$transition-duration;
       }
 
       &:hover {
@@ -458,7 +458,7 @@
     .p-paginator-icon {
       color: var(--color-action-primary);
       cursor: pointer;
-      transition: $transition-duration;
+      transition: variables.$transition-duration;
     }
 
     .p-link.p-disabled {
@@ -476,7 +476,7 @@
     align-items: stretch;
     flex: 1;
     background-color: transparent;
-    transition: $transition-duration;
+    transition: variables.$transition-duration;
     padding: 6px 15px 6px 7px;
     margin-right: 0;
     font-size: var(--font-size-md);
@@ -541,7 +541,7 @@
     z-index: 100;
     border: 1px solid transparent;
     cursor: pointer;
-    transition: $transition-duration;
+    transition: variables.$transition-duration;
 
     > span {
       display: block;
@@ -552,7 +552,7 @@
       opacity: 0;
       visibility: hidden;
       background-color: transparent;
-      transition: $transition-duration;
+      transition: variables.$transition-duration;
     }
 
     &.plus {
@@ -648,7 +648,7 @@
 
     &:hover {
       color: var(--color-primary);
-      transition: $transition-duration;
+      transition: variables.$transition-duration;
     }
   }
 
@@ -664,7 +664,7 @@
 
     &:not(.disabled) {
       &:hover {
-        @include link-hover;
+        @include mixins.link-hover;
       }
     }
 
@@ -703,7 +703,7 @@
     }
 
     &:hover {
-      @include link-hover;
+      @include mixins.link-hover;
     }
   }
 }
@@ -711,7 +711,7 @@
 .clear-all-button {
   button {
     &:hover {
-      @include link-hover;
+      @include mixins.link-hover;
     }
   }
 }
@@ -723,7 +723,7 @@
   border-radius: 3px;
   box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
 
-  .p-overlaypanel-content {
+  .p-popover-content {
     padding: 20px;
   }
 }
@@ -733,7 +733,7 @@
   background: #fff;
   box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
 
-  .p-overlaypanel-content {
+  .p-popover-content {
     padding: 40px;
   }
 
@@ -794,7 +794,7 @@
   background: #fff;
   box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
 
-  .p-overlaypanel-content {
+  .p-popover-content {
     ul#scores-columns {
       &::after {
         content: ' ';

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -48,7 +48,7 @@ import { FormsModule } from '@angular/forms';
 import { PopoverLinkComponent } from '@sagebionetworks/agora/genes';
 import { LoadingIconComponent, SvgIconComponent } from '@sagebionetworks/agora/shared';
 import { InputSwitchModule } from 'primeng/inputswitch';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
+import { PopoverModule } from 'primeng/popover';
 import { SelectModule } from 'primeng/select';
 import { GeneComparisonToolFilterListComponent } from './components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component';
 import { GeneComparisonToolHowToPanelComponent } from './components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component';
@@ -66,7 +66,7 @@ import { GeneComparisonToolLegendPanelComponent } from './components/gene-compar
     SelectModule,
     InputSwitchModule,
     PopoverLinkComponent,
-    OverlayPanelModule,
+    PopoverModule,
     SvgIconComponent,
     GeneComparisonToolHowToPanelComponent,
     GeneComparisonToolLegendPanelComponent,

--- a/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.html
+++ b/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.html
@@ -1,7 +1,7 @@
 <p-button type="button" rounded="true" size="small" (click)="op.toggle($event)">
   <fa-icon [icon]="downloadIcon"></fa-icon>
 </p-button>
-<p-overlayPanel
+<p-popover
   #op
   styleClass="download-dom-image-panel"
   (rotate)="onRotate()"
@@ -26,4 +26,4 @@
       <div *ngIf="error" class="download-dom-image-error">{{ error }}</div>
     </div>
   </div>
-</p-overlayPanel>
+</p-popover>

--- a/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.scss
+++ b/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.scss
@@ -1,5 +1,5 @@
-@import 'libs/agora/styles/src/lib/variables';
-@import 'libs/agora/styles/src/lib/mixins';
+@use 'libs/agora/styles/src/lib/variables';
+@use 'libs/agora/styles/src/lib/mixins';
 
 .download-dom-image-icon {
   transform: translateY(6px);
@@ -14,7 +14,7 @@
     display: flex;
   }
 
-  .p-overlaypanel-content {
+  .p-popover-content {
     width: 290px;
     padding: 25px;
     background-color: #fff;

--- a/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.ts
+++ b/libs/agora/genes/src/lib/components/download-dom-image/download-dom-image.component.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 import domtoimage from 'dom-to-image-more';
 
-import { Component, ViewChild, Input, ViewEncapsulation } from '@angular/core';
-import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
-import { saveAs } from 'file-saver';
-import { RadioButtonModule } from 'primeng/radiobutton';
 import { CommonModule } from '@angular/common';
+import { Component, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ButtonModule } from 'primeng/button';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faDownload, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { saveAs } from 'file-saver';
+import { ButtonModule } from 'primeng/button';
+import { Popover, PopoverModule } from 'primeng/popover';
+import { RadioButtonModule } from 'primeng/radiobutton';
 
 interface Type {
   value: string;
@@ -21,7 +21,7 @@ interface Type {
   imports: [
     CommonModule,
     FormsModule,
-    OverlayPanelModule,
+    PopoverModule,
     RadioButtonModule,
     ButtonModule,
     FontAwesomeModule,
@@ -54,7 +54,7 @@ export class DownloadDomImageComponent {
   isLoading = false;
   resizeTimer: ReturnType<typeof setTimeout> | number = 0;
 
-  @ViewChild('op', { static: true }) overlayPanel: OverlayPanel = {} as OverlayPanel;
+  @ViewChild('op', { static: true }) popover: Popover = {} as Popover;
 
   download() {
     if (this.isLoading) {
@@ -86,7 +86,7 @@ export class DownloadDomImageComponent {
 
   hide() {
     this.error = '';
-    this.overlayPanel.hide();
+    this.popover.hide();
   }
 
   onRotate() {

--- a/libs/agora/genes/src/lib/components/popover-link/popover-link.component.html
+++ b/libs/agora/genes/src/lib/components/popover-link/popover-link.component.html
@@ -21,8 +21,10 @@
     }
   </span>
 </p-button>
-<p-popover #popover styleClass="popover">
-  @if (wikiId && hasActived) {
-    <agora-wiki [ownerId]="ownerId" [wikiId]="wikiId"></agora-wiki>
-  }
+<p-popover #popover>
+  <div class="popover-link-content">
+    @if (wikiId && hasActived) {
+      <agora-wiki [ownerId]="ownerId" [wikiId]="wikiId"></agora-wiki>
+    }
+  </div>
 </p-popover>

--- a/libs/agora/genes/src/lib/components/popover-link/popover-link.component.scss
+++ b/libs/agora/genes/src/lib/components/popover-link/popover-link.component.scss
@@ -6,6 +6,12 @@ agora-popover-link,
   display: inline-block;
 }
 
+.popover-link-content {
+  max-width: 425px;
+  padding: 20px;
+  background: #fff;
+}
+
 .popover-link-inner {
   display: flex;
 }

--- a/libs/agora/styles/src/lib/components/_shame.scss
+++ b/libs/agora/styles/src/lib/components/_shame.scss
@@ -298,16 +298,6 @@ p-inputswitch.ng-dirty.ng-invalid > .p-inputswitch {
   border-color: #e24c4c;
 }
 
-.popover {
-  max-width: 425px;
-  background: #fff;
-  box-shadow: 0 0 10px 0 rgb(0 0 0 / 15%);
-
-  .p-popover-content {
-    padding: 40px;
-  }
-}
-
 /* Remove primeng popover arrow */
 .p-popover::before,
 .p-popover::after {


### PR DESCRIPTION
## Description

We recently updated to PrimeNG v19 from v17. There were a number of changes to the component names and style classes from v17 to v18+, see [here](https://primeng.org/guides/migration). The `OverlayPanel` component was renamed `Popover`. This PR updates all Agora components to use `Popover` instead of `OverlayPanel`.

## Related Issues

- [AG-1703](https://sagebionetworks.jira.com/browse/AG-1703)

## Changelog

- Migrates all Agora components to use `Popover` instead of `OverlayPanel`
- Moves global popover styles into preset or colocate with targeted component
- Updates SASS files to use `@use` rather than [deprecated `@import`](https://sass-lang.com/blog/import-is-deprecated/)

## Validation

component | currentdev | newdev | fix
:---:|:---:|:---:|:---:
download dom image | <img width="323" alt="currentdev_downloaddomimage" src="https://github.com/user-attachments/assets/201cd867-302a-4ff7-9236-c343648887b8" /> | <img width="227" alt="newdev_downloaddomimage" src="https://github.com/user-attachments/assets/66cc12f5-c5c6-4c18-a805-f69665dc3a4a" /> | <img width="348" alt="fix_downloaddomimage" src="https://github.com/user-attachments/assets/471756c6-ee8b-40a5-9c06-a7138f959596" />
GCT gene details | <img width="992" alt="currentdev_details" src="https://github.com/user-attachments/assets/553f2010-4796-4e56-8191-5ff2398e8fa3" /> | <img width="553" alt="newdev_details" src="https://github.com/user-attachments/assets/07fb7db5-dd2a-45b5-8446-9685813d71f3" /> | <img width="845" alt="fix_details" src="https://github.com/user-attachments/assets/ce25e96a-d8ae-47dc-8c87-b8cef5a27364" />
GCT columns filter | <img width="388" alt="currentdev_columns" src="https://github.com/user-attachments/assets/966fcd6d-b736-4fee-ac44-56b6a2c9b9ae" /> | <img width="408" alt="newdev_columns" src="https://github.com/user-attachments/assets/baca3099-0379-450c-8ce2-2b92067f2302" /> | <img width="442" alt="fix_columns" src="https://github.com/user-attachments/assets/b4cd51b6-294e-4e1c-84c9-a18c6facd97c" />
GCT significance filter | <img width="581" alt="currentdev_significance" src="https://github.com/user-attachments/assets/33f35d1d-5c4d-4f0b-b162-a41db65d4b17" /> | <img width="462" alt="newdev_significance" src="https://github.com/user-attachments/assets/e1c2f418-697f-433b-99f8-584371cb85c1" /> | <img width="506" alt="fix_significance" src="https://github.com/user-attachments/assets/ace32fc6-c14f-4443-9107-c61250fc9053" />

[AG-1703]: https://sagebionetworks.jira.com/browse/AG-1703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ