### PR TITLE
fix(agora): remove horizontal scroll bars on table, align styling with current GCT (AG-1651)

### DIFF
--- a/apps/agora/app/src/app/myPrimeNGPreset.ts
+++ b/apps/agora/app/src/app/myPrimeNGPreset.ts
@@ -2064,12 +2064,12 @@ export const MyPreset = definePreset(Lara, {
         padding: '0.75rem 1rem',
       },
       headerCell: {
-        selectedBackground: '{highlight.background}',
+        selectedBackground: 'transparent',
         borderColor: '{datatable.border.color}',
         hoverColor: '{content.hover.color}',
         selectedColor: '{highlight.color}',
         gap: '0.5rem',
-        padding: '0.75rem 1rem',
+        padding: '0.0625rem 0.0625rem',
         focusRing: {
           width: '{focus.ring.width}',
           style: '{focus.ring.style}',
@@ -2198,12 +2198,12 @@ export const MyPreset = definePreset(Lara, {
             borderColor: '{content.border.color}',
           },
           header: {
-            background: '{surface.50}',
+            background: 'transparent',
             color: '{text.color}',
           },
           headerCell: {
-            background: '{surface.50}',
-            hoverBackground: '{surface.100}',
+            background: 'transparent',
+            hoverBackground: 'transparent',
             color: '{text.color}',
           },
           footer: {

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.scss
@@ -125,7 +125,7 @@
       background-color: transparent;
 
       .p-select-label {
-        padding-left: 0;
+        padding: 0;
         font-size: 14px;
         font-weight: 400;
         color: var(--color-text);
@@ -319,6 +319,10 @@
     color: #a6a6a6;
     text-align: center;
     padding: 15px 20px 20px;
+  }
+
+  .p-datatable-table-container {
+    overflow: hidden !important;
   }
 
   .p-datatable-thead,


### PR DESCRIPTION
## Description

Small changes to align styling of GCT with current Agora.

## Related Issue

- [AG-1651](https://sagebionetworks.jira.com/browse/AG-1651)

## Changelog

- Remove unwanted scrollbars
- Remove header bar background color 
- Align search input with header bar

## Validation

current dev | new dev | fix 
:---:|:---:|:---:
<img width="1525" alt="currentdev_gct" src="https://github.com/user-attachments/assets/e77abe17-ee60-4c2b-95a2-354d5dc9d64a" /> | <img width="1541" alt="newdev_gct" src="https://github.com/user-attachments/assets/e5b8656e-5487-4a16-b688-c81dbd70bf7a" /> | <img width="1527" alt="fix_gct" src="https://github.com/user-attachments/assets/9e497e9a-4698-4753-9181-8a2887e1c71c" />

[AG-1651]: https://sagebionetworks.jira.com/browse/AG-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ