### PR TITLE
fix(iatlas): migrate iAtlas API Dockerfile to uv (ARCH-381)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,10 +16,14 @@
   },
   "features": {},
   "forwardPorts": [
-    2432, 3306, 3333, 4200, 4211, 5000, 5200, 5432, 5601, 8010, 8071, 8000, 8080, 8081, 8082, 8084,
+    2000, 2432, 3306, 3333, 4200, 4211, 5200, 5432, 5601, 8010, 8071, 8000, 8080, 8081, 8082, 8084,
     8085, 8086, 8090, 8200, 8888, 8889, 9200, 9411, 27017
   ],
   "portsAttributes": {
+    "2000": {
+      "label": "iatlas-api",
+      "onAutoForward": "silent"
+    },
     "2432": {
       "label": "iatlas-postgres",
       "onAutoForward": "silent"
@@ -38,10 +42,6 @@
     },
     "4211": {
       "label": "nx graph",
-      "onAutoForward": "silent"
-    },
-    "5000": {
-      "label": "iatlas-api",
       "onAutoForward": "silent"
     },
     "5432": {

--- a/apps/iatlas/api/Dockerfile
+++ b/apps/iatlas/api/Dockerfile
@@ -56,4 +56,4 @@ RUN chmod +x docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD ["uwsgi", "--ini", "uwsgi.ini", "--lazy", "--http", ":5000"]
+CMD ["uwsgi", "--ini", "uwsgi.ini", "--lazy", "--http", ":2000"]

--- a/apps/iatlas/api/Dockerfile
+++ b/apps/iatlas/api/Dockerfile
@@ -12,26 +12,30 @@ ENV UV_NO_INSTALLER_METADATA=1
 # Enable copy mode to support bind mount caching.
 ENV UV_LINK_MODE=copy
 
-# Copy uv binary
+# Copy uv binary.
 COPY --from=uv /uv /bin/uv
 
-# Copy dependency files
+# Copy dependency files.
 WORKDIR /app
 COPY pyproject.toml uv.lock ./
 
-# Generate requirements.txt and install dependencies
-RUN uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
-    uv pip install -r requirements.txt --target "/app"
+# Install C compiler to build uWSGI.
+RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get install --no-install-recommends -qq -y \
+    build-essential
+
+# Generate requirements.txt and install dependencies.
+RUN uv export --frozen --no-emit-workspace --no-dev --group prod --no-editable -o requirements.txt \
+  && uv pip install -r requirements.txt --target "/app"
 
 FROM python:3.8.20-slim
 
 ENV APP_DIR=/app
 ENV PYTHONPATH="${APP_DIR}"
+ENV PATH="${APP_DIR}/bin:${PATH}"
 
 RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && apt-get install --no-install-recommends -qq -y \
-    # Required to install uWSGI
-    build-essential \
     # Used in docker-entrypoint.sh
     gosu \
   && apt-get -y clean \
@@ -52,4 +56,4 @@ RUN chmod +x docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD ["python", "src/build_database.py"]
+CMD ["uwsgi", "--ini", "uwsgi.ini", "--lazy", "--http", ":5000"]

--- a/apps/iatlas/api/README.md
+++ b/apps/iatlas/api/README.md
@@ -40,14 +40,6 @@ Refer to the `iatlas-data` project README for instructions.
 
 ## Running the application
 
-### Run locally
-
-Start the application in a local development environment:
-
-```console
-nx serve iatlas-api
-```
-
 ### Build the Docker image
 
 Create a Docker image of the application:
@@ -68,13 +60,14 @@ nx serve-detach iatlas-api
 
 ## Open the GraphQL Playground
 
-To access the GraphQL Playground, open your browser and navigate to:
+To access the GraphQL Playground, open your browser and go to:
 
-`http://http://localhost:5000/graphiql`
+`http://http://localhost:2000/graphiql`
 
-Use the query shown below to test the API or use one included in `./example_queries`.
+You can test the API using the query below or explore additional examples in the `./example_queries`
+directory.
 
-```json
+```graphql
 {
   __schema {
     queryType {

--- a/apps/iatlas/api/README.md
+++ b/apps/iatlas/api/README.md
@@ -1,5 +1,7 @@
 # iAtlas API
 
+## Overview
+
 A GraphQL API that serves data from the iAtlas Data Database. This is built in Python and developed
 and deployed in Docker.
 
@@ -11,25 +13,54 @@ Show the tasks available to this project:
 nx show project iatlas-api
 ```
 
-## Create the project configuration file
+## Create the project config
+
+Generate the `.env` configuration file before updating it manually:
 
 ```console
 nx create-config iatlas-api
 ```
 
-## Prepare the Python environment
+## Prepare the project
+
+Set up the Python virtual environment and install dependencies:
 
 ```console
 nx prepare iatlas-api
 ```
 
-## Build the Docker image
+## Start the PostgreSQL Docker container
+
+Refer to the `iatlas-postgres` project README for instructions on building and starting the
+PostgreSQL Docker container.
+
+## Populate the PostgreSQL database
+
+Refer to the `iatlas-data` project README for instructions.
+
+## Running the application
+
+### Run locally
+
+Start the application in a local development environment:
+
+```console
+nx serve iatlas-api
+```
+
+### Build the Docker image
+
+Create a Docker image of the application:
 
 ```console
 nx build-image iatlas-api
 ```
 
-## Start the API with Docker Compose
+### Run with Docker Compose
+
+Start the application using Docker Compose. This command will automatically start the PostgreSQL
+container if it is not already running, then populate the data before launching the application
+container:
 
 ```console
 nx serve-detach iatlas-api

--- a/apps/iatlas/data/README.md
+++ b/apps/iatlas/data/README.md
@@ -5,7 +5,7 @@
 This project provides a containerized solution for downloading iAtlas data and its schema from
 Synapse before seeding the iAtlas database (PostgreSQL).
 
-## Create the initial config
+## Create the project config
 
 Generate the `.env` configuration file before updating it manually:
 
@@ -23,8 +23,8 @@ nx prepare iatlas-data
 
 ## Start the PostgreSQL Docker container
 
-Refer to the `iatlas-data` project README for instructions on building and starting the PostgreSQL
-Docker container.
+Refer to the `iatlas-postgres` project README for instructions on building and starting the
+PostgreSQL Docker container.
 
 ## Running the application
 

--- a/apps/iatlas/data/docker-entrypoint.sh
+++ b/apps/iatlas/data/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ "$1" = 'python' ]; then
+if [ "$1" = 'python' ] || [ "$1" = 'uwsgi' ]; then
     cd ${APP_DIR}
     exec gosu www-data "$@"
 fi

--- a/apps/iatlas/postgres/README.md
+++ b/apps/iatlas/postgres/README.md
@@ -4,7 +4,7 @@
 
 This project provides a containerized PostgreSQL database for the iAtlas application.
 
-## Create the initial config
+## Create the project config
 
 Generate the `.env` configuration file before updating it manually:
 

--- a/docker/iatlas/services/api.yml
+++ b/docker/iatlas/services/api.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - iatlas
     ports:
-      - '2000:5000'
+      - '2000:2000'
       - '8020:8020' # SnakeViz
     depends_on:
       iatlas-postgres:

--- a/docker/iatlas/services/api.yml
+++ b/docker/iatlas/services/api.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - iatlas
     ports:
-      - '5000:5000'
+      - '2000:5000'
       - '8020:8020' # SnakeViz
     depends_on:
       iatlas-postgres:


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/ARCH-381

## Changelog

- Update the Dockerfile to build uWSGI and add it to the PATH.
- Update the `docker-entrypoint.sh` to support `uwsgi` commands.
- Update the README of the project `iatlas-api`.
- Update `iatlas-api` container and the dev container to forward to port 2000 instead of 5000.

## How to test this PR

Build the Docker images:

```console
iatlas-build-images
```

Start the database and GraphQL API containers:

```console
nx serve-detach iatlas-api
```

Navigate to `http://localhost:2000/graphiql` and enter the following query in the GraphQL Playground:

```graphql
{
  __schema {
    queryType {
      name
    }
  }
}
```

![image](https://github.com/user-attachments/assets/9262d520-e2c3-47ee-8a03-45b322024c9d)

## Notes

- VS Code was forwarding to port 5001 instead of 5000 for unknown reason (reserved port?). An quick solution to have the dev container forward to the same port as the API container was to change the port.