### PR TITLE
fix(agora): fix GCT paginator styling (AG-1700)

### DIFF
--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
@@ -457,9 +457,11 @@
               #genesTable
               [value]="genes"
               [paginator]="true"
+              paginatorStyleClass="gct-paginator"
               [rows]="10"
               [showCurrentPageReport]="true"
               currentPageReportTemplate="{first}-{last} of {totalRecords}"
+              [showPageLinks]="false"
               breakpoint="0"
               (sortFunction)="sortCallback($event)"
               [customSort]="true"

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
@@ -429,15 +429,11 @@
     }
   }
 
-  .p-paginator-bottom {
+  .gct-paginator {
     display: block;
     padding: 20px 30px;
     text-align: right;
     border-top: 1px solid var(--color-gray-300);
-
-    .p-paginator-pages {
-      display: none;
-    }
 
     .p-paginator-current {
       margin-right: 15px;
@@ -446,7 +442,10 @@
       color: var(--color-text);
     }
 
-    .p-paginator-icon {
+    .p-paginator-first-icon,
+    .p-paginator-prev-icon,
+    .p-paginator-next-icon,
+    .p-paginator-last-icon {
       color: var(--color-action-primary);
       cursor: pointer;
       transition: variables.$transition-duration;
@@ -458,6 +457,8 @@
 
     button {
       transform: translateY(3px);
+      height: 16px;
+      min-width: 16px;
     }
   }
 


### PR DESCRIPTION
## Description

We need to update the GCT paginator styling to match the current dev site after the PrimeNG update.

## Related Issues

- [AG-1700](https://sagebionetworks.jira.com/browse/AG-1700)

## Validation

Build and serve agora: `agora-build-images && nx serve-detach agora-apex`
Navigate to GCT via home page
View paginator: 

current dev | new dev | fix
:---:|:---:|:---:
<img width="1496" alt="currentdev_AG-1700" src="https://github.com/user-attachments/assets/f6903553-4b2a-4256-a82e-9c3509a990b8" /> |  <img width="1496" alt="newdev_AG-1700" src="https://github.com/user-attachments/assets/581960c7-2794-4619-b3ee-97b569823f10" /> | <img width="1493" alt="fix_AG-1700" src="https://github.com/user-attachments/assets/c271f6c2-5760-46db-88c9-33bd4e28325a" />


[AG-1700]: https://sagebionetworks.jira.com/browse/AG-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ