### PR TITLE
chore(sage): upgrade to latest GHA-hosted runner (SMR-47)

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   trivy-edge:
     name: ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
       TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   trivy:
     name: Trivy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

`Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101.`

## Related Issues

- [SMR-47](https://sagebionetworks.jira.com/browse/SMR-47)

[SMR-47]: https://sagebionetworks.jira.com/browse/SMR-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ