### PR TITLE
fix(agora): reset GCT pinned genes when loading new data (AG-1727)

### DIFF
--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -259,6 +259,7 @@ export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDes
     this.isLoading = true;
     // this.genesTable.showLoader = true;
     this.genes = [];
+    this.pinnedItems = [];
 
     const genesApi$ = this.geneService.getComparisonGenes(this.category, this.subCategory);
     const distributionApi$ = this.distributionService.getDistribution();


### PR DESCRIPTION
## Description

The current Agora shows a loading screen when loading new GCT data, whereas the new Agora continues showing the site header while the data loads. However, the row of pinned genes data is displayed while the new data loads. This PR resets the pinned genes table so that only the loader is displayed while new data loads.

## Related Issue

- [AG-1727](https://sagebionetworks.jira.com/browse/AG-1727)

## Validation

Build and serve agora: `agora-build-images && nx serve-detach agora-apex`
Navigate to GCT
Pin a gene, then change the model

New agora:

https://github.com/user-attachments/assets/875b9119-37ec-4779-8a4a-32d84ac5ae06

Fix:

https://github.com/user-attachments/assets/dc12b7ec-71b4-48f0-bd82-aa7fda4c36ba

[AG-1727]: https://sagebionetworks.jira.com/browse/AG-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ