### PR TITLE
feat(amp-als): index datasets in Elasticsearch on AMP-ALS dataset service startup (SMR-46)

### DIFF
--- a/apps/amp-als/dataset-service/build.gradle
+++ b/apps/amp-als/dataset-service/build.gradle
@@ -21,38 +21,50 @@ repositories {
 }
 
 dependencies {
-  // implementation "org.hibernate.search:hibernate-search-mapper-orm:${hibernateSearchVersion}"
-  // implementation "org.hibernate.search:hibernate-search-backend-elasticsearch:${hibernateSearchVersion}"
-
+  // Lombok
+  compileOnly "org.projectlombok:lombok:${lombokVersion}"
   annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
-  compileOnly "org.projectlombok:lombok:${lombokVersion}"
-  implementation 'com.google.code.findbugs:jsr305:3.0.2'
-  implementation 'org.openapitools:jackson-databind-nullable:0.2.3'
-  implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
-  implementation "com.fasterxml.jackson.core:jackson-databind:${fasterxmlVersion}"
-  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${fasterxmlVersion}"
-  implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${fasterxmlVersion}"
-  implementation "org.flywaydb:flyway-core:${flywaydbVersion}"
-  implementation "org.flywaydb:flyway-mysql:${flywaydbVersion}"
-  implementation "org.sagebionetworks:util:${ampAlsVersion}"
-
-  implementation 'org.springframework.boot:spring-boot-starter-amqp:2.7.7'
-
-  implementation "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
-
-  implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
+  // Spring Boot Starters
+  implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
   implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
   implementation "org.springframework.boot:spring-boot-starter-security:${springBootVersion}"
   implementation "org.springframework.boot:spring-boot-starter-validation:${springBootVersion}"
-  implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-  implementation "org.springframework.data:spring-data-commons:${springDataVersion}"
-  runtimeOnly 'mysql:mysql-connector-java:8.0.30'
+  implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
+  implementation "org.springframework.boot:spring-boot-starter-amqp:2.7.7"
+  implementation "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
   testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
 
+  // Spring Data
+  implementation "org.springframework.data:spring-data-commons:${springDataVersion}"
+
+  // Jackson
+  implementation "com.fasterxml.jackson.core:jackson-databind:${fasterxmlVersion}"
+  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${fasterxmlVersion}"
+  implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${fasterxmlVersion}"
+  implementation 'org.openapitools:jackson-databind-nullable:0.2.3'
+
+  // OpenAPI
+  implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
+
+  // Hibernate Search
+  implementation "org.hibernate.search:hibernate-search-mapper-orm:${hibernateSearchVersion}"
+  implementation "org.hibernate.search:hibernate-search-backend-elasticsearch:${hibernateSearchVersion}"
+
+  // Flyway
+  implementation "org.flywaydb:flyway-core:${flywaydbVersion}"
+  implementation "org.flywaydb:flyway-mysql:${flywaydbVersion}"
+
+  // Sage Bionetworks
+  implementation "org.sagebionetworks:util:${ampAlsVersion}"
   implementation "org.sagebionetworks.amp.als:amp-als-app-config-data:${ampAlsVersion}"
 
+  // Misc
+  implementation 'com.google.code.findbugs:jsr305:3.0.2'
   implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+  // Database
+  runtimeOnly 'mysql:mysql-connector-java:8.0.30'
 }
 
 group = 'org.sagebionetworks.amp.als'

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/configuration/HibernateSearchIndexBuild.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/configuration/HibernateSearchIndexBuild.java
@@ -1,0 +1,43 @@
+package org.sagebionetworks.amp.als.dataset.service.configuration;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class HibernateSearchIndexBuild implements ApplicationListener<ApplicationReadyEvent> {
+
+  private final EntityManager entityManager;
+
+  public HibernateSearchIndexBuild(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  @Override
+  @Transactional
+  public void onApplicationEvent(ApplicationReadyEvent event) {
+    log.info("Started Initializing Indexes");
+    SearchSession searchSession = Search.session(entityManager);
+    MassIndexer indexer = searchSession
+      .massIndexer()
+      .idFetchSize(150)
+      .batchSizeToLoadObjects(25)
+      .threadsToLoadObjects(12);
+
+    try {
+      indexer.startAndWait();
+    } catch (InterruptedException e) {
+      log.warn("Failed to load data from database");
+      Thread.currentThread().interrupt();
+    }
+
+    log.info("Completed Indexing");
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/entity/DatasetEntity.java
@@ -11,6 +11,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 @Entity
 @Table(name = "dataset")
@@ -18,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Indexed(index = "amp-als-dataset")
 public class DatasetEntity {
 
   @Id
@@ -26,12 +31,15 @@ public class DatasetEntity {
   private Long id;
 
   @Column(nullable = false)
+  @FullTextField
   private String name;
 
   @Column(nullable = false)
+  @FullTextField
   private String description;
 
   @Column(name = "created_at")
+  @GenericField(name = "created_at", sortable = Sortable.YES)
   private OffsetDateTime createdAt;
 
   @Column(name = "updated_at")

--- a/apps/amp-als/dataset-service/src/main/resources/application.yml
+++ b/apps/amp-als/dataset-service/src/main/resources/application.yml
@@ -9,6 +9,27 @@ spring:
     url: ${db.url}
     username: dataset_service
     password: changeme
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        search:
+          enabled: true
+          schema_management:
+            strategy: drop-and-create
+          backend:
+            # version_check: false
+            # version: 'opensearch:1.3.7'
+            # type: elasticsearch
+            hosts: amp-als-elasticsearch:8402
+            username: admin
+            password: admin
+  autoconfigure:
+    # Prevent Spring Boot from auto-configuring a default Elasticsearch client,
+    # which Hibernate Search might incorrectly use, leading to node sniffing errors
+    # when a local cluster is not available.
+    exclude: org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration
   jackson:
     date-format: org.sagebionetworks.amp.als.dataset.service.RFC3339DateFormat
     serialization:

--- a/docker/amp-als/services/dataset-service.yml
+++ b/docker/amp-als/services/dataset-service.yml
@@ -10,9 +10,9 @@ services:
     ports:
       - '8404:8404'
     depends_on:
-      #   amp-als-elasticsearch:
-      #     condition: service_healthy
       amp-als-mariadb:
+        condition: service_healthy
+      amp-als-elasticsearch:
         condition: service_healthy
     deploy:
       resources:

--- a/docker/amp-als/services/elasticsearch.yml
+++ b/docker/amp-als/services/elasticsearch.yml
@@ -6,8 +6,7 @@ services:
     environment:
       - node.name=amp-als-elasticsearch
       - cluster.name=amp-als-elasticsearch
-      - discovery.seed_hosts=
-      - cluster.initial_master_nodes=amp-als-elasticsearch
+      - discovery.type=single-node
       - bootstrap.memory_lock=true
       - 'ES_JAVA_OPTS=-Xms1g -Xmx1g'
       - http.port=8402


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-46

## Changelog

- Index the name, description and creation date of datasets in Elasticsearch.
- Organize dependencies in `build.gradle`.
- Update the configuration of Elasticsearch for single node setup.

## Preview

### Build the Docker images

```bash
amp-als-build-images
```

### Start the dataset service and its dependencies with Docker Compose

```bash
nx serve-detach amp-als-dataset-service
```

### Stop the dataset service container (Optional)

Stop and remove the container if you prefer to start the development server of the dataset service. This is preferred for development to benefit from live reloading.

```bash
docker rm -f amp-als-dataset-service
```

### Start the development server of the dataset service

```bash
nx serve amp-als-dataset-service
```

### Show the created index in Elasticsearch (ES):

```console
$ curl -X GET "http://amp-als-elasticsearch:8402/_cat/indices?v"
health status index                  uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .geoip_databases       Z275L3OGTbKXQRa0Cp82WQ   1   0         39            0     36.7mb         36.7mb
yellow open   amp-als-dataset-000001 Zrb47S4TS2Cpjn2q2ZJIHg   1   1          3            0      8.9kb          8.9kb
```

### Show the indexed documents

Show the datasets indexed in Elasticsearch by the dataset service:

```console
$ curl -X GET "http://amp-als-elasticsearch:8402/amp-als-dataset-000001/_search?pretty"
{
  "took" : 4,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 3,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "amp-als-dataset-000001",
        "_type" : "_doc",
        "_id" : "1",
        "_score" : 1.0,
        "_source" : {
          "created_at" : "2025-04-02T02:38:59.000000000Z",
          "description" : "Clinical data from patients with cardiovascular conditions",
          "name" : "Mock Dataset 1",
          "_entity_type" : "DatasetEntity"
        }
      },
      {
        "_index" : "amp-als-dataset-000001",
        "_type" : "_doc",
        "_id" : "2",
        "_score" : 1.0,
        "_source" : {
          "created_at" : "2025-04-02T02:38:59.000000000Z",
          "description" : "Longitudinal dataset of individuals with early signs of neurodegeneration",
          "name" : "Mock Dataset 2",
          "_entity_type" : "DatasetEntity"
        }
      },
      {
        "_index" : "amp-als-dataset-000001",
        "_type" : "_doc",
        "_id" : "3",
        "_score" : 1.0,
        "_source" : {
          "created_at" : "2025-04-02T02:38:59.000000000Z",
          "description" : "Registry of patients enrolled in various oncology clinical trials",
          "name" : "Mock Dataset 3",
          "_entity_type" : "DatasetEntity"
        }
      }
    ]
  }
}
```