### PR TITLE
fix(common): pin nrwl/nx-set-shas to v4.2.1

### DIFF
--- a/.github/workflows/e2e-agora.yaml
+++ b/.github/workflows/e2e-agora.yaml
@@ -29,7 +29,8 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.sha || github.ref }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        # Pin to v4.2.1 until https://github.com/nrwl/nx-set-shas/issues/186 is fixed
+        uses: nrwl/nx-set-shas@v4.2.1
 
       - name: Set up the dev container
         id: setup-dev-container
@@ -81,7 +82,8 @@ jobs:
         run: git switch -c new-branch
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        # Pin to v4.2.1 until https://github.com/nrwl/nx-set-shas/issues/186 is fixed
+        uses: nrwl/nx-set-shas@v4.2.1
 
       - name: Set up the dev container
         id: setup-dev-container

--- a/.github/workflows/sonar-scan-pull-request.yml
+++ b/.github/workflows/sonar-scan-pull-request.yml
@@ -26,7 +26,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        # Pin to v4.2.1 until https://github.com/nrwl/nx-set-shas/issues/186 is fixed
+        uses: nrwl/nx-set-shas@v4.2.1
 
       - name: Set up the dev container
         env:


### PR DESCRIPTION
Workflows that are triggered by `pull_request_target` are failing (see [here](https://github.com/Sage-Bionetworks/sage-monorepo/actions/runs/13727614427/job/38397544419?pr=3027)) due to an error in `nrwl/nx-set-shas@v4.3.0` (see nrwl/nx-set-shas#186). For now, we will pin the action to the previous version of `nrwl/nx-set-shas`. 