### PR TITLE
fix(agora): handle legacy page URLs (AG-1712)

### DIFF
--- a/apps/agora/app/e2e/gene-details.spec.ts
+++ b/apps/agora/app/e2e/gene-details.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { baseURL } from '../playwright.config';
 import { waitForSpinnerNotVisible } from './helpers/utils';
 
 test.describe('specific viewport block', () => {
@@ -26,5 +27,12 @@ test.describe('specific viewport block', () => {
 
     const header = page.getByRole('heading', { name: 'Consistency of Change in Expression' });
     await expect(header).toBeInViewport();
+  });
+});
+
+test.describe('legacy url redirects', () => {
+  test('redirects to gene details', async ({ page }) => {
+    await page.goto('/genes/(genes-router:gene-details/ENSG00000135940)');
+    await expect(page).toHaveURL(`${baseURL}/genes/ENSG00000135940`);
   });
 });

--- a/apps/agora/app/e2e/nominated-targets.spec.ts
+++ b/apps/agora/app/e2e/nominated-targets.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { baseURL } from '../playwright.config';
 
 test.describe('specific viewport block', () => {
   test.use({ viewport: { width: 1600, height: 1200 } });
@@ -10,5 +11,12 @@ test.describe('specific viewport block', () => {
     await expect(page).toHaveTitle(
       'Nominated Targets | Candidate genes for AD treatment or prevention',
     );
+  });
+});
+
+test.describe('legacy url redirects', () => {
+  test('redirects to nominated targets', async ({ page }) => {
+    await page.goto('/genes/(genes-router:genes-list)');
+    await expect(page).toHaveURL(`${baseURL}/genes/nominated-targets`);
   });
 });

--- a/apps/agora/app/src/app/app.config.ts
+++ b/apps/agora/app/src/app/app.config.ts
@@ -1,24 +1,26 @@
-import { ApplicationConfig, APP_ID, inject, provideAppInitializer } from '@angular/core';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { APP_ID, ApplicationConfig, inject, provideAppInitializer } from '@angular/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
+  UrlSerializer,
   withEnabledBlockingInitialNavigation,
   withInMemoryScrolling,
 } from '@angular/router';
-import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/agora/api-client-angular';
+import { configFactory, ConfigService } from '@sagebionetworks/agora/config';
+import { BASE_PATH as SYNAPSE_API_CLIENT_BASE_PATH } from '@sagebionetworks/synapse/api-client-angular';
 import { providePrimeNG } from 'primeng/config';
 import { MyPreset } from './myPrimeNGPreset';
-import { BASE_PATH as API_CLIENT_BASE_PATH } from '@sagebionetworks/agora/api-client-angular';
-import { BASE_PATH as SYNAPSE_API_CLIENT_BASE_PATH } from '@sagebionetworks/synapse/api-client-angular';
-import { configFactory, ConfigService } from '@sagebionetworks/agora/config';
 
-import { routes } from './app.routes';
 import {
   httpErrorInterceptor,
   rollbarFactory,
   RollbarService,
 } from '@sagebionetworks/agora/services';
 import { MessageService } from 'primeng/api';
+import { CustomUrlSerializer } from './app.custom-uri-serializer';
+import { routes } from './app.routes';
 
 // This index is used to remove the corresponding provider in app.config.server.ts.
 // TODO: This index could be out of sync if we are not careful. Find a more elegant way.
@@ -71,6 +73,7 @@ export const appConfig: ApplicationConfig = {
         scrollPositionRestoration: 'enabled',
       }),
     ),
+    { provide: UrlSerializer, useClass: CustomUrlSerializer },
     MessageService,
   ],
 };

--- a/apps/agora/app/src/app/app.custom-uri-serializer.ts
+++ b/apps/agora/app/src/app/app.custom-uri-serializer.ts
@@ -1,0 +1,17 @@
+import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
+
+// CustomUrlSerializer strips parentheses from legacy Agora URLs
+// before parsing; this prevents legacy path parts (e.g. (genes-router:genes-list)
+// from being stripped before Angular route handling.
+export class CustomUrlSerializer implements UrlSerializer {
+  private readonly defaultSerializer = new DefaultUrlSerializer();
+
+  parse(url: any): UrlTree {
+    url = url.replace('(', '').replace(')', '');
+    return this.defaultSerializer.parse(url);
+  }
+
+  serialize(tree: UrlTree): any {
+    return this.defaultSerializer.serialize(tree);
+  }
+}


### PR DESCRIPTION
## Description

Current Agora redirects legacy URLs to their current URLs. The migrated Agora app should replicate this behavior.

## Related Issues

- [AG-1712](https://sagebionetworks.jira.com/browse/AG-1712)

## Changelog

- Add [CustomUrlSerializer](https://github.com/Sage-Bionetworks/Agora/blob/develop/src/app/app.custom-uri-serializer.ts) from current Agora to strip parentheses from legacy URLs
- Add e2e tests to confirm that redirect works as expected

## Validation

Build and run agora: `agora-build-images && nx serve-detach agora-apex`
Navigate to legacy URLs and see that you are redirected: 

http://localhost:8000/genes/(genes-router:genes-list)  -> http://localhost:8000/genes/nominated-targets

https://github.com/user-attachments/assets/6fa773a4-0a9f-4939-851e-597ac8fc2263

http://localhost:8000/genes/(genes-router:gene-details/ENSG00000135940) -> http://localhost:8000/genes/ENSG00000135940

https://github.com/user-attachments/assets/bda7c8e6-c18d-4471-bab1-795f5573eb51

[AG-1712]: https://sagebionetworks.jira.com/browse/AG-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ