### PR TITLE
fix(agora): ensure that query parameter sets initially selected model on gene details RNA page, revert @Input changes to GCT (AG-1739)

### DIFF
--- a/apps/agora/app/e2e/gene-comparison-tool-pinning-cache.spec.ts
+++ b/apps/agora/app/e2e/gene-comparison-tool-pinning-cache.spec.ts
@@ -113,176 +113,170 @@ test.describe('GCT: Caching pinned genes', () => {
     });
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'Pinned proteins are maintained when switching between Protein subcategories',
-    async ({ page }) => {
-      const gene1 = geneWithMultipleProteinsTMT.name;
-      const gene2 = gene2WithMultipleProteinsTMT.name;
-      const genes = [gene1, gene2];
-      const nGenes = genes.length;
+  test('Pinned proteins are maintained when switching between Protein subcategories', async ({
+    page,
+  }) => {
+    const gene1 = geneWithMultipleProteinsTMT.name;
+    const gene2 = gene2WithMultipleProteinsTMT.name;
+    const genes = [gene1, gene2];
+    const nGenes = genes.length;
 
-      const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
-      const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
-      const nProteins = proteins1.length + proteins2.length;
+    const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
+    const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
+    const nProteins = proteins1.length + proteins2.length;
 
+    await page.goto(URL_GCT_PROTEIN_TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+
+    for (const gene of genes) {
+      await pinAllItemsViaSearchByGene(page, gene);
+    }
+
+    await test.step('confirm # genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+      await confirmPinnedItemsCount(page, nProteins);
+    });
+
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.TMT,
+      GCT_PROTEIN_SUBCATEGORIES.SRM,
+    );
+
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.SRM,
+      GCT_PROTEIN_SUBCATEGORIES.LFQ,
+    );
+
+    // back to original subcategory
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.LFQ,
+      GCT_PROTEIN_SUBCATEGORIES.TMT,
+    );
+
+    await test.step('confirm same genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+      await confirmPinnedItemsCount(page, nProteins);
+
+      await confirmPinnedProteins(page, gene1, proteins1);
+      await confirmPinnedProteins(page, gene2, proteins2);
+    });
+  });
+
+  test('Pinned proteins are maintained when switching categories: Protein -> RNA -> Protein', async ({
+    page,
+  }) => {
+    const gene1 = geneWithMultipleProteinsTMT.name;
+    const gene2 = gene2WithMultipleProteinsTMT.name;
+    const genes = [gene1, gene2];
+    const nGenes = genes.length;
+
+    const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
+    const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
+    const nProteins = proteins1.length + proteins2.length;
+
+    await page.goto(URL_GCT_PROTEIN_TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+
+    for (const gene of genes) {
+      await pinAllItemsViaSearchByGene(page, gene);
+    }
+
+    await test.step('confirm # genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+      await confirmPinnedItemsCount(page, nProteins);
+    });
+
+    await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
+
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.RNA,
+      GCT_RNA_SUBCATEGORIES.AD,
+      GCT_RNA_SUBCATEGORIES.AD_AOD,
+    );
+
+    // back to original category
+    await changeGctCategory(page, GCT_CATEGORIES.RNA, GCT_CATEGORIES.PROTEIN);
+
+    // back to original subcategory
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.SRM,
+      GCT_PROTEIN_SUBCATEGORIES.TMT,
+    );
+
+    await test.step('confirm same genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+
+      await confirmPinnedItemsCount(page, nProteins);
+      await confirmPinnedProteins(page, gene1, proteins1);
+      await confirmPinnedProteins(page, gene2, proteins2);
+    });
+  });
+
+  test('Last pinned genes are maintained even if proteins were pinned initially', async ({
+    page,
+  }) => {
+    const rnaCategoryGene = geneWithMultipleProteinsTMT.name;
+    const rnaCategoryProteins = geneWithMultipleProteinsTMT.uniProtIds;
+    const proteinCategoryGene = gene2WithMultipleProteinsTMT.name;
+
+    await test.step('pin proteins in Protein category', async () => {
       await page.goto(URL_GCT_PROTEIN_TMT);
       await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      for (const gene of genes) {
-        await pinAllItemsViaSearchByGene(page, gene);
-      }
+      await pinAllItemsViaSearchByGene(page, proteinCategoryGene);
+    });
 
-      await test.step('confirm # genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
-        await confirmPinnedItemsCount(page, nProteins);
-      });
-
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.PROTEIN,
-        GCT_PROTEIN_SUBCATEGORIES.TMT,
-        GCT_PROTEIN_SUBCATEGORIES.SRM,
-      );
-
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.PROTEIN,
-        GCT_PROTEIN_SUBCATEGORIES.SRM,
-        GCT_PROTEIN_SUBCATEGORIES.LFQ,
-      );
-
-      // back to original subcategory
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.PROTEIN,
-        GCT_PROTEIN_SUBCATEGORIES.LFQ,
-        GCT_PROTEIN_SUBCATEGORIES.TMT,
-      );
-
-      await test.step('confirm same genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
-        await confirmPinnedItemsCount(page, nProteins);
-
-        await confirmPinnedProteins(page, gene1, proteins1);
-        await confirmPinnedProteins(page, gene2, proteins2);
-      });
-    },
-  );
-
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'Pinned proteins are maintained when switching categories: Protein -> RNA -> Protein',
-    async ({ page }) => {
-      const gene1 = geneWithMultipleProteinsTMT.name;
-      const gene2 = gene2WithMultipleProteinsTMT.name;
-      const genes = [gene1, gene2];
-      const nGenes = genes.length;
-
-      const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
-      const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
-      const nProteins = proteins1.length + proteins2.length;
-
-      await page.goto(URL_GCT_PROTEIN_TMT);
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
-
-      for (const gene of genes) {
-        await pinAllItemsViaSearchByGene(page, gene);
-      }
-
-      await test.step('confirm # genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
-        await confirmPinnedItemsCount(page, nProteins);
-      });
-
+    await test.step('pin genes in RNA category', async () => {
       await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
 
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.RNA,
-        GCT_RNA_SUBCATEGORIES.AD,
-        GCT_RNA_SUBCATEGORIES.AD_AOD,
-      );
+      await test.step('clear all items', async () => {
+        await page.getByRole('button', { name: 'Clear All' }).click();
+        await expect(page.getByText(/Pinned Genes/i)).toBeHidden();
+      });
 
-      // back to original category
+      await pinGeneViaSearch(page, rnaCategoryGene);
+
+      await test.step('confirm pinned gene', async () => {
+        await expectPinnedGenesCountText(page, 1);
+        await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
+      });
+    });
+
+    await test.step('Protein category pins have changed', async () => {
       await changeGctCategory(page, GCT_CATEGORIES.RNA, GCT_CATEGORIES.PROTEIN);
-
-      // back to original subcategory
       await changeGctSubcategory(
         page,
         GCT_CATEGORIES.PROTEIN,
         GCT_PROTEIN_SUBCATEGORIES.SRM,
         GCT_PROTEIN_SUBCATEGORIES.TMT,
       );
+      await expectPinnedGenesCountText(page, 1);
+      await expectPinnedProteinsCountText(page, rnaCategoryProteins.length);
+      await confirmPinnedProteins(page, rnaCategoryGene, rnaCategoryProteins);
+    });
 
-      await test.step('confirm same genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
+    await test.step('RNA category pins are maintained', async () => {
+      await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
 
-        await confirmPinnedItemsCount(page, nProteins);
-        await confirmPinnedProteins(page, gene1, proteins1);
-        await confirmPinnedProteins(page, gene2, proteins2);
-      });
-    },
-  );
-
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'Last pinned genes are maintained even if proteins were pinned initially',
-    async ({ page }) => {
-      const rnaCategoryGene = geneWithMultipleProteinsTMT.name;
-      const rnaCategoryProteins = geneWithMultipleProteinsTMT.uniProtIds;
-      const proteinCategoryGene = gene2WithMultipleProteinsTMT.name;
-
-      await test.step('pin proteins in Protein category', async () => {
-        await page.goto(URL_GCT_PROTEIN_TMT);
-        await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
-
-        await pinAllItemsViaSearchByGene(page, proteinCategoryGene);
-      });
-
-      await test.step('pin genes in RNA category', async () => {
-        await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
-
-        await test.step('clear all items', async () => {
-          await page.getByRole('button', { name: 'Clear All' }).click();
-          await expect(page.getByText(/Pinned Genes/i)).toBeHidden();
-        });
-
-        await pinGeneViaSearch(page, rnaCategoryGene);
-
-        await test.step('confirm pinned gene', async () => {
-          await expectPinnedGenesCountText(page, 1);
-          await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
-        });
-      });
-
-      await test.step('Protein category pins have changed', async () => {
-        await changeGctCategory(page, GCT_CATEGORIES.RNA, GCT_CATEGORIES.PROTEIN);
-        await changeGctSubcategory(
-          page,
-          GCT_CATEGORIES.PROTEIN,
-          GCT_PROTEIN_SUBCATEGORIES.SRM,
-          GCT_PROTEIN_SUBCATEGORIES.TMT,
-        );
+      await test.step('confirm pinned gene', async () => {
         await expectPinnedGenesCountText(page, 1);
-        await expectPinnedProteinsCountText(page, rnaCategoryProteins.length);
-        await confirmPinnedProteins(page, rnaCategoryGene, rnaCategoryProteins);
+        await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
       });
-
-      await test.step('RNA category pins are maintained', async () => {
-        await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
-
-        await test.step('confirm pinned gene', async () => {
-          await expectPinnedGenesCountText(page, 1);
-          await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
-        });
-      });
-    },
-  );
+    });
+  });
 
   test('Last pinned proteins are maintained even if genes were pinned initially', async ({
     page,

--- a/apps/agora/app/e2e/gene-comparison-tool-pinning-url.spec.ts
+++ b/apps/agora/app/e2e/gene-comparison-tool-pinning-url.spec.ts
@@ -34,21 +34,16 @@ test.describe('GCT: Pinning Genes from URL', () => {
     await confirmPinnedItemsCount(page, 0);
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url does not include pinned genes, no genes are pinned',
-    async ({ page }) => {
-      await page.goto(URL_GCT_PROTEIN);
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.SRM);
+  test('when Protein url does not include pinned genes, no genes are pinned', async ({ page }) => {
+    await page.goto(URL_GCT_PROTEIN);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.SRM);
 
-      await expect(page.getByText('Pinned Genes')).toBeHidden();
-      await expect(page.getByText('All Genes')).toBeHidden();
-      await confirmPinnedItemsCount(page, 0);
-    },
-  );
+    await expect(page.getByText('Pinned Genes')).toBeHidden();
+    await expect(page.getByText('All Genes')).toBeHidden();
+    await confirmPinnedItemsCount(page, 0);
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme('when RNA url includes 50 pinned genes, all genes are pinned', async ({ page }) => {
+  test('when RNA url includes 50 pinned genes, all genes are pinned', async ({ page }) => {
     const url = `${URL_GCT}?${formatPinnedGenesQueryParam(fiftyGenes)}`;
     await page.goto(url);
 
@@ -68,57 +63,53 @@ test.describe('GCT: Pinning Genes from URL', () => {
     });
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when RNA url includes >50 pinned genes, only 50 genes are pinned and toast is displayed',
-    async ({ page }) => {
-      const url = `${URL_GCT}?${formatPinnedGenesQueryParam(fiftyOneGenes)}`;
-      await page.goto(url);
+  test('when RNA url includes >50 pinned genes, only 50 genes are pinned and toast is displayed', async ({
+    page,
+  }) => {
+    const url = `${URL_GCT}?${formatPinnedGenesQueryParam(fiftyOneGenes)}`;
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
 
-      await test.step('confirm only pinned 50 genes', async () => {
-        await expect(page.getByText('All Genes')).toBeVisible();
-        await expectPinnedGenesCountText(page, 50);
-        await confirmPinnedItemsCount(page, 50);
-        await expectTooManyPinnedGenesToast(page);
-      });
+    await test.step('confirm only pinned 50 genes', async () => {
+      await expect(page.getByText('All Genes')).toBeVisible();
+      await expectPinnedGenesCountText(page, 50);
+      await confirmPinnedItemsCount(page, 50);
+      await expectTooManyPinnedGenesToast(page);
+    });
 
-      await test.step('confirm url dropped 51st gene', () => {
-        const genes = getPinnedItemsFromUrl(page.url());
-        expect(genes).toHaveLength(50);
-        expect(genes).toEqual(fiftyOneGenes.sort().slice(0, -1));
-      });
-    },
-  );
+    await test.step('confirm url dropped 51st gene', () => {
+      const genes = getPinnedItemsFromUrl(page.url());
+      expect(genes).toHaveLength(50);
+      expect(genes).toEqual(fiftyOneGenes.sort().slice(0, -1));
+    });
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when RNA url includes invalid gene, that gene is dropped from the url',
-    async ({ page }) => {
-      const validGeneId = geneWithMultipleProteinsTMT.ensemblId;
-      const url = `${URL_GCT}?${formatPinnedGenesQueryParam([validGeneId, 'invalidGene'])}`;
-      await page.goto(url);
+  test('when RNA url includes invalid gene, that gene is dropped from the url', async ({
+    page,
+  }) => {
+    const validGeneId = geneWithMultipleProteinsTMT.ensemblId;
+    const url = `${URL_GCT}?${formatPinnedGenesQueryParam([validGeneId, 'invalidGene'])}`;
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
 
-      await test.step('confirm toast not shown', async () => {
-        await expect(page.getByRole('alert')).toBeHidden();
-      });
+    await test.step('confirm toast not shown', async () => {
+      await expect(page.getByRole('alert')).toBeHidden();
+    });
 
-      await test.step('confirm only pinned 1 gene', async () => {
-        await expect(page.getByText('All Genes')).toBeVisible();
-        await expectPinnedGenesCountText(page, 1);
-        await confirmPinnedItemsCount(page, 1);
-      });
+    await test.step('confirm only pinned 1 gene', async () => {
+      await expect(page.getByText('All Genes')).toBeVisible();
+      await expectPinnedGenesCountText(page, 1);
+      await confirmPinnedItemsCount(page, 1);
+    });
 
-      await test.step('confirm url dropped invalid gene', () => {
-        const genes = getPinnedItemsFromUrl(page.url());
-        expect(genes).toHaveLength(1);
-        expect(genes).toEqual([validGeneId]);
-      });
-    },
-  );
+    await test.step('confirm url dropped invalid gene', () => {
+      const genes = getPinnedItemsFromUrl(page.url());
+      expect(genes).toHaveLength(1);
+      expect(genes).toEqual([validGeneId]);
+    });
+  });
 
   test.fail(
     'when RNA url includes proteins, the related gene is pinned',
@@ -172,108 +163,100 @@ test.describe('GCT: Pinning Genes from URL', () => {
     },
   );
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes 50 proteins from 50 unique genes, all proteins are pinned',
-    async ({ page }) => {
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(
-        fiftyProteinsToFiftyUniqueGenesTMT,
-      )}`;
-      await page.goto(url);
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+  test('when Protein url includes 50 proteins from 50 unique genes, all proteins are pinned', async ({
+    page,
+  }) => {
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(
+      fiftyProteinsToFiftyUniqueGenesTMT,
+    )}`;
+    await page.goto(url);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm counts', async () => {
-        await confirmPinnedItemsCount(page, 50);
-        await expectPinnedGenesCountText(page, 50);
-        await expectPinnedProteinsCountText(page, 50);
-      });
-    },
-  );
+    await test.step('confirm counts', async () => {
+      await confirmPinnedItemsCount(page, 50);
+      await expectPinnedGenesCountText(page, 50);
+      await expectPinnedProteinsCountText(page, 50);
+    });
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes >50 proteins from 50 unique genes, all proteins are pinned',
-    async ({ page }) => {
-      const fortyNineProteinsToUniqueGenes = fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1);
-      const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
-        (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
-      );
-      const allProteins = [...fortyNineProteinsToUniqueGenes, ...oneGeneWithManyProteins];
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
+  test('when Protein url includes >50 proteins from 50 unique genes, all proteins are pinned', async ({
+    page,
+  }) => {
+    const fortyNineProteinsToUniqueGenes = fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1);
+    const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
+      (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
+    );
+    const allProteins = [...fortyNineProteinsToUniqueGenes, ...oneGeneWithManyProteins];
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
 
-      await page.goto(url);
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm counts', async () => {
-        await expectPinnedGenesCountText(page, 50);
-        await confirmPinnedItemsCount(page, allProteins.length);
-        await expectPinnedProteinsCountText(page, allProteins.length);
-      });
+    await test.step('confirm counts', async () => {
+      await expectPinnedGenesCountText(page, 50);
+      await confirmPinnedItemsCount(page, allProteins.length);
+      await expectPinnedProteinsCountText(page, allProteins.length);
+    });
 
-      await confirmPinnedItemsByGeneName(
-        page,
-        geneWithMultipleProteinsTMT.name,
-        geneWithMultipleProteinsTMT.uniProtIds.length,
-      );
-    },
-  );
+    await confirmPinnedItemsByGeneName(
+      page,
+      geneWithMultipleProteinsTMT.name,
+      geneWithMultipleProteinsTMT.uniProtIds.length,
+    );
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes proteins from 51 unique genes, only proteins from 50 genes are pinned',
-    async ({ page }) => {
-      const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
-        (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
-      );
-      const allProteins = [...fiftyProteinsToFiftyUniqueGenesTMT, ...oneGeneWithManyProteins];
-      const expectedPinnedProteins = [
-        ...fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1),
-        ...oneGeneWithManyProteins,
-      ];
+  test('when Protein url includes proteins from 51 unique genes, only proteins from 50 genes are pinned', async ({
+    page,
+  }) => {
+    const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
+      (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
+    );
+    const allProteins = [...fiftyProteinsToFiftyUniqueGenesTMT, ...oneGeneWithManyProteins];
+    const expectedPinnedProteins = [
+      ...fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1),
+      ...oneGeneWithManyProteins,
+    ];
 
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
 
-      await page.goto(url);
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm counts', async () => {
-        await expectPinnedGenesCountText(page, 50);
-        await confirmPinnedItemsCount(page, expectedPinnedProteins.length);
-        await expectPinnedProteinsCountText(page, expectedPinnedProteins.length);
-      });
-    },
-  );
+    await test.step('confirm counts', async () => {
+      await expectPinnedGenesCountText(page, 50);
+      await confirmPinnedItemsCount(page, expectedPinnedProteins.length);
+      await expectPinnedProteinsCountText(page, expectedPinnedProteins.length);
+    });
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes invalid protein, that protein is dropped from the url',
-    async ({ page }) => {
-      const validGeneProtein = fiftyProteinsToFiftyUniqueGenesTMT[1];
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam([
-        validGeneProtein,
-        'invalidGeneProtein',
-      ])}`;
-      await page.goto(url);
+  test('when Protein url includes invalid protein, that protein is dropped from the url', async ({
+    page,
+  }) => {
+    const validGeneProtein = fiftyProteinsToFiftyUniqueGenesTMT[1];
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam([
+      validGeneProtein,
+      'invalidGeneProtein',
+    ])}`;
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm toast not shown', async () => {
-        await expect(page.getByRole('alert')).toBeHidden();
-      });
+    await test.step('confirm toast not shown', async () => {
+      await expect(page.getByRole('alert')).toBeHidden();
+    });
 
-      await test.step('confirm only pinned 1 protein', async () => {
-        await expectPinnedGenesCountText(page, 1);
-        await confirmPinnedItemsCount(page, 1);
-        await expectPinnedProteinsCountText(page, 1);
-      });
+    await test.step('confirm only pinned 1 protein', async () => {
+      await expectPinnedGenesCountText(page, 1);
+      await confirmPinnedItemsCount(page, 1);
+      await expectPinnedProteinsCountText(page, 1);
+    });
 
-      await test.step('confirm url dropped invalid protein', () => {
-        const geneProteins = getPinnedItemsFromUrl(page.url());
-        expect(geneProteins).toHaveLength(1);
-        expect(geneProteins).toEqual([validGeneProtein]);
-      });
-    },
-  );
+    await test.step('confirm url dropped invalid protein', () => {
+      const geneProteins = getPinnedItemsFromUrl(page.url());
+      expect(geneProteins).toHaveLength(1);
+      expect(geneProteins).toEqual([validGeneProtein]);
+    });
+  });
 });

--- a/apps/agora/app/e2e/gene-comparison-tool.spec.ts
+++ b/apps/agora/app/e2e/gene-comparison-tool.spec.ts
@@ -22,8 +22,7 @@ test.describe('specific viewport block', () => {
     await expect(page).toHaveTitle('Gene Comparison | Visual comparison tool for AD genes');
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme('protein has sub-category of SRM by default', async ({ page }) => {
+  test('protein has sub-category of SRM by default', async ({ page }) => {
     // set category for Protein - Differential Expression
     await page.goto(URL_GCT_PROTEIN);
 

--- a/apps/agora/app/e2e/gene-details.spec.ts
+++ b/apps/agora/app/e2e/gene-details.spec.ts
@@ -1,5 +1,6 @@
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { baseURL } from '../playwright.config';
+import { GCT_RNA_SUBCATEGORIES } from './helpers/constants';
 import { waitForSpinnerNotVisible } from './helpers/utils';
 
 test.describe('specific viewport block', () => {
@@ -35,4 +36,28 @@ test.describe('legacy url redirects', () => {
     await page.goto('/genes/(genes-router:gene-details/ENSG00000135940)');
     await expect(page).toHaveURL(`${baseURL}/genes/ENSG00000135940`);
   });
+});
+
+test.describe('gene details - query parameter sets initial selected model', () => {
+  const path = '/genes/ENSG00000178209/evidence/rna';
+  function buildUrlWithModelQueryParam(model: string) {
+    return `${path}?model=${model}`;
+  }
+  async function confirmDropdown(page: Page, model: string) {
+    await expect(page.getByRole('combobox', { name: model })).toBeVisible();
+  }
+
+  test('default model is used when there is no query parameter', async ({ page }) => {
+    await page.goto(path);
+    await waitForSpinnerNotVisible(page);
+    await confirmDropdown(page, GCT_RNA_SUBCATEGORIES.AD);
+  });
+
+  for (const model of Object.values(GCT_RNA_SUBCATEGORIES)) {
+    test(`model ${model} is used when query parameter is set`, async ({ page }) => {
+      await page.goto(buildUrlWithModelQueryParam(model));
+      await waitForSpinnerNotVisible(page);
+      await confirmDropdown(page, model);
+    });
+  }
 });

--- a/apps/agora/app/e2e/gene-details.spec.ts
+++ b/apps/agora/app/e2e/gene-details.spec.ts
@@ -3,7 +3,7 @@ import { baseURL } from '../playwright.config';
 import { GCT_RNA_SUBCATEGORIES } from './helpers/constants';
 import { waitForSpinnerNotVisible } from './helpers/utils';
 
-test.describe('specific viewport block', () => {
+test.describe('gene details', () => {
   test.slow();
   test.use({ viewport: { width: 1600, height: 1200 } });
 
@@ -28,6 +28,24 @@ test.describe('specific viewport block', () => {
 
     const header = page.getByRole('heading', { name: 'Consistency of Change in Expression' });
     await expect(header).toBeInViewport();
+  });
+
+  test('can navigate to new gene via search bar', async ({ page }) => {
+    const gene1 = { name: 'PLEC', id: 'ENSG00000178209' };
+    const gene2 = { name: 'PTEN', id: 'ENSG00000171862' };
+
+    await page.goto(`/genes/${gene1.id}`);
+    await waitForSpinnerNotVisible(page);
+
+    await expect(page.getByRole('heading', { name: gene1.name, exact: true })).toBeVisible();
+
+    const searchInput = page.getByRole('textbox', { name: 'Search genes' });
+    await searchInput.pressSequentially(gene2.id); // will navigate automatically via ensembl gene id
+
+    await expect(page).toHaveURL(`${baseURL}/genes/${gene2.id}`);
+    await waitForSpinnerNotVisible(page);
+
+    await expect(page.getByRole('heading', { name: gene2.name, exact: true })).toBeVisible();
   });
 });
 

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -1,16 +1,14 @@
-/* eslint-disable @angular-eslint/no-input-rename */
 import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   Component,
   inject,
-  Input,
   OnDestroy,
   OnInit,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import {
   DistributionService,
   GCTGene,
@@ -86,18 +84,12 @@ import { GeneComparisonToolLegendPanelComponent } from './components/gene-compar
 })
 export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDestroy {
   router = inject(Router);
+  route = inject(ActivatedRoute);
   geneService = inject(GenesService);
   distributionService = inject(DistributionService);
   helperService = inject(HelperService);
   messageService = inject(MessageService);
   filterService = inject(FilterService);
-
-  /* Query Parameters ------------------------------------------------------ */
-  @Input('category') categoryParam = '';
-  @Input('subCategory') subCategoryParam = '';
-  @Input('sortField') sortFieldParam = '';
-  @Input('sortOrder') sortOrderParam = '';
-  @Input('significance') significanceParam = '';
 
   isLoading = true;
 
@@ -106,8 +98,7 @@ export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDes
 
   /* Categories ------------------------------------------------------------ */
   categories: GCTSelectOption[] = cloneDeep(variables.categories);
-  category: 'RNA - Differential Expression' | 'Protein - Differential Expression' =
-    'RNA - Differential Expression';
+  category: 'RNA - Differential Expression' | 'Protein - Differential Expression';
   subCategories: GCTSelectOption[] = [];
   subCategory = '';
   subCategoryLabel = '';
@@ -180,31 +171,27 @@ export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDes
   @ViewChild('scorePanel') scorePanel!: ScorePanelComponent;
   @ViewChild('pinnedGenesModal') pinnedGenesModal!: PinnedGenesModalComponent;
 
+  constructor() {
+    this.category = 'RNA - Differential Expression';
+  }
+
   ngOnInit() {
-    this.category = this.categoryParam ? this.categoryParam : this.categories[0].value;
+    this.urlParamsSubscription = this.route.queryParams.subscribe((params) => {
+      this.urlParams = params || {};
 
-    if (this.subCategoryParam) {
-      this.subCategory = this.subCategoryParam;
-    }
-    this.updateSubCategories();
+      this.category = this.urlParams['category'] || this.categories[0].value;
+      this.subCategory = this.urlParams['subCategory'] || '';
+      this.updateSubCategories();
 
-    if (this.sortFieldParam) {
-      this.sortField = this.sortFieldParam;
-    }
+      this.sortField = this.urlParams['sortField'] || '';
+      this.sortOrder = '1' === this.urlParams['sortOrder'] ? 1 : -1;
 
-    if (this.sortOrderParam) {
-      this.sortOrder = this.sortOrderParam === '1' ? 1 : -1;
-    }
+      this.significanceThreshold =
+        this.urlParams['significance'] || this.DEFAULT_SIGNIFICANCE_THRESHOLD;
+      this.significanceThresholdActive = !!this.urlParams['significance'];
 
-    if (this.significanceParam) {
-      const parsedValue = parseFloat(this.significanceParam);
-      if (!isNaN(parsedValue)) {
-        this.significanceThreshold = parsedValue;
-        this.significanceThresholdActive = true;
-      }
-    }
-
-    this.loadGenes();
+      this.loadGenes();
+    });
 
     this.filterService.register('intersect', helpers.intersectFilterCallback);
     this.filterService.register(

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
@@ -74,7 +74,7 @@
             }
 
             @if (panel.name === 'rna') {
-              <agora-gene-evidence-rna [gene]="gene"></agora-gene-evidence-rna>
+              <agora-gene-evidence-rna [model]="modelParam" [gene]="gene"></agora-gene-evidence-rna>
             }
 
             @if (panel.name === 'protein') {

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.html
@@ -74,7 +74,7 @@
             }
 
             @if (panel.name === 'rna') {
-              <agora-gene-evidence-rna [model]="modelParam" [gene]="gene"></agora-gene-evidence-rna>
+              <agora-gene-evidence-rna [model]="model()" [gene]="gene"></agora-gene-evidence-rna>
             }
 
             @if (panel.name === 'protein') {

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
@@ -59,6 +59,7 @@ export class GeneDetailsComponent implements OnInit, AfterViewInit, AfterViewChe
   @Input('id') idParam = '';
   @Input('tab') tabParam = '';
   @Input('subtab') subtabParam = '';
+  @Input('model') modelParam = '';
 
   faAngleRight = faAngleRight;
   faAngleLeft = faAngleLeft;
@@ -257,9 +258,8 @@ export class GeneDetailsComponent implements OnInit, AfterViewInit, AfterViewChe
     }
 
     // added logic to support dropdown state when page is refreshed
-    const modelUrlParam = this.helperService.getUrlParam('model');
-    if (modelUrlParam) {
-      url = this.helperService.addSingleUrlParam(url, 'model', modelUrlParam);
+    if (this.modelParam) {
+      url = this.helperService.addSingleUrlParam(url, 'model', this.modelParam);
     }
 
     const nav = document.querySelector('.gene-details-nav');

--- a/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.html
+++ b/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.html
@@ -57,6 +57,7 @@
             </agora-modal-link>
           </h2>
           <agora-gene-model-selector
+            [model]="_model"
             [options]="statisticalModels"
             (changeEvent)="onStatisticalModelChange($event)"
           ></agora-gene-model-selector>

--- a/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-evidence-rna/gene-evidence-rna.component.ts
@@ -45,7 +45,17 @@ export class GeneEvidenceRnaComponent implements AfterViewChecked {
   }
   @Input() set gene(gene: Gene | undefined) {
     this._gene = gene;
-    this.init();
+    this.initGene();
+  }
+
+  _model: string | undefined;
+  get model(): string | undefined {
+    return this._model;
+  }
+  @Input()
+  set model(model: string) {
+    this._model = model;
+    this.updateStatisticalModel(model);
   }
 
   statisticalModels: string[] = [];
@@ -83,7 +93,7 @@ export class GeneEvidenceRnaComponent implements AfterViewChecked {
     this.differentialExpressionYAxisMax = undefined;
   }
 
-  init() {
+  initGene() {
     this.reset();
 
     if (!this._gene?.rna_differential_expression) {
@@ -92,12 +102,8 @@ export class GeneEvidenceRnaComponent implements AfterViewChecked {
 
     this.statisticalModels = getStatisticalModels(this._gene);
 
-    const urlModelParam = this.helperService.getUrlParam('model');
-    this.selectedStatisticalModel = urlModelParam || this.statisticalModels[0];
-
     this.initMedianExpression();
-    this.initDifferentialExpression();
-    this.initConsistencyOfChange();
+    this.updateStatisticalModel(this._model || this.statisticalModels[0]);
   }
 
   ngAfterViewChecked() {
@@ -222,6 +228,12 @@ export class GeneEvidenceRnaComponent implements AfterViewChecked {
     });
   }
 
+  updateStatisticalModel(selectedStatisticalModel: string) {
+    this.selectedStatisticalModel = selectedStatisticalModel;
+    this.initDifferentialExpression();
+    this.initConsistencyOfChange();
+  }
+
   onStatisticalModelChange(event: any) {
     if (!event) {
       return;
@@ -229,8 +241,6 @@ export class GeneEvidenceRnaComponent implements AfterViewChecked {
     if (!this._gene?.rna_differential_expression) {
       return;
     }
-    this.selectedStatisticalModel = event.name;
-    this.initDifferentialExpression();
-    this.initConsistencyOfChange();
+    this.updateStatisticalModel(event.name);
   }
 }

--- a/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @angular-eslint/no-input-rename */
-import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { removeParenthesis } from '@sagebionetworks/agora/util';
 import { SelectModule } from 'primeng/select';
@@ -15,15 +15,21 @@ interface Option {
   templateUrl: './gene-model-selector.component.html',
   styleUrls: ['./gene-model-selector.component.scss'],
 })
-export class GeneModelSelectorComponent implements OnInit {
-  @Input('model') modelParam = '';
+export class GeneModelSelectorComponent {
+  _model = '';
+  get model(): string {
+    return this._model;
+  }
+  @Input() set model(model: string | undefined) {
+    this._model = model ?? '';
+    this.initSelected();
+  }
 
   _options: Option[] = [];
   get options(): Option[] {
     return this._options;
   }
   @Input() set options(options: any) {
-    this.selected = {} as Option;
     this._options =
       options?.map((option: any) => {
         const newValue = removeParenthesis(option);
@@ -32,16 +38,18 @@ export class GeneModelSelectorComponent implements OnInit {
           value: newValue,
         } as Option;
       }) || [];
+    this.initSelected();
   }
 
   selected: Option = { name: '', value: '' };
 
   @Output() changeEvent: EventEmitter<object> = new EventEmitter<object>();
 
-  ngOnInit() {
-    let index = this._options.findIndex((o) => o.value === this.modelParam);
+  initSelected() {
+    this.selected = {} as Option;
+    let index = this._options.findIndex((o) => o.value === this._model);
     if (index === -1) {
-      // default to first option if page is loaded without a model parameter
+      // default to first option if model is not defined
       index = 0;
     }
     this.selected = this._options[index];


### PR DESCRIPTION
## Description

We recently updated Agora to use `@Input` to bind route information in components (#3042), but ran into two issues: 
1. Route information is only available in the routed component (GeneDetailsComponent), not non-routed descendants (GeneEvidenceRnaComponent, GeneModelSelectorComponent). Resolved by passing the route information via component `@Inputs` to descendant components.
2. The GCT dynamically checks for >10 query parameters using an object of possible filters. These parameters were not defined with `@Input`, so these query parameters were not populated correctly. The GCT also contains complicated logic related to the URL, which may need to be updated to ensure that depending on the Router state for route information will be sufficient (e.g. if the Location is updated directly, then the Router state will not reflect the change). Resolved by reverting GCT to use `ActivatedRouter` until there is time to tackle a larger refactor of this component.
3. The Gene Details component no longer subscribes to route information, so the component is not updated when the URL changes. Resolved by using [`InputSignals`](https://angular.dev/guide/components/inputs) and wrapping the component initialization in an [`effect`](https://angular.dev/guide/signals#effects), so the component is updated when the URL changes.

## Related Issues

- [AG-1739](https://sagebionetworks.jira.com/browse/AG-1739)
- [AG-1713](https://sagebionetworks.jira.com/browse/AG-1713)
- [AG-1745](https://sagebionetworks.jira.com/browse/AG-1745)

## Changelog

- Passes Route information via component `@Input` from `GeneDetailsComponent` to `GeneModelSelectorComponent`
- Uses `InputSignal` and `effect` to update `GeneDetailsComponent` when URL changes
- Reverts changes to GCT so that `ActivatedRouter` is used
- Adds e2e test for deriving the Gene Details RNA Evidence initially selected model from query parameter
- Adds e2e test for navigating to a new Gene Details page via search on Gene Details page
- Re-enables GCT e2e tests that involve query parameters

## Validation

### GCT 

URL contains the pinned genes: HLA-C, APP

Pins are not loaded from query params on the new dev site: 

https://github.com/user-attachments/assets/048bcbf4-dfc5-4c89-94bd-a2c883b1d935

Pins are loaded from query params in this PR: 

https://github.com/user-attachments/assets/9a266512-9c49-48ed-9c9e-217c93124c48

### Gene Details - RNA

URL contains the selected model: `AD Diagnosis x Sex (females only)`

Selected model is not initialized correctly on the dev site: 

https://github.com/user-attachments/assets/6a0d0f59-c64e-4015-97c1-1e17d7157861

Selected model is initialized correctly in this PR: 

https://github.com/user-attachments/assets/5c62c928-86ec-42fc-8b18-0fc0a46b47e8
 

[AG-1739]: https://sagebionetworks.jira.com/browse/AG-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ