### PR TITLE
feat(amp-als): add Keycloak to the AMP-ALS stack (SMR-48)

### DIFF
--- a/apps/amp-als/keycloak/.env.example
+++ b/apps/amp-als/keycloak/.env.example
@@ -1,0 +1,11 @@
+# https://www.keycloak.org/server/all-config
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=changeme
+KC_DB=dev-file
+#KC_DB=postgres
+#KC_DB_URL_HOST=keycloak-db
+#KC_DB_URL_DATABASE=keycloak
+#KC_DB_USERNAME=keycloak
+#KC_DB_SCHEMA=public
+#KC_DB_PASSWORD=changeme
+KC_LOG_LEVEL=info

--- a/apps/amp-als/keycloak/Dockerfile
+++ b/apps/amp-als/keycloak/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/keycloak/keycloak:26.1.4

--- a/apps/amp-als/keycloak/project.json
+++ b/apps/amp-als/keycloak/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "amp-als-keycloak",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "create-config": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker/amp-als/serve-detach.sh {projectName}"
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/{projectName}:local --quiet",
+        "color": true
+      }
+    }
+  },
+  "tags": ["type:service", "scope:backend"]
+}

--- a/docker/amp-als/serve-detach.sh
+++ b/docker/amp-als/serve-detach.sh
@@ -5,6 +5,7 @@ args=(
   --file docker/amp-als/services/api-docs.yml
   --file docker/amp-als/services/dataset-service.yml
   --file docker/amp-als/services/elasticsearch.yml
+  --file docker/amp-als/services/keycloak.yml
   --file docker/amp-als/services/mariadb.yml
 
   --file docker/amp-als/networks.yml

--- a/docker/amp-als/services/keycloak.yml
+++ b/docker/amp-als/services/keycloak.yml
@@ -1,0 +1,16 @@
+services:
+  amp-als-keycloak:
+    image: ghcr.io/sage-bionetworks/amp-als-keycloak:${AMP_ALS_VERSION:-local}
+    container_name: amp-als-keycloak
+    restart: always
+    env_file:
+      - ../../../apps/amp-als/keycloak/.env
+    command: start-dev
+    networks:
+      - amp-als
+    ports:
+      - '8406:8406'
+    deploy:
+      resources:
+        limits:
+          memory: 1G


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-48

## Changelog

- Create the `amp-als-keycloak` project based on former `openchallenges-keycloak` project.
- Add Docker Compose files to start Keycloak container.
- Forward the dev container port 8406 for Keycloak.

## Preview

### Build the Docker image

```bash
nx build-image amp-als-keycloak
```

### Start Keycloak with Docker Compose

```bash
nx serve-detach amp-als-keycloak
```

### Login into Keycloak

Navigate to `http://localhost:8604`:

![image](https://github.com/user-attachments/assets/fc31d2fd-5c5c-4577-82c7-dcbbbf99930a)

Login into Keycloak with the credentials defined in `.env`:

![image](https://github.com/user-attachments/assets/0a9e75f0-491a-48eb-b504-fb56eae7142b)
