### PR TITLE
fix(agora): standardizing display of true and false values (AG-1665)

### DIFF
--- a/libs/agora/genes/src/lib/components/gene-table/gene-table.component.html
+++ b/libs/agora/genes/src/lib/components/gene-table/gene-table.component.html
@@ -78,7 +78,7 @@
           [style]="{ width: column.width + 'px' }"
           [ngClass]="{ hidden: !selectedColumns.includes(column) }"
         >
-          {{ item[column.field] }}
+          {{ item[column.field] | capitalize }}
         </td>
       </tr>
     </ng-template>

--- a/libs/agora/genes/src/lib/components/gene-table/gene-table.component.html
+++ b/libs/agora/genes/src/lib/components/gene-table/gene-table.component.html
@@ -78,7 +78,7 @@
           [style]="{ width: column.width + 'px' }"
           [ngClass]="{ hidden: !selectedColumns.includes(column) }"
         >
-          {{ item[column.field] | capitalize }}
+          {{ item[column.field] | capitalizeBoolean }}
         </td>
       </tr>
     </ng-template>

--- a/libs/agora/genes/src/lib/components/gene-table/gene-table.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-table/gene-table.component.ts
@@ -11,7 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faArrowRightArrowLeft, faDownload } from '@fortawesome/free-solid-svg-icons';
 import { GeneTableColumnSelectorComponent } from '../gene-table-column-selector/gene-table-column-selector.component';
-import { CapitalizePipe } from '@sagebionetworks/agora/util';
+import { CapitalizeBooleanPipe } from '@sagebionetworks/agora/util';
 
 @Component({
   selector: 'agora-gene-table',
@@ -23,7 +23,7 @@ import { CapitalizePipe } from '@sagebionetworks/agora/util';
     FormsModule,
     FontAwesomeModule,
     GeneTableColumnSelectorComponent,
-    CapitalizePipe,
+    CapitalizeBooleanPipe,
   ],
   providers: [HelperService],
   templateUrl: './gene-table.component.html',

--- a/libs/agora/genes/src/lib/components/gene-table/gene-table.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-table/gene-table.component.ts
@@ -11,6 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faArrowRightArrowLeft, faDownload } from '@fortawesome/free-solid-svg-icons';
 import { GeneTableColumnSelectorComponent } from '../gene-table-column-selector/gene-table-column-selector.component';
+import { CapitalizePipe } from '@sagebionetworks/agora/util';
 
 @Component({
   selector: 'agora-gene-table',
@@ -22,6 +23,7 @@ import { GeneTableColumnSelectorComponent } from '../gene-table-column-selector/
     FormsModule,
     FontAwesomeModule,
     GeneTableColumnSelectorComponent,
+    CapitalizePipe,
   ],
   providers: [HelperService],
   templateUrl: './gene-table.component.html',

--- a/libs/agora/util/src/index.ts
+++ b/libs/agora/util/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/pipes/capitalize.pipe';
 export * from './lib/app-helpers';
 export * from './lib/default-seo-data';
 export * from './lib/path-sanitizer';

--- a/libs/agora/util/src/index.ts
+++ b/libs/agora/util/src/index.ts
@@ -1,4 +1,4 @@
-export * from './lib/pipes/capitalize.pipe';
+export * from './lib/pipes/capitalize-boolean.pipe';
 export * from './lib/app-helpers';
 export * from './lib/default-seo-data';
 export * from './lib/path-sanitizer';

--- a/libs/agora/util/src/lib/pipes/capitalize-boolean.pipe.ts
+++ b/libs/agora/util/src/lib/pipes/capitalize-boolean.pipe.ts
@@ -1,9 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'capitalize',
+  name: 'capitalizeBoolean',
 })
-export class CapitalizePipe implements PipeTransform {
+export class CapitalizeBooleanPipe implements PipeTransform {
   transform(value: any): string {
     if (typeof value === 'boolean') {
       return value.toString().charAt(0).toUpperCase() + value.toString().slice(1);

--- a/libs/agora/util/src/lib/pipes/capitalize.pipe.ts
+++ b/libs/agora/util/src/lib/pipes/capitalize.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'capitalize',
+})
+export class CapitalizePipe implements PipeTransform {
+  transform(value: any): string {
+    if (typeof value === 'boolean') {
+      return value.toString().charAt(0).toUpperCase() + value.toString().slice(1);
+    }
+    if (typeof value === 'string') {
+      if (value === 'true') return 'True';
+      if (value === 'false') return 'False';
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
### Description
This PR standardizes the display of boolean values that use the shared component gene-table to capitalize the first letter of boolean values.  To accomplish this a custom pipe was created as the value may be a boolean or a string.  Some columns are booleans and some are tri-state (true, false or 'No data').

### Testing
The shared component is used on the /genes/{gene}/similar and /genes/nominated-targets routes.
Both were tested for issues.

Before:
<img width="1922" alt="image" src="https://github.com/user-attachments/assets/775016e9-40c2-40d3-b058-0adb3e55de8e" />

After:
<img width="1934" alt="image" src="https://github.com/user-attachments/assets/1bc279d9-9e79-4434-8aac-1b929b92dda3" />

