### PR TITLE
feat(amp-als): update the AMP-ALS dataset service to return datasets by ID (SMR-49)

### DIFF
--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApi.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApi.java
@@ -111,7 +111,7 @@ public interface DatasetApi {
     value = "/datasets/{datasetId}",
     produces = { "application/json", "application/ld+json", "application/problem+json" }
   )
-  default ResponseEntity<DatasetDto> getDataset(
+  default ResponseEntity<?> getDataset(
     @Parameter(
       name = "datasetId",
       description = "The unique identifier of the dataset.",

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegate.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegate.java
@@ -35,7 +35,7 @@ public interface DatasetApiDelegate {
    *         or The request cannot be fulfilled due to an unexpected server error (status code 500)
    * @see DatasetApi#getDataset
    */
-  default ResponseEntity<DatasetDto> getDataset(Long datasetId) {
+  default ResponseEntity<?> getDataset(Long datasetId) {
     getRequest()
       .ifPresent(request -> {
         for (MediaType mediaType : MediaType.parseMediaTypes(request.getHeader("Accept"))) {

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
@@ -1,0 +1,57 @@
+package org.sagebionetworks.amp.als.dataset.service.api;
+
+import java.util.List;
+import java.util.Optional;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
+import org.sagebionetworks.amp.als.dataset.service.service.DatasetService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.NativeWebRequest;
+
+@Component
+public class DatasetApiDelegateImpl implements DatasetApiDelegate {
+
+  private static final Logger log = LoggerFactory.getLogger(DatasetApiDelegateImpl.class);
+
+  private static final MediaType APPLICATION_JSON = MediaType.valueOf("application/json");
+
+  private final DatasetService datasetService;
+
+  private final NativeWebRequest request;
+
+  public DatasetApiDelegateImpl(DatasetService datasetService, NativeWebRequest request) {
+    this.datasetService = datasetService;
+    this.request = request;
+  }
+
+  @Override
+  public Optional<NativeWebRequest> getRequest() {
+    return Optional.ofNullable(request);
+  }
+
+  @Override
+  public ResponseEntity<?> getDataset(Long datasetId) {
+    for (MediaType mediaType : getAcceptedMediaTypes(getRequest())) {
+      if (mediaType.isCompatibleWith(APPLICATION_JSON)) {
+        return ResponseEntity.ok(datasetService.getDataset(datasetId));
+      }
+    }
+    // TODO return an error object if this API does not support any of the accepted types
+    return ResponseEntity.ok(datasetService.getDataset(datasetId));
+  }
+
+  // @Override
+  // public ResponseEntity<DatasetsPageDto> listDatasets(DatasetSearchQueryDto query) {
+  //   return ResponseEntity.ok(datasetService.listDatasets(query));
+  // }
+
+  public List<MediaType> getAcceptedMediaTypes(Optional<NativeWebRequest> requestOpt) {
+    return requestOpt
+      .map(request -> MediaType.parseMediaTypes(request.getHeader("Accept")))
+      .orElseGet(List::of);
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
@@ -2,11 +2,7 @@ package org.sagebionetworks.amp.als.dataset.service.api;
 
 import java.util.List;
 import java.util.Optional;
-import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
-import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
 import org.sagebionetworks.amp.als.dataset.service.service.DatasetService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -14,8 +10,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 
 @Component
 public class DatasetApiDelegateImpl implements DatasetApiDelegate {
-
-  private static final Logger log = LoggerFactory.getLogger(DatasetApiDelegateImpl.class);
 
   private static final MediaType APPLICATION_JSON = MediaType.valueOf("application/json");
 
@@ -40,14 +34,9 @@ public class DatasetApiDelegateImpl implements DatasetApiDelegate {
         return ResponseEntity.ok(datasetService.getDataset(datasetId));
       }
     }
-    // TODO return an error object if this API does not support any of the accepted types
+    // TODO: Return an error object if this API does not support any of the accepted types
     return ResponseEntity.ok(datasetService.getDataset(datasetId));
   }
-
-  // @Override
-  // public ResponseEntity<DatasetsPageDto> listDatasets(DatasetSearchQueryDto query) {
-  //   return ResponseEntity.ok(datasetService.listDatasets(query));
-  // }
 
   public List<MediaType> getAcceptedMediaTypes(Optional<NativeWebRequest> requestOpt) {
     return requestOpt

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/DatasetNotFoundException.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/DatasetNotFoundException.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+public class DatasetNotFoundException extends SimpleDatasetGlobalException {
+
+  public DatasetNotFoundException(String detail) {
+    super(
+      ErrorConstants.ENTITY_NOT_FOUND.getType(),
+      ErrorConstants.ENTITY_NOT_FOUND.getTitle(),
+      ErrorConstants.ENTITY_NOT_FOUND.getStatus(),
+      detail
+    );
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/ErrorConstants.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/ErrorConstants.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorConstants {
+  ENTITY_NOT_FOUND("DATASET-SERVICE-1000", "Entity not found", HttpStatus.NOT_FOUND),
+  BAD_REQUEST("DATASET-SERVICE-1001", "Bad request", HttpStatus.BAD_REQUEST);
+
+  private String type;
+  private String title;
+  private HttpStatus status;
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/SimpleDatasetGlobalException.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/SimpleDatasetGlobalException.java
@@ -1,0 +1,23 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimpleDatasetGlobalException extends RuntimeException {
+
+  private String type;
+  private String title;
+  private HttpStatus status;
+  private String detail;
+
+  public SimpleDatasetGlobalException(String details) {
+    super(details);
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
@@ -1,18 +1,11 @@
 package org.sagebionetworks.amp.als.dataset.service.model.entity;
 
-import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
@@ -19,27 +19,12 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-// import org.hibernate.annotations.LazyCollection;
-// import org.hibernate.annotations.LazyCollectionOption;
-// import org.hibernate.search.engine.backend.types.Sortable;
-// import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
-// import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
-// import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtract;
-// import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction;
-// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
-// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
-// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
-// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
-// import org.sagebionetworks.openchallenges.challenge.service.model.search.CollectionSizeBridge;
-
 @Entity
 @Table(name = "dataset")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-// @Indexed(index = "openchallenges-challenge")
 public class DatasetEntity {
 
   @Id
@@ -48,15 +33,12 @@ public class DatasetEntity {
   private Long id;
 
   @Column(nullable = false)
-  // @FullTextField
   private String name;
 
   @Column(nullable = false)
-  // @FullTextField
   private String description;
 
   @Column(name = "created_at")
-  // @GenericField(name = "created_at", sortable = Sortable.YES)
   private OffsetDateTime createdAt;
 
   @Column(name = "updated_at")

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
@@ -1,0 +1,64 @@
+package org.sagebionetworks.amp.als.dataset.service.model.entity;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+// import org.hibernate.annotations.LazyCollection;
+// import org.hibernate.annotations.LazyCollectionOption;
+// import org.hibernate.search.engine.backend.types.Sortable;
+// import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
+// import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
+// import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtract;
+// import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction;
+// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+// import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
+// import org.sagebionetworks.openchallenges.challenge.service.model.search.CollectionSizeBridge;
+
+@Entity
+@Table(name = "dataset")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+// @Indexed(index = "openchallenges-challenge")
+public class DatasetEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(nullable = false, updatable = false)
+  private Long id;
+
+  @Column(nullable = false)
+  // @FullTextField
+  private String name;
+
+  @Column(nullable = false)
+  // @FullTextField
+  private String description;
+
+  @Column(name = "created_at")
+  // @GenericField(name = "created_at", sortable = Sortable.YES)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private OffsetDateTime updatedAt;
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/mapper/DatasetMapper.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/mapper/DatasetMapper.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.amp.als.dataset.service.model.mapper;
+
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.sagebionetworks.util.model.mapper.BaseMapper;
+import org.springframework.beans.BeanUtils;
+
+public class DatasetMapper extends BaseMapper<DatasetEntity, DatasetDto> {
+
+  @Override
+  public DatasetEntity convertToEntity(DatasetDto dto, Object... args) {
+    DatasetEntity entity = new DatasetEntity();
+    if (dto != null) {
+      BeanUtils.copyProperties(dto, entity);
+    }
+    return entity;
+  }
+
+  @Override
+  public DatasetDto convertToDto(DatasetEntity entity, Object... args) {
+    DatasetDto dto = new DatasetDto();
+    if (entity != null) {
+      BeanUtils.copyProperties(entity, dto);
+    }
+    return dto;
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/DatasetRepository.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/DatasetRepository.java
@@ -1,0 +1,6 @@
+package org.sagebionetworks.amp.als.dataset.service.model.repository;
+
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DatasetRepository extends JpaRepository<DatasetEntity, Long> {}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
@@ -1,0 +1,45 @@
+package org.sagebionetworks.amp.als.dataset.service.service;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.sagebionetworks.amp.als.dataset.service.exception.DatasetNotFoundException;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.sagebionetworks.amp.als.dataset.service.model.mapper.DatasetMapper;
+import org.sagebionetworks.amp.als.dataset.service.model.repository.DatasetRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class DatasetService {
+
+  private final DatasetRepository datasetRepository;
+
+  public DatasetService(DatasetRepository datasetRepository) {
+    this.datasetRepository = datasetRepository;
+  }
+
+  private DatasetMapper datasetMapper = new DatasetMapper();
+
+  @Transactional(readOnly = true)
+  public DatasetDto getDataset(Long datasetId) {
+    DatasetEntity datasetEntity = getDatasetEntity(datasetId);
+    return datasetMapper.convertToDto(datasetEntity);
+  }
+
+  private DatasetEntity getDatasetEntity(Long datasetId) throws DatasetNotFoundException {
+    return datasetRepository
+      .findById(datasetId)
+      .orElseThrow(() ->
+        new DatasetNotFoundException(
+          String.format("The dataset with ID %d does not exist.", datasetId)
+        )
+      );
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
@@ -1,21 +1,14 @@
 package org.sagebionetworks.amp.als.dataset.service.service;
 
-import java.util.Arrays;
-import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.sagebionetworks.amp.als.dataset.service.exception.DatasetNotFoundException;
 import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDto;
 import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
 import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
 import org.sagebionetworks.amp.als.dataset.service.model.mapper.DatasetMapper;
 import org.sagebionetworks.amp.als.dataset.service.model.repository.DatasetRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 public class DatasetService {
 


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-49

## Changelog

- Implement the endpoint to get dataset by ID.

## Preview

### Get the dataset by ID

Before this PR:

```console
$ curl -X 'GET' \
  'http://amp-als-apex:8400/api/v1/datasets/1' \
  -H 'accept: application/json' \
  -w "\nHTTP status: %{http_code}\n"

HTTP status: 501
```

With this PR:

```console
$ curl -X 'GET' \
  'http://amp-als-apex:8400/api/v1/datasets/1' \
  -H 'accept: application/json

{"id":1,"name":"Mock Dataset 1","description":"Clinical data from patients with cardiovascular conditions","createdAt":"2025-04-01T23:08:59Z","updatedAt":"2025-04-01T23:08:59Z"}
```

Using Swagger UI:

![image](https://github.com/user-attachments/assets/81485475-3a33-44d6-89c8-778aeebd0e24)

