### PR TITLE
feat(amp-als): add Elasticsearch and update MariaDB port

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   "features": {},
   "forwardPorts": [
     2000, 2432, 3306, 3333, 4200, 4211, 5200, 5432, 5601, 8010, 8071, 8000, 8080, 8081, 8082, 8084,
-    8085, 8086, 8090, 8200, 8888, 8889, 9200, 9411, 27017
+    8085, 8086, 8090, 8401, 8402, 8200, 8888, 8889, 9200, 9411, 27017
   ],
   "portsAttributes": {
     "2000": {
@@ -90,6 +90,14 @@
     },
     "8090": {
       "label": "openchallenges-config-server",
+      "onAutoForward": "silent"
+    },
+    "8401": {
+      "label": "amp-als-mariadb",
+      "onAutoForward": "silent"
+    },
+    "8402": {
+      "label": "amp-als-elasticsearch",
       "onAutoForward": "silent"
     },
     "8888": {

--- a/apps/amp-als/elasticsearch/Dockerfile
+++ b/apps/amp-als/elasticsearch/Dockerfile
@@ -1,0 +1,6 @@
+FROM elasticsearch:7.17.8
+
+COPY docker-healthcheck /usr/local/bin/
+
+HEALTHCHECK --interval=2s --timeout=3s --retries=20 --start-period=5s \
+  CMD ["docker-healthcheck"]

--- a/apps/amp-als/elasticsearch/docker-healthcheck
+++ b/apps/amp-als/elasticsearch/docker-healthcheck
@@ -3,8 +3,9 @@
 set -eo pipefail
 
 host="$(hostname --ip-address || echo '127.0.0.1')"
+port="8402"
 
-if health="$(curl -fsSL "http://$host:9200/_cat/health?h=status")"; then
+if health="$(curl -fsSL "http://${host}:${port}/_cat/health?h=status")"; then
 	health="$(echo "$health" | sed -r 's/^[[:space:]]+|[[:space:]]+$//g')" # trim whitespace (otherwise we'll have "green")
 	if [ "$health" = 'green' ] || [ "$health" = 'yellow' ]; then
 		exit 0

--- a/apps/amp-als/elasticsearch/docker-healthcheck
+++ b/apps/amp-als/elasticsearch/docker-healthcheck
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# See https://github.com/docker-library/healthcheck/blob/master/elasticsearch/docker-healthcheck
+set -eo pipefail
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+
+if health="$(curl -fsSL "http://$host:9200/_cat/health?h=status")"; then
+	health="$(echo "$health" | sed -r 's/^[[:space:]]+|[[:space:]]+$//g')" # trim whitespace (otherwise we'll have "green")
+	if [ "$health" = 'green' ] || [ "$health" = 'yellow' ]; then
+		exit 0
+	fi
+	echo >&2 "unexpected health status: $health"
+fi
+
+exit 1

--- a/apps/amp-als/elasticsearch/project.json
+++ b/apps/amp-als/elasticsearch/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "amp-als-elasticsearch",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "create-config": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker/amp-als/serve-detach.sh amp-als-elasticsearch"
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/amp-als-elasticsearch:local --quiet",
+        "color": true
+      }
+    }
+  },
+  "tags": ["type:db", "scope:backend"]
+}

--- a/apps/amp-als/mariadb/docker-healthcheck
+++ b/apps/amp-als/mariadb/docker-healthcheck
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 host="$(hostname -i || echo '127.0.0.1')"
-port="3306" # TODO read port from config
+port="8401" # TODO read port from config
 user="${MARIADB_USER:-root}"
 password="${MARIADB_PASSWORD}"
 

--- a/docker/amp-als/serve-detach.sh
+++ b/docker/amp-als/serve-detach.sh
@@ -2,6 +2,7 @@
 
 args=(
   # List of services in alphanumeric order
+  --file docker/amp-als/services/elasticsearch.yml
   --file docker/amp-als/services/mariadb.yml
 
   --file docker/amp-als/networks.yml

--- a/docker/amp-als/services/elasticsearch.yml
+++ b/docker/amp-als/services/elasticsearch.yml
@@ -1,0 +1,24 @@
+services:
+  amp-als-elasticsearch:
+    image: ghcr.io/sage-bionetworks/amp-als-elasticsearch:${AMP_ALS_VERSION:-local}
+    container_name: amp-als-elasticsearch
+    restart: always
+    environment:
+      - node.name=amp-als-elasticsearch
+      - cluster.name=amp-als-elasticsearch
+      - discovery.seed_hosts=
+      - cluster.initial_master_nodes=amp-als-elasticsearch
+      - bootstrap.memory_lock=true
+      - 'ES_JAVA_OPTS=-Xms1g -Xmx1g'
+    networks:
+      - amp-als
+    ports:
+      - '9200:9200'
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    deploy:
+      resources:
+        limits:
+          memory: 2G

--- a/docker/amp-als/services/elasticsearch.yml
+++ b/docker/amp-als/services/elasticsearch.yml
@@ -10,10 +10,11 @@ services:
       - cluster.initial_master_nodes=amp-als-elasticsearch
       - bootstrap.memory_lock=true
       - 'ES_JAVA_OPTS=-Xms1g -Xmx1g'
+      - http.port=8402
     networks:
       - amp-als
     ports:
-      - '9200:9200'
+      - '8402:8402'
     ulimits:
       memlock:
         soft: -1

--- a/docker/amp-als/services/mariadb.yml
+++ b/docker/amp-als/services/mariadb.yml
@@ -5,10 +5,11 @@ services:
     restart: always
     env_file:
       - ../../../apps/amp-als/mariadb/.env
+    command: --port=8401
     networks:
       - amp-als
     ports:
-      - '3306:3306'
+      - '8401:8401'
     deploy:
       resources:
         limits:

--- a/tools/configure-hostnames.sh
+++ b/tools/configure-hostnames.sh
@@ -6,6 +6,8 @@
 declare -a hostnames=(
   "127.0.0.1 agora-api"
   "127.0.0.1 agora-mongo"
+  "127.0.0.1 amp-als-elasticsearch"
+  "127.0.0.1 amp-als-mariadb"
   "127.0.0.1 iatlas-api"
   "127.0.0.1 iatlas-postgres"
   "127.0.0.1 model-ad-api"


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-40

## Description

Create the `amp-als-elasticsearch` project based on the existing `openchallenges-elasticsearch` project. This Elasticsearch instance will support integration with the upcoming Dataset service. If the project evolves further, we anticipate migrating to the latest version of OpenSearch.

## Changelog

- Create the project `amp-als-elasticsearch`.
- Setup Docker Compose to deploy `amp-als-elasticsearch`.
- Configure Elasticsearch to listen to port 8402 (internal container port and host-mapped port).
- Publish the Docker image `ghcr.io/sage-bionetworks/amp-als-elasticsearch:{edge,sha-xxxxxxx}`.
- Add the hostnames `amp-als-{mariadb,elasticsearch}` to `tools/configure-hostnames.sh`.
- Configure `amp-als-mariadb` to listen to port 8401.
- Forward the dev container port 8401 to `amp-als-mariadb`.
- Forward the dev container port 8402 to `amp-als-elasticsearch`.

## Preview

Create the config file (`.env`):

```console
nx create-config amp-als-elasticsearch
```

Build the Docker image:

```console
nx build-image amp-als-elasticsearch
```

Deploy the container locally with Docker Compose:

```console
nx serve-detach amp-als-elasticsearch
```

Scan the Docker image for CVEs with Trivy:

```console
nx scan-image amp-als-elasticsearch
```

Publish the Docker image to GHCR via CI/CD:

```console
nx publish-image amp-als-elasticsearch
```

Check that the MariaDB and Elasticsearch containers are healthy:

```console
$ docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
CONTAINER ID   IMAGE                                                  STATUS                        PORTS
436892ba50dc   ghcr.io/sage-bionetworks/amp-als-elasticsearch:local   Up About a minute (healthy)   9200/tcp, 0.0.0.0:8402->8402/tcp, 9300/tcp
17d743ba5d2f   ghcr.io/sage-bionetworks/amp-als-mariadb:local         Up 2 minutes (healthy)        3306/tcp, 0.0.0.0:8401->8401/tcp
```

List the indexes of the local Elasticsearch instance:

```console
$ curl -X GET "amp-als-elasticsearch:8402/_cat/indices?v"
health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .geoip_databases YX5AzVEWT2KX_umrH6044A   1   0         40            0       37mb           37mb
```