### PR TITLE
chore: remove VS Code extensions.json from Git tracking (SMR-36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,9 @@ sitemap.xml
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
-!.vscode/extensions.json
+
+# Extensions should be defined in `.devcontainer/devcontainer.json` instead of extensions.json.
+# !.vscode/extensions.json
 
 # misc
 /.sass-cache

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,0 @@
-{
-  // Extensions should be defined in `.devcontainer/devcontainer.json` instead of here.
-  "recommendations": []
-}


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-36

## Changelog

- Remove `extensions.json`.
- Configure Git to no longer track `extensions.json`.