### PR TITLE
chore: add SQLTools connection profile for AMP-ALS MariaDB instance (SMR-41)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,16 +58,6 @@
   "sqltools.autoOpenSessionFiles": false,
   "sqltools.connections": [
     {
-      "previewLimit": 50,
-      "server": "localhost",
-      "port": 5432,
-      "driver": "PostgreSQL",
-      "name": "openchallenges-postgres",
-      "database": "challenge",
-      "username": "postgres",
-      "password": "changeme"
-    },
-    {
       "mysqlOptions": {
         "authProtocol": "default"
       },
@@ -75,13 +65,13 @@
       "server": "openchallenges-mariadb",
       "port": 3306,
       "driver": "MariaDB",
-      "name": "openchallenges",
+      "name": "openchallenges-mariadb",
       "username": "maria",
       "password": "changeme"
     },
     {
       "previewLimit": 50,
-      "server": "localhost",
+      "server": "iatlas-postgres",
       "port": 2432,
       "driver": "PostgreSQL",
       "name": "iatlas-postgres",
@@ -97,7 +87,7 @@
       "server": "amp-als-mariadb",
       "port": 8401,
       "driver": "MariaDB",
-      "name": "amp-als",
+      "name": "amp-als-mariadb",
       "username": "maria",
       "password": "changeme"
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -88,6 +88,18 @@
       "database": "iatlas",
       "username": "postgres",
       "password": "changeme"
+    },
+    {
+      "mysqlOptions": {
+        "authProtocol": "default"
+      },
+      "previewLimit": 50,
+      "server": "amp-als-mariadb",
+      "port": 8401,
+      "driver": "MariaDB",
+      "name": "amp-als",
+      "username": "maria",
+      "password": "changeme"
     }
   ],
   "terminal.integrated.showExitAlert": false,


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-41

## Description

Add SQLTools connection profile for AMP-ALS MariaDB instance.

## Preview

![image](https://github.com/user-attachments/assets/192688f6-064a-42e5-9be2-087024960135)
