### PR TITLE
chore: configure the monorepo to support the AMP-ALS product

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -21,14 +21,15 @@ body:
       multiple: true
       options:
         - Agora
+        - AMP-ALS
         - iAtlas
         - MODEL-AD
         - OpenChallenges
+        - Other
         - Sage
         - Sage Monorepo
         - Sandbox
         - Synapse
-        - Other
   - type: textarea
     attributes:
       label: Current behavior

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -10,14 +10,15 @@ body:
       multiple: true
       options:
         - Agora
+        - AMP-ALS
         - iAtlas
         - MODEL-AD
         - OpenChallenges
+        - Other
         - Sage
         - Sage Monorepo
         - Sandbox
         - Synapse
-        - Other
   - type: textarea
     attributes:
       label: Description

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -10,14 +10,15 @@ body:
       multiple: true
       options:
         - Agora
+        - AMP-ALS
         - iAtlas
         - MODEL-AD
         - OpenChallenges
+        - Other
         - Sage
         - Sage Monorepo
         - Sandbox
         - Synapse
-        - Other
   - type: checkboxes
     attributes:
       label: Documentation issue

--- a/.github/ISSUE_TEMPLATE/4-story.yml
+++ b/.github/ISSUE_TEMPLATE/4-story.yml
@@ -10,14 +10,15 @@ body:
       multiple: true
       options:
         - Agora
+        - AMP-ALS
         - iAtlas
         - MODEL-AD
         - OpenChallenges
+        - Other
         - Sage
         - Sage Monorepo
         - Sandbox
         - Synapse
-        - Other
   - type: textarea
     attributes:
       label: 'As a user, I want'

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -25,6 +25,7 @@ jobs:
           # These are regex patterns auto-wrapped in `^ $`.
           scopes: |
             agora
+            amp-als
             bridge2ai
             common
             iatlas

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'agora/v*'
+      - 'amp-als/v*'
       - 'openchallenges/v*'
       - 'sage/v*'
 

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -87,6 +87,10 @@ function openchallenges-infra {
   node dist/apps/openchallenges/infra/src/main.js "$@"
 }
 
+function amp-als-build-images {
+  nx run-many --target=build-image --projects=amp-als-* --parallel=3
+}
+
 function agora-build-images {
   nx run-many --target=build-image --projects=agora-* --parallel=3
 }


### PR DESCRIPTION
## Changelog

- Update GitHub workflows to support the AMP-ALS product.
- Add "AMP-ALS" to the list of products in GitHub issue templates.
- Add the command `amp-als-build-images`.