### PR TITLE
feat(amp-als): implements listDatasets endpoint with full-text search and sorting powered by Elasticsearch (SMR-50)

### DIFF
--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/DatasetServiceApplication.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/DatasetServiceApplication.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.ComponentScan;
 @ComponentScan(basePackages = { "org.sagebionetworks.amp.als" })
 public class DatasetServiceApplication implements CommandLineRunner {
 
-  private static final Logger log = LoggerFactory.getLogger(DatasetServiceApplication.class);
+  private static final Logger logger = LoggerFactory.getLogger(DatasetServiceApplication.class);
 
   private final DatasetServiceConfigData datasetServiceConfigData;
 
@@ -26,6 +26,6 @@ public class DatasetServiceApplication implements CommandLineRunner {
 
   @Override
   public void run(String... args) throws Exception {
-    log.info(datasetServiceConfigData.getWelcomeMessage());
+    logger.info(datasetServiceConfigData.getWelcomeMessage());
   }
 }

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.amp.als.dataset.service.api;
 
 import java.util.List;
 import java.util.Optional;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
 import org.sagebionetworks.amp.als.dataset.service.service.DatasetService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +38,11 @@ public class DatasetApiDelegateImpl implements DatasetApiDelegate {
     }
     // TODO: Return an error object if this API does not support any of the accepted types
     return ResponseEntity.ok(datasetService.getDataset(datasetId));
+  }
+
+  @Override
+  public ResponseEntity<DatasetsPageDto> listDatasets(DatasetSearchQueryDto query) {
+    return ResponseEntity.ok(datasetService.listDatasets(query));
   }
 
   public List<MediaType> getAcceptedMediaTypes(Optional<NativeWebRequest> requestOpt) {

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/configuration/FlywayConfiguration.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/configuration/FlywayConfiguration.java
@@ -9,14 +9,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class FlywayConfiguration {
 
-  private static final Logger log = LoggerFactory.getLogger(FlywayConfiguration.class);
+  private static final Logger logger = LoggerFactory.getLogger(FlywayConfiguration.class);
 
   // TODO: Clean the DB only in dev mode, never in production.
   // @Profile("dev")
   @Bean
   public FlywayMigrationStrategy cleanMigrationStrategy() {
     return flyway -> {
-      log.info("Executing custom Flyway migration: clean and migrate");
+      logger.info("Executing custom Flyway migration: clean and migrate");
       flyway.clean();
       flyway.migrate();
     };

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/BadRequestException.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/BadRequestException.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+public class BadRequestException extends SimpleDatasetGlobalException {
+
+  public BadRequestException(String detail) {
+    super(
+      ErrorConstants.BAD_REQUEST.getType(),
+      ErrorConstants.BAD_REQUEST.getTitle(),
+      ErrorConstants.BAD_REQUEST.getStatus(),
+      detail
+    );
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepository.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepository.java
@@ -1,0 +1,10 @@
+package org.sagebionetworks.amp.als.dataset.service.model.repository;
+
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomDatasetRepository {
+  Page<DatasetEntity> findAll(Pageable pageable, DatasetSearchQueryDto query, String... fields);
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepositoryImpl.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepositoryImpl.java
@@ -1,0 +1,186 @@
+package org.sagebionetworks.amp.als.dataset.service.model.repository;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
+import org.hibernate.search.engine.search.common.BooleanOperator;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.search.sort.SearchSort;
+import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
+import org.hibernate.search.engine.search.sort.dsl.SortOrder;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.sagebionetworks.amp.als.dataset.service.exception.BadRequestException;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDirectionDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CustomDatasetRepositoryImpl implements CustomDatasetRepository {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Override
+  public Page<DatasetEntity> findAll(
+    Pageable pageable,
+    DatasetSearchQueryDto query,
+    String... fields
+  ) {
+    SearchResult<DatasetEntity> result = getSearchResult(pageable, query, fields);
+    return new PageImpl<>(result.hits(), pageable, result.total().hitCount());
+  }
+
+  private SearchResult<DatasetEntity> getSearchResult(
+    Pageable pageable,
+    DatasetSearchQueryDto query,
+    String[] fields
+  ) {
+    SearchSession searchSession = Search.session(entityManager);
+    SearchPredicateFactory pf = searchSession.scope(DatasetEntity.class).predicate();
+    SearchSortFactory sf = searchSession.scope(DatasetEntity.class).sort();
+    List<SearchPredicate> predicates = new ArrayList<>();
+
+    if (query.getSearchTerms() != null && !query.getSearchTerms().isBlank()) {
+      predicates.add(getSearchTermsPredicate(pf, query, fields));
+    }
+
+    SearchSort sort = getSearchSort(sf, query);
+    SearchPredicate sortPredicate = getSearchSortPredicate(pf, query);
+    if (sortPredicate != null) {
+      predicates.add(sortPredicate);
+    }
+
+    SearchPredicate topLevelPredicate = buildTopLevelPredicate(pf, predicates);
+
+    SearchResult<DatasetEntity> result = searchSession
+      .search(DatasetEntity.class)
+      .where(topLevelPredicate)
+      .sort(sort)
+      .fetch((int) pageable.getOffset(), pageable.getPageSize());
+    return result;
+  }
+
+  /**
+   * Searches the datasets using the search terms specified.
+   *
+   * @param pf
+   * @param query
+   * @param fields
+   * @return
+   */
+  private SearchPredicate getSearchTermsPredicate(
+    SearchPredicateFactory pf,
+    DatasetSearchQueryDto query,
+    String[] fields
+  ) {
+    return pf
+      .simpleQueryString()
+      .fields(fields)
+      .matching(query.getSearchTerms())
+      .defaultOperator(BooleanOperator.AND)
+      .toPredicate();
+  }
+
+  /**
+   * Combines the dataset search predicates.
+   *
+   * @param pf
+   * @param predicates
+   * @return
+   */
+  private SearchPredicate buildTopLevelPredicate(
+    SearchPredicateFactory pf,
+    List<SearchPredicate> predicates
+  ) {
+    return pf
+      .bool(b -> {
+        b.must(f -> f.matchAll());
+        for (SearchPredicate predicate : predicates) {
+          b.must(predicate);
+        }
+      })
+      .toPredicate();
+  }
+
+  /**
+   * Sorts the datasets according to the sort and direction values specified.
+   *
+   * @param sf
+   * @param query
+   * @return
+   */
+  private SearchSort getSearchSort(SearchSortFactory sf, DatasetSearchQueryDto query) {
+    // SortOrder orderWithDefaultAsc = query.getDirection() == DatasetDirectionDto.DESC
+    //   ? SortOrder.DESC
+    //   : SortOrder.ASC;
+    SortOrder orderWithDefaultDesc = query.getDirection() == DatasetDirectionDto.ASC
+      ? SortOrder.ASC
+      : SortOrder.DESC;
+
+    SearchSort createdSort = sf.field("created_at").order(orderWithDefaultDesc).toSort();
+    SearchSort scoreSort = sf.score().order(orderWithDefaultDesc).toSort();
+    SearchSort relevanceSort = (query.getSearchTerms() == null || query.getSearchTerms().isBlank())
+      ? createdSort
+      : scoreSort;
+
+    switch (query.getSort()) {
+      case CREATED -> {
+        return createdSort;
+      }
+      case RANDOM -> {
+        return scoreSort;
+      }
+      case RELEVANCE -> {
+        return relevanceSort;
+      }
+      default -> {
+        throw new BadRequestException(
+          String.format("Unhandled sorting strategy '%s'", query.getSort())
+        );
+      }
+    }
+  }
+
+  private SearchPredicate getSearchSortPredicate(
+    SearchPredicateFactory pf,
+    DatasetSearchQueryDto query
+  ) {
+    switch (query.getSort()) {
+      case RANDOM -> {
+        Integer seed = query.getSortSeed();
+        if (seed == null) {
+          SecureRandom rand = new SecureRandom();
+          seed = rand.nextInt(Integer.MAX_VALUE);
+        }
+        return pf
+          .extension(ElasticsearchExtension.get())
+          .fromJson(
+            "{" +
+            "  \"function_score\": {" +
+            "    \"random_score\": {" +
+            "      \"seed\": " +
+            seed +
+            "," +
+            "      \"field\": \"_seq_no\"" +
+            "    }" +
+            "  }" +
+            "}"
+          )
+          .toPredicate();
+      }
+      default -> {
+        return null;
+      }
+    }
+  }
+}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/DatasetRepository.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/DatasetRepository.java
@@ -3,4 +3,5 @@ package org.sagebionetworks.amp.als.dataset.service.model.repository;
 import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DatasetRepository extends JpaRepository<DatasetEntity, Long> {}
+public interface DatasetRepository
+  extends JpaRepository<DatasetEntity, Long>, CustomDatasetRepository {}

--- a/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
+++ b/apps/amp-als/dataset-service/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
@@ -1,11 +1,17 @@
 package org.sagebionetworks.amp.als.dataset.service.service;
 
+import java.util.Arrays;
+import java.util.List;
 import org.sagebionetworks.amp.als.dataset.service.exception.DatasetNotFoundException;
 import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
 import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
 import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
 import org.sagebionetworks.amp.als.dataset.service.model.mapper.DatasetMapper;
 import org.sagebionetworks.amp.als.dataset.service.model.repository.DatasetRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +25,32 @@ public class DatasetService {
   }
 
   private DatasetMapper datasetMapper = new DatasetMapper();
+
+  private static final List<String> SEARCHABLE_FIELDS = Arrays.asList("name", "description");
+
+  @Transactional(readOnly = true)
+  public DatasetsPageDto listDatasets(DatasetSearchQueryDto query) {
+    Pageable pageable = PageRequest.of(query.getPageNumber(), query.getPageSize());
+
+    List<String> fieldsToSearchBy = SEARCHABLE_FIELDS;
+    Page<DatasetEntity> datasetEntitiesPage = datasetRepository.findAll(
+      pageable,
+      query,
+      fieldsToSearchBy.toArray(new String[0])
+    );
+
+    List<DatasetDto> datasets = datasetMapper.convertToDtoList(datasetEntitiesPage.getContent());
+
+    return DatasetsPageDto.builder()
+      .datasets(datasets)
+      .number(datasetEntitiesPage.getNumber())
+      .size(datasetEntitiesPage.getSize())
+      .totalElements(datasetEntitiesPage.getTotalElements())
+      .totalPages(datasetEntitiesPage.getTotalPages())
+      .hasNext(datasetEntitiesPage.hasNext())
+      .hasPrevious(datasetEntitiesPage.hasPrevious())
+      .build();
+  }
 
   @Transactional(readOnly = true)
   public DatasetDto getDataset(Long datasetId) {


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-50

## Changelog

- List datasets with full-text search and sorting powered by Hibernate Search and Elasticsearch.
- Support paginated responses (`pageSize` and `pageNumber`).
- Sort results with different strategies (`created`, `random`, `relevance`).
- Order the results in ascending or descending order (`asc` and `desc`).
- Full-test search (`searchTerms`).

## Preview

### Full-text search for "clinical"

- Search for the keyword "clinical"
- Sort the results 1) by their creation date and time and 2) in ascending order.
- Set the page size to 10.
- Request the first page (page number 0).

```console
$ curl -X 'GET' \
  'http://localhost:8404/v1/datasets?pageNumber=0&pageSize=10&sort=created&direction=asc&searchTerms=clinical' \
  -H 'accept: application/json'
{"number":0,"size":10,"totalElements":2,"totalPages":1,"hasNext":false,"hasPrevious":false,"datasets":[{"id":3,"name":"Mock Dataset 3","description":"Registry of patients enrolled in various oncology clinical trials","createdAt":"2025-04-02T03:23:07Z","updatedAt":"2025-04-02T03:23:07Z"},{"id":1,"name":"Mock Dataset 1","description":"Clinical data from patients with cardiovascular conditions","createdAt":"2025-04-02T03:23:07Z","updatedAt":"2025-04-02T03:23:07Z"}]}
```

### Set page size

The above request returned a page with two results. We now set the page size to 1:

```console
$ curl -X 'GET' \","updatedAt":"2025-04-02T03:23:07Z"}]}ubuntu@ea6161b5fcd4:/workspaces/sage-monorepo$ curl -X 'GET' \
  'http://localhost:8404/v1/datasets?pageNumber=0&pageSize=1&sort=created&direction=asc&searchTerms=clinical' \
  -H 'accept: application/json'
{"number":0,"size":1,"totalElements":2,"totalPages":2,"hasNext":true,"hasPrevious":false,"datasets":[{"id":3,"name":"Mock Dataset 3","description":"Registry of patients enrolled in various oncology clinical trials","createdAt":"2025-04-02T03:23:07Z","updatedAt":"2025-04-02T03:23:07Z"}]}
```

### Search with Swagger UI

![image](https://github.com/user-attachments/assets/4e33b522-a10f-47c4-8bfa-849015943e05)
