### PR TITLE
chore(iatlas): add the task `iatlas-data:serve-detach` and update docs (ARCH-380)

### DIFF
--- a/apps/iatlas/data/README.md
+++ b/apps/iatlas/data/README.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-This project provides a Dockerized solution for downloading iAtlas data and its schema from Synapse
-before seeding the iAtlas database (PostgreSQL).
+This project provides a containerized solution for downloading iAtlas data and its schema from
+Synapse before seeding the iAtlas database (PostgreSQL).
 
 ## Create the initial config
 

--- a/apps/iatlas/data/README.md
+++ b/apps/iatlas/data/README.md
@@ -2,11 +2,53 @@
 
 ## Overview
 
-Creates a Docker container that download iAtlas data and data schema from Synapse before seeding the
-iAtlas DB.
+This project provides a Dockerized solution for downloading iAtlas data and its schema from Synapse
+before seeding the iAtlas database (PostgreSQL).
+
+## Create the initial config
+
+Generate the `.env` configuration file before updating it manually:
+
+```console
+nx create-config iatlas-data
+```
 
 ## Prepare the project
 
+Set up the Python virtual environment and install dependencies:
+
 ```console
 nx prepare iatlas-data
+```
+
+## Start the PostgreSQL Docker container
+
+Refer to the `iatlas-data` project README for instructions on building and starting the PostgreSQL
+Docker container.
+
+## Running the application
+
+### Run locally
+
+Start the application in a local development environment:
+
+```console
+nx serve iatlas-data
+```
+
+### Build the Docker image
+
+Create a Docker image of the application:
+
+```console
+nx build-image iatlas-data
+```
+
+### Run with Docker Compose
+
+Start the application using Docker Compose. This command will automatically start the PostgreSQL
+container if it is not already running, then launch the application container:
+
+```console
+nx serve-detach iatlas-data
 ```

--- a/apps/iatlas/data/project.json
+++ b/apps/iatlas/data/project.json
@@ -4,6 +4,13 @@
   "projectType": "application",
   "sourceRoot": "apps/iatlas/data/src",
   "targets": {
+    "create-config": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
+      }
+    },
     "prepare": {
       "executor": "nx:run-commands",
       "options": {
@@ -16,6 +23,12 @@
       "options": {
         "command": "uv run src/build_database.py",
         "cwd": "{projectRoot}"
+      }
+    },
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker/iatlas/serve-detach.sh {projectName}"
       }
     }
   },

--- a/apps/iatlas/postgres/README.md
+++ b/apps/iatlas/postgres/README.md
@@ -1,11 +1,31 @@
 # iAtlas PostgreSQL
 
-## Build the Docker image
+## Overview
+
+This project provides a containerized PostgreSQL database for the iAtlas application.
+
+## Create the initial config
+
+Generate the `.env` configuration file before updating it manually:
+
+```console
+nx create-config iatlas-postgres
+```
+
+## Running the database
+
+### Build the Docker image
+
+Create a Docker image of the database:
 
 ```
 nx build-image iatlas-postgres
 ```
 
-## References
+### Run with Docker Compose
 
-- https://github.com/generalui/postgres_docker
+Start the database using Docker Compose:
+
+```console
+nx serve-detach iatlas-postgres
+```


### PR DESCRIPTION
Closes [ARCH-380](https://sagebionetworks.jira.com/browse/ARCH-380)

## Changelog

- Add the task `iatlas-data:serve-detach` and `iatlas-data:serve`.
- Update the READMEs of `iatlas-data` and `iatlas-postgres`.

## Notes

The tasks `iatlas-data:serve-detach` and `iatlas-data:serve` have not been tested yet due to their long execution time. @andrewelamb will test them separately as part of a dedicated effort.

[ARCH-380]: https://sagebionetworks.jira.com/browse/ARCH-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ