### PR TITLE
feat: create OpenAPI description for AMP-ALS (SMR-37)

### DIFF
--- a/libs/amp-als/api-description/openapi-merge.yaml
+++ b/libs/amp-als/api-description/openapi-merge.yaml
@@ -1,0 +1,6 @@
+inputs:
+  # info is defined in base OA definition. This file must be listed first.
+  - inputFile: openapi/base.openapi.yaml
+  # list files in alphanumeric order
+  - inputFile: openapi/dataset.openapi.yaml
+output: openapi/openapi.yaml

--- a/libs/amp-als/api-description/openapi/base.openapi.yaml
+++ b/libs/amp-als/api-description/openapi/base.openapi.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: AMP-ALS REST API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1
+components: {}

--- a/libs/amp-als/api-description/openapi/dataset.openapi.yaml
+++ b/libs/amp-als/api-description/openapi/dataset.openapi.yaml
@@ -1,0 +1,283 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: AMP-ALS Dataset REST API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1
+tags:
+  - name: Dataset
+    description: Operations about datasets.
+paths:
+  /datasets:
+    get:
+      tags:
+        - Dataset
+      summary: List datasets
+      description: List datasets
+      operationId: listDatasets
+      parameters:
+        - $ref: '#/components/parameters/datasetSearchQuery'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetsPage'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /datasets/{datasetId}:
+    parameters:
+      - $ref: '#/components/parameters/datasetId'
+    get:
+      tags:
+        - Dataset
+      summary: Get a dataset
+      description: Returns the dataset specified
+      operationId: getDataset
+      responses:
+        '200':
+          description: A dataset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dataset'
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/DatasetJsonLd'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  schemas:
+    DatasetSort:
+      description: What to sort results by.
+      type: string
+      default: relevance
+      enum:
+        - created
+        - random
+        - relevance
+    DatasetDirection:
+      description: The direction to sort the results by.
+      type: string
+      nullable: true
+      enum:
+        - asc
+        - desc
+    DatasetSearchQuery:
+      type: object
+      description: A dataset search query.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+        sort:
+          $ref: '#/components/schemas/DatasetSort'
+        sortSeed:
+          description: The seed that initializes the random sorter.
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 2147483647
+          nullable: true
+        direction:
+          $ref: '#/components/schemas/DatasetDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          type: string
+          example: clinical
+    PageMetadata:
+      type: object
+      description: The metadata of a page.
+      properties:
+        number:
+          description: The page number.
+          type: integer
+          format: int32
+          example: 99
+        size:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          example: 99
+        totalElements:
+          description: Total number of elements in the result set.
+          type: integer
+          format: int64
+          example: 99
+        totalPages:
+          description: Total number of pages in the result set.
+          type: integer
+          format: int32
+          example: 99
+        hasNext:
+          description: Returns if there is a next page.
+          type: boolean
+          example: true
+        hasPrevious:
+          description: Returns if there is a previous page.
+          type: boolean
+          example: true
+      required:
+        - number
+        - size
+        - totalElements
+        - totalPages
+        - hasNext
+        - hasPrevious
+    DatasetId:
+      description: The unique identifier of the dataset.
+      type: integer
+      format: int64
+      example: 1
+    DatasetName:
+      description: The name of the dataset.
+      type: string
+      minLength: 3
+      maxLength: 255
+    DatasetDescription:
+      description: The description of the dataset.
+      type: string
+      minLength: 0
+      maxLength: 1000
+      example: This is an example description of the dataset.
+    CreatedDateTime:
+      description: Datetime when the object was added to the database.
+      type: string
+      format: date-time
+      example: '2022-07-04T22:19:11Z'
+    UpdatedDateTime:
+      description: Datetime when the object was last modified in the database.
+      type: string
+      format: date-time
+      example: '2022-07-04T22:19:11Z'
+    Dataset:
+      type: object
+      description: A dataset
+      properties:
+        id:
+          $ref: '#/components/schemas/DatasetId'
+        name:
+          $ref: '#/components/schemas/DatasetName'
+        description:
+          $ref: '#/components/schemas/DatasetDescription'
+        createdAt:
+          $ref: '#/components/schemas/CreatedDateTime'
+        updatedAt:
+          $ref: '#/components/schemas/UpdatedDateTime'
+      required:
+        - id
+        - name
+        - description
+        - createdAt
+        - updatedAt
+    DatasetsPage:
+      type: object
+      description: A page of datasets.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            datasets:
+              description: A list of datasets.
+              type: array
+              items:
+                $ref: '#/components/schemas/Dataset'
+          required:
+            - datasets
+      x-java-class-annotations:
+        - '@lombok.Builder'
+    BasicError:
+      type: object
+      description: Problem details (tools.ietf.org/html/rfc7807)
+      properties:
+        title:
+          type: string
+          description: A human readable documentation for the problem type
+        status:
+          type: integer
+          description: The HTTP status code
+        detail:
+          type: string
+          description: A human readable explanation specific to this occurrence of the problem
+        type:
+          type: string
+          description: An absolute URI that identifies the problem type
+      required:
+        - title
+        - status
+      x-java-class-annotations:
+        - '@lombok.AllArgsConstructor'
+        - '@lombok.Builder'
+    DatasetJsonLd:
+      type: object
+      description: A dataset
+      allOf:
+        - $ref: '#/components/schemas/Dataset'
+        - type: object
+          properties:
+            '@context':
+              type: string
+              example: https://schema.org
+            '@id':
+              type: string
+              example: https://example.com/api/v1/datasets/1
+            '@type':
+              type: string
+              example: Dataset
+          required:
+            - '@context'
+            - '@id'
+            - '@type'
+  parameters:
+    datasetSearchQuery:
+      name: datasetSearchQuery
+      description: The search query used to find datasets.
+      in: query
+      schema:
+        $ref: '#/components/schemas/DatasetSearchQuery'
+    datasetId:
+      name: datasetId
+      in: path
+      description: The unique identifier of the dataset.
+      required: true
+      schema:
+        $ref: '#/components/schemas/DatasetId'
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    InternalServerError:
+      description: The request cannot be fulfilled due to an unexpected server error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'

--- a/libs/amp-als/api-description/openapi/openapi.yaml
+++ b/libs/amp-als/api-description/openapi/openapi.yaml
@@ -1,0 +1,285 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: AMP-ALS REST API
+  license:
+    name: Apache 2.0
+    url: 'https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt'
+  contact:
+    name: Support
+    url: 'https://github.com/Sage-Bionetworks/sage-monorepo'
+servers:
+  - url: 'http://localhost/v1'
+tags:
+  - name: Dataset
+    description: Operations about datasets.
+paths:
+  /datasets:
+    get:
+      tags:
+        - Dataset
+      summary: List datasets
+      description: List datasets
+      operationId: listDatasets
+      parameters:
+        - $ref: '#/components/parameters/datasetSearchQuery'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetsPage'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  '/datasets/{datasetId}':
+    parameters:
+      - $ref: '#/components/parameters/datasetId'
+    get:
+      tags:
+        - Dataset
+      summary: Get a dataset
+      description: Returns the dataset specified
+      operationId: getDataset
+      responses:
+        '200':
+          description: A dataset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dataset'
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/DatasetJsonLd'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  schemas:
+    DatasetSort:
+      description: What to sort results by.
+      type: string
+      default: relevance
+      enum:
+        - created
+        - random
+        - relevance
+    DatasetDirection:
+      description: The direction to sort the results by.
+      type: string
+      nullable: true
+      enum:
+        - asc
+        - desc
+    DatasetSearchQuery:
+      type: object
+      description: A dataset search query.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+        sort:
+          $ref: '#/components/schemas/DatasetSort'
+        sortSeed:
+          description: The seed that initializes the random sorter.
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 2147483647
+          nullable: true
+        direction:
+          $ref: '#/components/schemas/DatasetDirection'
+        searchTerms:
+          description: A string of search terms used to filter the results.
+          type: string
+          example: clinical
+    PageMetadata:
+      type: object
+      description: The metadata of a page.
+      properties:
+        number:
+          description: The page number.
+          type: integer
+          format: int32
+          example: 99
+        size:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          example: 99
+        totalElements:
+          description: Total number of elements in the result set.
+          type: integer
+          format: int64
+          example: 99
+        totalPages:
+          description: Total number of pages in the result set.
+          type: integer
+          format: int32
+          example: 99
+        hasNext:
+          description: Returns if there is a next page.
+          type: boolean
+          example: true
+        hasPrevious:
+          description: Returns if there is a previous page.
+          type: boolean
+          example: true
+      required:
+        - number
+        - size
+        - totalElements
+        - totalPages
+        - hasNext
+        - hasPrevious
+    DatasetId:
+      description: The unique identifier of the dataset.
+      type: integer
+      format: int64
+      example: 1
+    DatasetName:
+      description: The name of the dataset.
+      type: string
+      minLength: 3
+      maxLength: 255
+    DatasetDescription:
+      description: The description of the dataset.
+      type: string
+      minLength: 0
+      maxLength: 1000
+      example: This is an example description of the dataset.
+    CreatedDateTime:
+      description: Datetime when the object was added to the database.
+      type: string
+      format: date-time
+      example: '2022-07-04T22:19:11Z'
+    UpdatedDateTime:
+      description: Datetime when the object was last modified in the database.
+      type: string
+      format: date-time
+      example: '2022-07-04T22:19:11Z'
+    Dataset:
+      type: object
+      description: A dataset
+      properties:
+        id:
+          $ref: '#/components/schemas/DatasetId'
+        name:
+          $ref: '#/components/schemas/DatasetName'
+        description:
+          $ref: '#/components/schemas/DatasetDescription'
+        createdAt:
+          $ref: '#/components/schemas/CreatedDateTime'
+        updatedAt:
+          $ref: '#/components/schemas/UpdatedDateTime'
+      required:
+        - id
+        - name
+        - description
+        - createdAt
+        - updatedAt
+    DatasetsPage:
+      type: object
+      description: A page of datasets.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            datasets:
+              description: A list of datasets.
+              type: array
+              items:
+                $ref: '#/components/schemas/Dataset'
+          required:
+            - datasets
+      x-java-class-annotations:
+        - '@lombok.Builder'
+    BasicError:
+      type: object
+      description: Problem details (tools.ietf.org/html/rfc7807)
+      properties:
+        title:
+          type: string
+          description: A human readable documentation for the problem type
+        status:
+          type: integer
+          description: The HTTP status code
+        detail:
+          type: string
+          description: >-
+            A human readable explanation specific to this occurrence of the
+            problem
+        type:
+          type: string
+          description: An absolute URI that identifies the problem type
+      required:
+        - title
+        - status
+      x-java-class-annotations:
+        - '@lombok.AllArgsConstructor'
+        - '@lombok.Builder'
+    DatasetJsonLd:
+      type: object
+      description: A dataset
+      allOf:
+        - $ref: '#/components/schemas/Dataset'
+        - type: object
+          properties:
+            '@context':
+              type: string
+              example: 'https://schema.org'
+            '@id':
+              type: string
+              example: 'https://example.com/api/v1/datasets/1'
+            '@type':
+              type: string
+              example: Dataset
+          required:
+            - '@context'
+            - '@id'
+            - '@type'
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    InternalServerError:
+      description: The request cannot be fulfilled due to an unexpected server error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+  parameters:
+    datasetSearchQuery:
+      name: datasetSearchQuery
+      description: The search query used to find datasets.
+      in: query
+      schema:
+        $ref: '#/components/schemas/DatasetSearchQuery'
+    datasetId:
+      name: datasetId
+      in: path
+      description: The unique identifier of the dataset.
+      required: true
+      schema:
+        $ref: '#/components/schemas/DatasetId'

--- a/libs/amp-als/api-description/project.json
+++ b/libs/amp-als/api-description/project.json
@@ -1,0 +1,35 @@
+{
+  "name": "amp-als-api-description",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/amp-als/api-description/src",
+  "projectType": "library",
+  "targets": {
+    "build-individuals": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "redocly bundle --output openapi/base.openapi.yaml src/base.openapi.yaml",
+          "redocly bundle --output openapi/dataset.openapi.yaml src/dataset.openapi.yaml"
+        ],
+        "parallel": true,
+        "cwd": "{projectRoot}"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "openapi-merge-cli --config openapi-merge.yaml",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["build-individuals"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "redocly lint --config tools/redocly/config.yaml {projectName}"
+      },
+      "dependsOn": ["build"]
+    }
+  },
+  "tags": ["language:openapi"]
+}

--- a/libs/amp-als/api-description/src/base.openapi.yaml
+++ b/libs/amp-als/api-description/src/base.openapi.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: AMP-ALS REST API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1

--- a/libs/amp-als/api-description/src/components/README.md
+++ b/libs/amp-als/api-description/src/components/README.md
@@ -1,0 +1,13 @@
+# Reusable components
+
+- You can create the following folders here:
+  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject)
+  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject)
+  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject)
+  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject)
+  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#headerObject)
+  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#requestBodyObject)
+  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#linkObject)
+  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#callbackObject)
+  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securitySchemeObject)
+- Filename of files inside the folders represent component name, e.g. `Customer.yaml`

--- a/libs/amp-als/api-description/src/components/headers/ExpiresAfter.yaml
+++ b/libs/amp-als/api-description/src/components/headers/ExpiresAfter.yaml
@@ -1,0 +1,4 @@
+description: date in UTC when token expires
+schema:
+  type: string
+  format: date-time

--- a/libs/amp-als/api-description/src/components/parameters/path/datasetId.yaml
+++ b/libs/amp-als/api-description/src/components/parameters/path/datasetId.yaml
@@ -1,0 +1,6 @@
+name: datasetId
+in: path
+description: The unique identifier of the dataset.
+required: true
+schema:
+  $ref: ../../schemas/DatasetId.yaml

--- a/libs/amp-als/api-description/src/components/parameters/query/datasetSearchQuery.yaml
+++ b/libs/amp-als/api-description/src/components/parameters/query/datasetSearchQuery.yaml
@@ -1,0 +1,5 @@
+name: datasetSearchQuery
+description: The search query used to find datasets.
+in: query
+schema:
+  $ref: ../../schemas/DatasetSearchQuery.yaml

--- a/libs/amp-als/api-description/src/components/parameters/query/pageNumber.yaml
+++ b/libs/amp-als/api-description/src/components/parameters/query/pageNumber.yaml
@@ -1,0 +1,8 @@
+name: pageNumber
+description: The page number.
+in: query
+schema:
+  type: integer
+  format: int32
+  default: 0
+  minimum: 0

--- a/libs/amp-als/api-description/src/components/parameters/query/pageSize.yaml
+++ b/libs/amp-als/api-description/src/components/parameters/query/pageSize.yaml
@@ -1,0 +1,8 @@
+name: pageSize
+description: The number of items in a single page.
+in: query
+schema:
+  type: integer
+  format: int32
+  default: 100
+  minimum: 1

--- a/libs/amp-als/api-description/src/components/responses/BadRequest.yaml
+++ b/libs/amp-als/api-description/src/components/responses/BadRequest.yaml
@@ -1,0 +1,5 @@
+description: Invalid request
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/amp-als/api-description/src/components/responses/Conflict.yaml
+++ b/libs/amp-als/api-description/src/components/responses/Conflict.yaml
@@ -1,0 +1,5 @@
+description: The request conflicts with current state of the target resource
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/amp-als/api-description/src/components/responses/InternalServerError.yaml
+++ b/libs/amp-als/api-description/src/components/responses/InternalServerError.yaml
@@ -1,0 +1,5 @@
+description: The request cannot be fulfilled due to an unexpected server error
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/amp-als/api-description/src/components/responses/NotFound.yaml
+++ b/libs/amp-als/api-description/src/components/responses/NotFound.yaml
@@ -1,0 +1,5 @@
+description: The specified resource was not found
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/amp-als/api-description/src/components/responses/Unauthorized.yaml
+++ b/libs/amp-als/api-description/src/components/responses/Unauthorized.yaml
@@ -1,0 +1,5 @@
+description: Unauthorized
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/amp-als/api-description/src/components/schemas/BasicError.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/BasicError.yaml
@@ -1,0 +1,22 @@
+type: object
+description: Problem details (tools.ietf.org/html/rfc7807)
+properties:
+  title:
+    type: string
+    description: A human readable documentation for the problem type
+  status:
+    type: integer
+    description: The HTTP status code
+  detail:
+    type: string
+    description: A human readable explanation specific to this occurrence of
+      the problem
+  type:
+    type: string
+    description: An absolute URI that identifies the problem type
+required:
+  - title
+  - status
+x-java-class-annotations:
+  - '@lombok.AllArgsConstructor'
+  - '@lombok.Builder'

--- a/libs/amp-als/api-description/src/components/schemas/CreatedDateTime.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/CreatedDateTime.yaml
@@ -1,0 +1,4 @@
+description: Datetime when the object was added to the database.
+type: string
+format: date-time
+example: '2022-07-04T22:19:11Z'

--- a/libs/amp-als/api-description/src/components/schemas/Dataset.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/Dataset.yaml
@@ -1,0 +1,19 @@
+type: object
+description: A dataset
+properties:
+  id:
+    $ref: DatasetId.yaml
+  name:
+    $ref: DatasetName.yaml
+  description:
+    $ref: DatasetDescription.yaml
+  createdAt:
+    $ref: CreatedDateTime.yaml
+  updatedAt:
+    $ref: UpdatedDateTime.yaml
+required:
+  - id
+  - name
+  - description
+  - createdAt
+  - updatedAt

--- a/libs/amp-als/api-description/src/components/schemas/DatasetDescription.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetDescription.yaml
@@ -1,0 +1,5 @@
+description: The description of the dataset.
+type: string
+minLength: 0
+maxLength: 1000
+example: This is an example description of the dataset.

--- a/libs/amp-als/api-description/src/components/schemas/DatasetDirection.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetDirection.yaml
@@ -1,0 +1,6 @@
+description: The direction to sort the results by.
+type: string
+nullable: true
+enum:
+  - asc
+  - desc

--- a/libs/amp-als/api-description/src/components/schemas/DatasetId.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetId.yaml
@@ -1,0 +1,4 @@
+description: The unique identifier of the dataset.
+type: integer
+format: int64
+example: 1

--- a/libs/amp-als/api-description/src/components/schemas/DatasetJsonLd.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetJsonLd.yaml
@@ -1,0 +1,19 @@
+type: object
+description: A dataset
+allOf:
+  - $ref: Dataset.yaml
+  - type: object
+    properties:
+      '@context':
+        type: string
+        example: 'https://schema.org'
+      '@id':
+        type: string
+        example: 'https://example.com/api/v1/datasets/1'
+      '@type':
+        type: string
+        example: 'Dataset'
+    required:
+      - '@context'
+      - '@id'
+      - '@type'

--- a/libs/amp-als/api-description/src/components/schemas/DatasetName.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetName.yaml
@@ -1,0 +1,4 @@
+description: The name of the dataset.
+type: string
+minLength: 3
+maxLength: 255

--- a/libs/amp-als/api-description/src/components/schemas/DatasetSearchQuery.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetSearchQuery.yaml
@@ -1,0 +1,30 @@
+type: object
+description: A dataset search query.
+properties:
+  pageNumber:
+    description: The page number.
+    type: integer
+    format: int32
+    default: 0
+    minimum: 0
+  pageSize:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    default: 100
+    minimum: 1
+  sort:
+    $ref: DatasetSort.yaml
+  sortSeed:
+    description: The seed that initializes the random sorter.
+    type: integer
+    format: int32
+    minimum: 0
+    maximum: 2147483647
+    nullable: true
+  direction:
+    $ref: DatasetDirection.yaml
+  searchTerms:
+    description: A string of search terms used to filter the results.
+    type: string
+    example: 'clinical'

--- a/libs/amp-als/api-description/src/components/schemas/DatasetSort.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetSort.yaml
@@ -1,0 +1,7 @@
+description: What to sort results by.
+type: string
+default: relevance
+enum:
+  - created
+  - random
+  - relevance

--- a/libs/amp-als/api-description/src/components/schemas/DatasetsPage.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetsPage.yaml
@@ -1,0 +1,15 @@
+type: object
+description: A page of datasets.
+allOf:
+  - $ref: PageMetadata.yaml
+  - type: object
+    properties:
+      datasets:
+        description: A list of datasets.
+        type: array
+        items:
+          $ref: Dataset.yaml
+    required:
+      - datasets
+x-java-class-annotations:
+  - '@lombok.Builder'

--- a/libs/amp-als/api-description/src/components/schemas/EmptyObject.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/EmptyObject.yaml
@@ -1,0 +1,2 @@
+type: object
+description: Empty JSON object

--- a/libs/amp-als/api-description/src/components/schemas/PageMetadata.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/PageMetadata.yaml
@@ -1,0 +1,38 @@
+type: object
+description: The metadata of a page.
+properties:
+  number:
+    description: The page number.
+    type: integer
+    format: int32
+    example: 99
+  size:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    example: 99
+  totalElements:
+    description: Total number of elements in the result set.
+    type: integer
+    format: int64
+    example: 99
+  totalPages:
+    description: Total number of pages in the result set.
+    type: integer
+    format: int32
+    example: 99
+  hasNext:
+    description: Returns if there is a next page.
+    type: boolean
+    example: true
+  hasPrevious:
+    description: Returns if there is a previous page.
+    type: boolean
+    example: true
+required:
+  - number
+  - size
+  - totalElements
+  - totalPages
+  - hasNext
+  - hasPrevious

--- a/libs/amp-als/api-description/src/components/schemas/UpdatedDateTime.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/UpdatedDateTime.yaml
@@ -1,0 +1,4 @@
+description: Datetime when the object was last modified in the database.
+type: string
+format: date-time
+example: '2022-07-04T22:19:11Z'

--- a/libs/amp-als/api-description/src/components/securitySchemes/ApiKeyAuth.yaml
+++ b/libs/amp-als/api-description/src/components/securitySchemes/ApiKeyAuth.yaml
@@ -1,0 +1,3 @@
+type: apiKey
+in: header
+name: X-API-Key

--- a/libs/amp-als/api-description/src/components/securitySchemes/BearerAuth.yaml
+++ b/libs/amp-als/api-description/src/components/securitySchemes/BearerAuth.yaml
@@ -1,0 +1,3 @@
+type: http
+scheme: bearer
+bearerFormat: JWT

--- a/libs/amp-als/api-description/src/components/securitySchemes/OAuth.yaml
+++ b/libs/amp-als/api-description/src/components/securitySchemes/OAuth.yaml
@@ -1,0 +1,8 @@
+type: oauth2
+description: For more information, see https://api.openchallenges.org/docs/oauth
+flows:
+  implicit:
+    authorizationUrl: '/oauth2/authorize'
+    scopes:
+      read:users: read users info
+      write:users: modify or remove users

--- a/libs/amp-als/api-description/src/dataset.openapi.yaml
+++ b/libs/amp-als/api-description/src/dataset.openapi.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: AMP-ALS Dataset REST API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1
+tags:
+  - name: Dataset
+    description: Operations about datasets.
+paths:
+  /datasets:
+    $ref: paths/datasets.yaml
+  /datasets/{datasetId}:
+    $ref: paths/datasets/@{datasetId}.yaml

--- a/libs/amp-als/api-description/src/paths/README.md
+++ b/libs/amp-als/api-description/src/paths/README.md
@@ -1,0 +1,107 @@
+# Paths
+
+Organize your path definitions within this folder. You will reference your paths from your main `openapi.yaml` entrypoint file.
+
+It may help you to adopt some conventions:
+
+- path separator token (e.g. `@`) or subfolders
+- path parameter (e.g. `{example}`)
+- file-per-path or file-per-operation
+
+There are different benefits and drawbacks to each decision.
+
+You can adopt any organization you wish. We have some tips for organizing paths based on common practices.
+
+## Each path in a separate file
+
+Use a predefined "path separator" and keep all of your path files in the top level of the `paths` folder.
+
+```
+# todo: insert tree view of paths folder
+```
+
+Redocly recommends using the `@` character for this case.
+
+In addition, Redocly recommends placing path parameters within `{}` curly braces if you adopt this style.
+
+#### Motivations
+
+- Quickly see a list of all paths. Many people think in terms of the "number" of "endpoints" (paths), and not the "number" of "operations" (paths \* http methods).
+
+- Only the "file-per-path" option is semantically correct with the OpenAPI Specification 3.0.2. However, Redocly's openapi-cli will build valid bundles for any of the other options too.
+
+#### Drawbacks
+
+- This may require multiple definitions per http method within a single file.
+- It requires settling on a path separator (that is allowed to be used in filenames) and sticking to that convention.
+
+## Each operation in a separate file
+
+You may also place each operation in a separate file.
+
+In this case, if you want all paths at the top-level, you can concatenate the http method to the path name. Similar to the above option, you can
+
+### Files at top-level of `paths`
+
+You may name your files with some concatenation for the http method. For example, following a convention such as: `<path with allowed separator>-<http-method>.yaml`.
+
+#### Motivations
+
+- Quickly see all operations without needing to navigate subfolders.
+
+#### Drawbacks
+
+- Adopting an unusual path separator convention, instead of using subfolders.
+
+### Use subfolders to mirror API path structure
+
+Example:
+
+```
+GET /customers
+
+/paths/customers/get.yaml
+```
+
+In this case, the path id defined within subfolders which mirror the API URL structure.
+
+Example with path parameter:
+
+```
+GET /customers/{id}
+
+/paths/customers/{id}/get.yaml
+```
+
+#### Motivations
+
+It matches the URL structure.
+
+It is pretty easy to reference:
+
+```yaml
+paths:
+  '/customers/{id}':
+    get:
+      $ref: ./paths/customers/{id}/get.yaml
+    put:
+      $ref: ./paths/customers/{id}/put.yaml
+```
+
+#### Drawbacks
+
+If you have a lot of nested folders, it may be confusing to reference your schemas.
+
+Example
+
+```
+file: /paths/customers/{id}/timeline/{messageId}/get.yaml
+
+# excerpt of file
+    headers:
+      Rate-Limit-Remaining:
+        $ref: ../../../../../components/headers/Rate-Limit-Remaining.yaml
+
+```
+
+Notice the `../../../../../` in the ref which requires some attention to formulate correctly. While openapi-cli has a linter which suggests possible refs when there is a mistake, this is still a net drawback for APIs with deep paths.

--- a/libs/amp-als/api-description/src/paths/datasets.yaml
+++ b/libs/amp-als/api-description/src/paths/datasets.yaml
@@ -1,0 +1,19 @@
+get:
+  tags:
+    - Dataset
+  summary: List datasets
+  description: List datasets
+  operationId: listDatasets
+  parameters:
+    - $ref: ../components/parameters/query/datasetSearchQuery.yaml
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/DatasetsPage.yaml
+      description: Success
+    '400':
+      $ref: ../components/responses/BadRequest.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml

--- a/libs/amp-als/api-description/src/paths/datasets/@{datasetId}.yaml
+++ b/libs/amp-als/api-description/src/paths/datasets/@{datasetId}.yaml
@@ -1,0 +1,22 @@
+parameters:
+  - $ref: ../../components/parameters/path/datasetId.yaml
+get:
+  tags:
+    - Dataset
+  summary: Get a dataset
+  description: Returns the dataset specified
+  operationId: getDataset
+  responses:
+    '200':
+      description: A dataset
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/Dataset.yaml
+        application/ld+json:
+          schema:
+            $ref: ../../components/schemas/DatasetJsonLd.yaml
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+    '500':
+      $ref: ../../components/responses/InternalServerError.yaml

--- a/libs/amp-als/api-description/src/paths/parameters/direction.yaml
+++ b/libs/amp-als/api-description/src/paths/parameters/direction.yaml
@@ -1,0 +1,9 @@
+name: direction
+description: Can be either `asc` or `desc`. Ignored without `sort` parameter.
+in: query
+required: false
+schema:
+  type: string
+  enum:
+    - asc
+    - desc

--- a/libs/amp-als/api-description/src/paths/parameters/searchTerms.yaml
+++ b/libs/amp-als/api-description/src/paths/parameters/searchTerms.yaml
@@ -1,0 +1,6 @@
+name: searchTerms
+description: A string of search terms used to filter the results
+in: query
+required: false
+schema:
+  type: string

--- a/libs/amp-als/api-description/src/paths/parameters/sort.yaml
+++ b/libs/amp-als/api-description/src/paths/parameters/sort.yaml
@@ -1,0 +1,16 @@
+name: sort
+in: query
+required: false
+schema:
+  type: string
+  enum:
+    - featured
+    - name
+    - createdAt
+    - updatedAt
+description: >
+  Properties used to sort the results that must be returned:
+    * featured - if a dataset is featured, from featured to non-featured.
+    * name - name of a dataset, from A to Z.
+    * createdAt - when a dataset is created, from latest to oldest.
+    * updatedAt - when a dataset is updated, from latest to oldest.

--- a/tools/redocly/config.yaml
+++ b/tools/redocly/config.yaml
@@ -10,6 +10,8 @@ rules:
   paths-kebab-case: warn
 
 apis:
+  amp-als-api-description:
+    root: libs/amp-als/api-description/openapi/openapi.yaml
   agora-api-description:
     root: libs/agora/api-description/build/openapi.yaml
   model-ad-api-description:


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-37

## Description

Define two endpoints for a dataset metadata service:

- GET /datasets/{id}: Retrieve a dataset by its unique identifier.
- GET /datasets: Search datasets and return a paginated list of results.

This project is based on `openchallenges-api-description`.

The dataset service is based on the OC challenge service.

## Changelog

- Create the project `amp-als-api-description`.

## Preview

### Build the OpenAPI description

Build the OpenAPI description of the individual services (e.g., the dataset service) as well as an OpenAPI description that aggregates all the services.

```bash
nx build amp-als-api-description
```

### Lint/validate the OpenAPI description

```console
$ nx lint amp-als-api-description

> nx run amp-als-api-description:build-individuals

> redocly bundle --output openapi/base.openapi.yaml src/base.openapi.yaml

> redocly bundle --output openapi/dataset.openapi.yaml src/dataset.openapi.yaml


    ╔═══════════════════════════════════════════════════════╗
    ║                                                       ║
    ║  A new version of Redocly CLI (1.34.1) is available.  ║
    ║  Update now: `npm i -g @redocly/cli@latest`.          ║
    ║  Changelog: https://redocly.com/docs/cli/changelog/   ║
    ║                                                       ║
    ╚═══════════════════════════════════════════════════════╝

bundling src/dataset.openapi.yaml...

    ╔═══════════════════════════════════════════════════════╗
    ║                                                       ║
    ║  A new version of Redocly CLI (1.34.1) is available.  ║
    ║  Update now: `npm i -g @redocly/cli@latest`.          ║
    ║  Changelog: https://redocly.com/docs/cli/changelog/   ║
    ║                                                       ║
    ╚═══════════════════════════════════════════════════════╝

📦 Created a bundle for src/dataset.openapi.yaml at openapi/dataset.openapi.yaml 46ms.
bundling src/base.openapi.yaml...
📦 Created a bundle for src/base.openapi.yaml at openapi/base.openapi.yaml 20ms.

> nx run amp-als-api-description:build

> openapi-merge-cli --config openapi-merge.yaml

## /usr/bin/node: Running v1.3.2 (+1ms)
## Loaded the configuration: 2 inputs (+83ms)
## Loading input 0: openapi/base.openapi.yaml (+1ms)
## Loading input 1: openapi/dataset.openapi.yaml (+0ms)
## Loaded the inputs into memory, merging the results. (+8ms)
## Inputs merged, writing the results out to 'openapi/openapi.yaml' (+8ms)
## Finished writing to 'openapi/openapi.yaml' (+8ms)

> nx run amp-als-api-description:lint

> redocly lint --config tools/redocly/config.yaml amp-als-api-description


    ╔═══════════════════════════════════════════════════════╗
    ║                                                       ║
    ║  A new version of Redocly CLI (1.34.1) is available.  ║
    ║  Update now: `npm i -g @redocly/cli@latest`.          ║
    ║  Changelog: https://redocly.com/docs/cli/changelog/   ║
    ║                                                       ║
    ╚═══════════════════════════════════════════════════════╝

validating libs/amp-als/api-description/openapi/openapi.yaml...
libs/amp-als/api-description/openapi/openapi.yaml: validated in 32ms

Woohoo! Your API description is valid. 🎉


———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target lint for project amp-als-api-description and 2 tasks it depends on (3s)
```