### PR TITLE
fix(agora): entering a comma in search does not show all genes (AG-1704)

### DIFF
--- a/apps/agora/app/e2e/gene-comparison-tool.spec.ts
+++ b/apps/agora/app/e2e/gene-comparison-tool.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { baseURL } from '../playwright.config';
-import { GCT_CATEGORIES, URL_GCT_PROTEIN } from './helpers/constants';
-import { changeGctCategory, closeGctHelpDialog } from './helpers/gct';
+import { GCT_CATEGORIES, GCT_RNA_SUBCATEGORIES, URL_GCT_PROTEIN } from './helpers/constants';
+import { changeGctCategory, closeGctHelpDialog, expectGctPageLoaded } from './helpers/gct';
 import { waitForSpinnerNotVisible } from './helpers/utils';
 
 const URL_GCT = '/genes/comparison';
@@ -73,5 +73,21 @@ test.describe('specific viewport block', () => {
     await expect(page.getByRole('columnheader', { name: 'RISK SCORE' }).locator('i')).toHaveClass(
       /pi-sort-amount-down/,
     );
+  });
+
+  test('AG-1704: entering a comma in search does not show all genes', async ({ page }) => {
+    await page.goto(URL_GCT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
+
+    const searchInput = page.getByPlaceholder('Search', { exact: true });
+
+    await searchInput.fill('app,');
+    await expect(page.getByText('1-1 of 1')).toBeVisible();
+
+    await searchInput.pressSequentially(' , pten');
+    await expect(page.getByText('1-2 of 2')).toBeVisible();
+
+    await searchInput.pressSequentially(',,,,,,');
+    await expect(page.getByText('1-2 of 2')).toBeVisible();
   });
 });

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -567,7 +567,8 @@ export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDes
         const terms = this.searchTerm
           .toLowerCase()
           .split(',')
-          .map((t: string) => t.trim());
+          .map((t: string) => t.trim())
+          .filter((t: string) => t !== '');
         filters['search_array'] = {
           value: terms,
           matchMode: 'intersect',


### PR DESCRIPTION
## Description

When searching for a gene in the GCT, the full list of genes should not be shown after entering a comma. Note: the newly added e2e test will not run until #3041 is merged.

## Related Issues

- [AG-1704](https://sagebionetworks.jira.com/browse/AG-1704)

## Validation

https://github.com/user-attachments/assets/03577410-a571-4ab9-800f-6c0a2b9a7d55


[AG-1704]: https://sagebionetworks.jira.com/browse/AG-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ