### PR TITLE
chore(common): use setupZoneTestEnv instead of deprecated setup-jest.js (SMR-22)

### DIFF
--- a/apps/agora/app/src/test-setup.ts
+++ b/apps/agora/app/src/test-setup.ts
@@ -6,4 +6,5 @@ globalThis.ngJest = {
   },
 };
 
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/apps/model-ad/app/src/test-setup.ts
+++ b/apps/model-ad/app/src/test-setup.ts
@@ -1,5 +1,7 @@
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();
+
 // @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-import 'jest-preset-angular/setup-jest';
 globalThis.ngJest = {
   testEnvironmentOptions: {
     errorOnUnknownElements: true,

--- a/apps/openchallenges/app/src/test-setup.ts
+++ b/apps/openchallenges/app/src/test-setup.ts
@@ -5,4 +5,5 @@ globalThis.ngJest = {
     errorOnUnknownProperties: true,
   },
 };
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/apps/sandbox/angular-app/src/test-setup.ts
+++ b/apps/sandbox/angular-app/src/test-setup.ts
@@ -5,4 +5,5 @@ globalThis.ngJest = {
     errorOnUnknownProperties: true,
   },
 };
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/about/src/test-setup.ts
+++ b/libs/agora/about/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/api-client-angular/src/test-setup.ts
+++ b/libs/agora/api-client-angular/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/charts/src/test-setup.ts
+++ b/libs/agora/charts/src/test-setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();
 
 /**
  * Mock clientHeight and clientWidth -- Apache Echarts expects a non-zero value to be returned, but

--- a/libs/agora/config/src/test-setup.ts
+++ b/libs/agora/config/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/gene-comparison-tool/src/test-setup.ts
+++ b/libs/agora/gene-comparison-tool/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/home/src/test-setup.ts
+++ b/libs/agora/home/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/news/src/test-setup.ts
+++ b/libs/agora/news/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/nominated-targets/src/test-setup.ts
+++ b/libs/agora/nominated-targets/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/not-found/src/test-setup.ts
+++ b/libs/agora/not-found/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/shared/src/test-setup.ts
+++ b/libs/agora/shared/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/teams/src/test-setup.ts
+++ b/libs/agora/teams/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/testing/src/test-setup.ts
+++ b/libs/agora/testing/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/ui/src/test-setup.ts
+++ b/libs/agora/ui/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/agora/util/src/test-setup.ts
+++ b/libs/agora/util/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/model-ad/api-client-angular/src/test-setup.ts
+++ b/libs/model-ad/api-client-angular/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/model-ad/config/src/test-setup.ts
+++ b/libs/model-ad/config/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/model-ad/not-found/src/test-setup.ts
+++ b/libs/model-ad/not-found/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/model-ad/ui/src/test-setup.ts
+++ b/libs/model-ad/ui/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/model-ad/util/src/test-setup.ts
+++ b/libs/model-ad/util/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/about/src/test-setup.ts
+++ b/libs/openchallenges/about/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/api-client-angular/src/test-setup.ts
+++ b/libs/openchallenges/api-client-angular/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/challenge-search/src/test-setup.ts
+++ b/libs/openchallenges/challenge-search/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/challenge/src/test-setup.ts
+++ b/libs/openchallenges/challenge/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/config/src/test-setup.ts
+++ b/libs/openchallenges/config/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/home/src/test-setup.ts
+++ b/libs/openchallenges/home/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/not-found/src/test-setup.ts
+++ b/libs/openchallenges/not-found/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/org-profile/src/test-setup.ts
+++ b/libs/openchallenges/org-profile/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/org-search/src/test-setup.ts
+++ b/libs/openchallenges/org-search/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/signup/src/test-setup.ts
+++ b/libs/openchallenges/signup/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/team/src/test-setup.ts
+++ b/libs/openchallenges/team/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/ui/src/test-setup.ts
+++ b/libs/openchallenges/ui/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/openchallenges/util/src/test-setup.ts
+++ b/libs/openchallenges/util/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/results-visualization-framework/ui/src/test-setup.ts
+++ b/libs/results-visualization-framework/ui/src/test-setup.ts
@@ -1,2 +1,3 @@
 import '@testing-library/jest-dom';
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/sandbox/angular-lib/src/test-setup.ts
+++ b/libs/sandbox/angular-lib/src/test-setup.ts
@@ -5,4 +5,5 @@ globalThis.ngJest = {
     errorOnUnknownProperties: true,
   },
 };
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/shared/typescript/charts-angular/src/test-setup.ts
+++ b/libs/shared/typescript/charts-angular/src/test-setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();
 
 /**
  * Mock clientHeight and clientWidth -- Apache Echarts expects a non-zero value to be returned, but

--- a/libs/shared/typescript/util/src/test-setup.ts
+++ b/libs/shared/typescript/util/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/synapse/api-client-angular/src/test-setup.ts
+++ b/libs/synapse/api-client-angular/src/test-setup.ts
@@ -1,1 +1,2 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();


### PR DESCRIPTION
## Description

Importing `setup-jest.js` directly is deprecated. The file `setup-jest.js` will be removed in the future. We should use `setupZoneTestEnv` instead.

## Related Issues

- [SMR-22](https://sagebionetworks.jira.com/browse/SMR-22)

[SMR-22]: https://sagebionetworks.jira.com/browse/SMR-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ