### PR TITLE
fix(agora): revert changes from AG-1713 related to @Input, keep MetaTagService, add e2e tests

### DIFF
--- a/apps/agora/app/e2e/gene-comparison-tool-pinning-cache.spec.ts
+++ b/apps/agora/app/e2e/gene-comparison-tool-pinning-cache.spec.ts
@@ -113,176 +113,170 @@ test.describe('GCT: Caching pinned genes', () => {
     });
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'Pinned proteins are maintained when switching between Protein subcategories',
-    async ({ page }) => {
-      const gene1 = geneWithMultipleProteinsTMT.name;
-      const gene2 = gene2WithMultipleProteinsTMT.name;
-      const genes = [gene1, gene2];
-      const nGenes = genes.length;
+  test('Pinned proteins are maintained when switching between Protein subcategories', async ({
+    page,
+  }) => {
+    const gene1 = geneWithMultipleProteinsTMT.name;
+    const gene2 = gene2WithMultipleProteinsTMT.name;
+    const genes = [gene1, gene2];
+    const nGenes = genes.length;
 
-      const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
-      const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
-      const nProteins = proteins1.length + proteins2.length;
+    const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
+    const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
+    const nProteins = proteins1.length + proteins2.length;
 
+    await page.goto(URL_GCT_PROTEIN_TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+
+    for (const gene of genes) {
+      await pinAllItemsViaSearchByGene(page, gene);
+    }
+
+    await test.step('confirm # genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+      await confirmPinnedItemsCount(page, nProteins);
+    });
+
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.TMT,
+      GCT_PROTEIN_SUBCATEGORIES.SRM,
+    );
+
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.SRM,
+      GCT_PROTEIN_SUBCATEGORIES.LFQ,
+    );
+
+    // back to original subcategory
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.LFQ,
+      GCT_PROTEIN_SUBCATEGORIES.TMT,
+    );
+
+    await test.step('confirm same genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+      await confirmPinnedItemsCount(page, nProteins);
+
+      await confirmPinnedProteins(page, gene1, proteins1);
+      await confirmPinnedProteins(page, gene2, proteins2);
+    });
+  });
+
+  test('Pinned proteins are maintained when switching categories: Protein -> RNA -> Protein', async ({
+    page,
+  }) => {
+    const gene1 = geneWithMultipleProteinsTMT.name;
+    const gene2 = gene2WithMultipleProteinsTMT.name;
+    const genes = [gene1, gene2];
+    const nGenes = genes.length;
+
+    const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
+    const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
+    const nProteins = proteins1.length + proteins2.length;
+
+    await page.goto(URL_GCT_PROTEIN_TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+
+    for (const gene of genes) {
+      await pinAllItemsViaSearchByGene(page, gene);
+    }
+
+    await test.step('confirm # genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+      await confirmPinnedItemsCount(page, nProteins);
+    });
+
+    await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
+
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.RNA,
+      GCT_RNA_SUBCATEGORIES.AD,
+      GCT_RNA_SUBCATEGORIES.AD_AOD,
+    );
+
+    // back to original category
+    await changeGctCategory(page, GCT_CATEGORIES.RNA, GCT_CATEGORIES.PROTEIN);
+
+    // back to original subcategory
+    await changeGctSubcategory(
+      page,
+      GCT_CATEGORIES.PROTEIN,
+      GCT_PROTEIN_SUBCATEGORIES.SRM,
+      GCT_PROTEIN_SUBCATEGORIES.TMT,
+    );
+
+    await test.step('confirm same genes and proteins pinned on Protein page', async () => {
+      await expectPinnedGenesCountText(page, nGenes);
+      await expectPinnedProteinsCountText(page, nProteins);
+
+      await confirmPinnedItemsCount(page, nProteins);
+      await confirmPinnedProteins(page, gene1, proteins1);
+      await confirmPinnedProteins(page, gene2, proteins2);
+    });
+  });
+
+  test('Last pinned genes are maintained even if proteins were pinned initially', async ({
+    page,
+  }) => {
+    const rnaCategoryGene = geneWithMultipleProteinsTMT.name;
+    const rnaCategoryProteins = geneWithMultipleProteinsTMT.uniProtIds;
+    const proteinCategoryGene = gene2WithMultipleProteinsTMT.name;
+
+    await test.step('pin proteins in Protein category', async () => {
       await page.goto(URL_GCT_PROTEIN_TMT);
       await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      for (const gene of genes) {
-        await pinAllItemsViaSearchByGene(page, gene);
-      }
+      await pinAllItemsViaSearchByGene(page, proteinCategoryGene);
+    });
 
-      await test.step('confirm # genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
-        await confirmPinnedItemsCount(page, nProteins);
-      });
-
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.PROTEIN,
-        GCT_PROTEIN_SUBCATEGORIES.TMT,
-        GCT_PROTEIN_SUBCATEGORIES.SRM,
-      );
-
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.PROTEIN,
-        GCT_PROTEIN_SUBCATEGORIES.SRM,
-        GCT_PROTEIN_SUBCATEGORIES.LFQ,
-      );
-
-      // back to original subcategory
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.PROTEIN,
-        GCT_PROTEIN_SUBCATEGORIES.LFQ,
-        GCT_PROTEIN_SUBCATEGORIES.TMT,
-      );
-
-      await test.step('confirm same genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
-        await confirmPinnedItemsCount(page, nProteins);
-
-        await confirmPinnedProteins(page, gene1, proteins1);
-        await confirmPinnedProteins(page, gene2, proteins2);
-      });
-    },
-  );
-
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'Pinned proteins are maintained when switching categories: Protein -> RNA -> Protein',
-    async ({ page }) => {
-      const gene1 = geneWithMultipleProteinsTMT.name;
-      const gene2 = gene2WithMultipleProteinsTMT.name;
-      const genes = [gene1, gene2];
-      const nGenes = genes.length;
-
-      const proteins1 = geneWithMultipleProteinsTMT.uniProtIds;
-      const proteins2 = gene2WithMultipleProteinsTMT.uniProtIds;
-      const nProteins = proteins1.length + proteins2.length;
-
-      await page.goto(URL_GCT_PROTEIN_TMT);
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
-
-      for (const gene of genes) {
-        await pinAllItemsViaSearchByGene(page, gene);
-      }
-
-      await test.step('confirm # genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
-        await confirmPinnedItemsCount(page, nProteins);
-      });
-
+    await test.step('pin genes in RNA category', async () => {
       await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
 
-      await changeGctSubcategory(
-        page,
-        GCT_CATEGORIES.RNA,
-        GCT_RNA_SUBCATEGORIES.AD,
-        GCT_RNA_SUBCATEGORIES.AD_AOD,
-      );
+      await test.step('clear all items', async () => {
+        await page.getByRole('button', { name: 'Clear All' }).click();
+        await expect(page.getByText(/Pinned Genes/i)).toBeHidden();
+      });
 
-      // back to original category
+      await pinGeneViaSearch(page, rnaCategoryGene);
+
+      await test.step('confirm pinned gene', async () => {
+        await expectPinnedGenesCountText(page, 1);
+        await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
+      });
+    });
+
+    await test.step('Protein category pins have changed', async () => {
       await changeGctCategory(page, GCT_CATEGORIES.RNA, GCT_CATEGORIES.PROTEIN);
-
-      // back to original subcategory
       await changeGctSubcategory(
         page,
         GCT_CATEGORIES.PROTEIN,
         GCT_PROTEIN_SUBCATEGORIES.SRM,
         GCT_PROTEIN_SUBCATEGORIES.TMT,
       );
+      await expectPinnedGenesCountText(page, 1);
+      await expectPinnedProteinsCountText(page, rnaCategoryProteins.length);
+      await confirmPinnedProteins(page, rnaCategoryGene, rnaCategoryProteins);
+    });
 
-      await test.step('confirm same genes and proteins pinned on Protein page', async () => {
-        await expectPinnedGenesCountText(page, nGenes);
-        await expectPinnedProteinsCountText(page, nProteins);
+    await test.step('RNA category pins are maintained', async () => {
+      await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
 
-        await confirmPinnedItemsCount(page, nProteins);
-        await confirmPinnedProteins(page, gene1, proteins1);
-        await confirmPinnedProteins(page, gene2, proteins2);
-      });
-    },
-  );
-
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'Last pinned genes are maintained even if proteins were pinned initially',
-    async ({ page }) => {
-      const rnaCategoryGene = geneWithMultipleProteinsTMT.name;
-      const rnaCategoryProteins = geneWithMultipleProteinsTMT.uniProtIds;
-      const proteinCategoryGene = gene2WithMultipleProteinsTMT.name;
-
-      await test.step('pin proteins in Protein category', async () => {
-        await page.goto(URL_GCT_PROTEIN_TMT);
-        await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
-
-        await pinAllItemsViaSearchByGene(page, proteinCategoryGene);
-      });
-
-      await test.step('pin genes in RNA category', async () => {
-        await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
-
-        await test.step('clear all items', async () => {
-          await page.getByRole('button', { name: 'Clear All' }).click();
-          await expect(page.getByText(/Pinned Genes/i)).toBeHidden();
-        });
-
-        await pinGeneViaSearch(page, rnaCategoryGene);
-
-        await test.step('confirm pinned gene', async () => {
-          await expectPinnedGenesCountText(page, 1);
-          await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
-        });
-      });
-
-      await test.step('Protein category pins have changed', async () => {
-        await changeGctCategory(page, GCT_CATEGORIES.RNA, GCT_CATEGORIES.PROTEIN);
-        await changeGctSubcategory(
-          page,
-          GCT_CATEGORIES.PROTEIN,
-          GCT_PROTEIN_SUBCATEGORIES.SRM,
-          GCT_PROTEIN_SUBCATEGORIES.TMT,
-        );
+      await test.step('confirm pinned gene', async () => {
         await expectPinnedGenesCountText(page, 1);
-        await expectPinnedProteinsCountText(page, rnaCategoryProteins.length);
-        await confirmPinnedProteins(page, rnaCategoryGene, rnaCategoryProteins);
+        await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
       });
-
-      await test.step('RNA category pins are maintained', async () => {
-        await changeGctCategory(page, GCT_CATEGORIES.PROTEIN, GCT_CATEGORIES.RNA);
-
-        await test.step('confirm pinned gene', async () => {
-          await expectPinnedGenesCountText(page, 1);
-          await confirmPinnedItemsByGeneName(page, rnaCategoryGene, 1);
-        });
-      });
-    },
-  );
+    });
+  });
 
   test('Last pinned proteins are maintained even if genes were pinned initially', async ({
     page,

--- a/apps/agora/app/e2e/gene-comparison-tool-pinning-url.spec.ts
+++ b/apps/agora/app/e2e/gene-comparison-tool-pinning-url.spec.ts
@@ -34,21 +34,16 @@ test.describe('GCT: Pinning Genes from URL', () => {
     await confirmPinnedItemsCount(page, 0);
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url does not include pinned genes, no genes are pinned',
-    async ({ page }) => {
-      await page.goto(URL_GCT_PROTEIN);
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.SRM);
+  test('when Protein url does not include pinned genes, no genes are pinned', async ({ page }) => {
+    await page.goto(URL_GCT_PROTEIN);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.SRM);
 
-      await expect(page.getByText('Pinned Genes')).toBeHidden();
-      await expect(page.getByText('All Genes')).toBeHidden();
-      await confirmPinnedItemsCount(page, 0);
-    },
-  );
+    await expect(page.getByText('Pinned Genes')).toBeHidden();
+    await expect(page.getByText('All Genes')).toBeHidden();
+    await confirmPinnedItemsCount(page, 0);
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme('when RNA url includes 50 pinned genes, all genes are pinned', async ({ page }) => {
+  test('when RNA url includes 50 pinned genes, all genes are pinned', async ({ page }) => {
     const url = `${URL_GCT}?${formatPinnedGenesQueryParam(fiftyGenes)}`;
     await page.goto(url);
 
@@ -68,57 +63,53 @@ test.describe('GCT: Pinning Genes from URL', () => {
     });
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when RNA url includes >50 pinned genes, only 50 genes are pinned and toast is displayed',
-    async ({ page }) => {
-      const url = `${URL_GCT}?${formatPinnedGenesQueryParam(fiftyOneGenes)}`;
-      await page.goto(url);
+  test('when RNA url includes >50 pinned genes, only 50 genes are pinned and toast is displayed', async ({
+    page,
+  }) => {
+    const url = `${URL_GCT}?${formatPinnedGenesQueryParam(fiftyOneGenes)}`;
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
 
-      await test.step('confirm only pinned 50 genes', async () => {
-        await expect(page.getByText('All Genes')).toBeVisible();
-        await expectPinnedGenesCountText(page, 50);
-        await confirmPinnedItemsCount(page, 50);
-        await expectTooManyPinnedGenesToast(page);
-      });
+    await test.step('confirm only pinned 50 genes', async () => {
+      await expect(page.getByText('All Genes')).toBeVisible();
+      await expectPinnedGenesCountText(page, 50);
+      await confirmPinnedItemsCount(page, 50);
+      await expectTooManyPinnedGenesToast(page);
+    });
 
-      await test.step('confirm url dropped 51st gene', () => {
-        const genes = getPinnedItemsFromUrl(page.url());
-        expect(genes).toHaveLength(50);
-        expect(genes).toEqual(fiftyOneGenes.sort().slice(0, -1));
-      });
-    },
-  );
+    await test.step('confirm url dropped 51st gene', () => {
+      const genes = getPinnedItemsFromUrl(page.url());
+      expect(genes).toHaveLength(50);
+      expect(genes).toEqual(fiftyOneGenes.sort().slice(0, -1));
+    });
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when RNA url includes invalid gene, that gene is dropped from the url',
-    async ({ page }) => {
-      const validGeneId = geneWithMultipleProteinsTMT.ensemblId;
-      const url = `${URL_GCT}?${formatPinnedGenesQueryParam([validGeneId, 'invalidGene'])}`;
-      await page.goto(url);
+  test('when RNA url includes invalid gene, that gene is dropped from the url', async ({
+    page,
+  }) => {
+    const validGeneId = geneWithMultipleProteinsTMT.ensemblId;
+    const url = `${URL_GCT}?${formatPinnedGenesQueryParam([validGeneId, 'invalidGene'])}`;
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.RNA, GCT_RNA_SUBCATEGORIES.AD);
 
-      await test.step('confirm toast not shown', async () => {
-        await expect(page.getByRole('alert')).toBeHidden();
-      });
+    await test.step('confirm toast not shown', async () => {
+      await expect(page.getByRole('alert')).toBeHidden();
+    });
 
-      await test.step('confirm only pinned 1 gene', async () => {
-        await expect(page.getByText('All Genes')).toBeVisible();
-        await expectPinnedGenesCountText(page, 1);
-        await confirmPinnedItemsCount(page, 1);
-      });
+    await test.step('confirm only pinned 1 gene', async () => {
+      await expect(page.getByText('All Genes')).toBeVisible();
+      await expectPinnedGenesCountText(page, 1);
+      await confirmPinnedItemsCount(page, 1);
+    });
 
-      await test.step('confirm url dropped invalid gene', () => {
-        const genes = getPinnedItemsFromUrl(page.url());
-        expect(genes).toHaveLength(1);
-        expect(genes).toEqual([validGeneId]);
-      });
-    },
-  );
+    await test.step('confirm url dropped invalid gene', () => {
+      const genes = getPinnedItemsFromUrl(page.url());
+      expect(genes).toHaveLength(1);
+      expect(genes).toEqual([validGeneId]);
+    });
+  });
 
   test.fail(
     'when RNA url includes proteins, the related gene is pinned',
@@ -172,108 +163,100 @@ test.describe('GCT: Pinning Genes from URL', () => {
     },
   );
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes 50 proteins from 50 unique genes, all proteins are pinned',
-    async ({ page }) => {
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(
-        fiftyProteinsToFiftyUniqueGenesTMT,
-      )}`;
-      await page.goto(url);
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+  test('when Protein url includes 50 proteins from 50 unique genes, all proteins are pinned', async ({
+    page,
+  }) => {
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(
+      fiftyProteinsToFiftyUniqueGenesTMT,
+    )}`;
+    await page.goto(url);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm counts', async () => {
-        await confirmPinnedItemsCount(page, 50);
-        await expectPinnedGenesCountText(page, 50);
-        await expectPinnedProteinsCountText(page, 50);
-      });
-    },
-  );
+    await test.step('confirm counts', async () => {
+      await confirmPinnedItemsCount(page, 50);
+      await expectPinnedGenesCountText(page, 50);
+      await expectPinnedProteinsCountText(page, 50);
+    });
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes >50 proteins from 50 unique genes, all proteins are pinned',
-    async ({ page }) => {
-      const fortyNineProteinsToUniqueGenes = fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1);
-      const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
-        (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
-      );
-      const allProteins = [...fortyNineProteinsToUniqueGenes, ...oneGeneWithManyProteins];
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
+  test('when Protein url includes >50 proteins from 50 unique genes, all proteins are pinned', async ({
+    page,
+  }) => {
+    const fortyNineProteinsToUniqueGenes = fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1);
+    const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
+      (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
+    );
+    const allProteins = [...fortyNineProteinsToUniqueGenes, ...oneGeneWithManyProteins];
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
 
-      await page.goto(url);
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm counts', async () => {
-        await expectPinnedGenesCountText(page, 50);
-        await confirmPinnedItemsCount(page, allProteins.length);
-        await expectPinnedProteinsCountText(page, allProteins.length);
-      });
+    await test.step('confirm counts', async () => {
+      await expectPinnedGenesCountText(page, 50);
+      await confirmPinnedItemsCount(page, allProteins.length);
+      await expectPinnedProteinsCountText(page, allProteins.length);
+    });
 
-      await confirmPinnedItemsByGeneName(
-        page,
-        geneWithMultipleProteinsTMT.name,
-        geneWithMultipleProteinsTMT.uniProtIds.length,
-      );
-    },
-  );
+    await confirmPinnedItemsByGeneName(
+      page,
+      geneWithMultipleProteinsTMT.name,
+      geneWithMultipleProteinsTMT.uniProtIds.length,
+    );
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes proteins from 51 unique genes, only proteins from 50 genes are pinned',
-    async ({ page }) => {
-      const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
-        (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
-      );
-      const allProteins = [...fiftyProteinsToFiftyUniqueGenesTMT, ...oneGeneWithManyProteins];
-      const expectedPinnedProteins = [
-        ...fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1),
-        ...oneGeneWithManyProteins,
-      ];
+  test('when Protein url includes proteins from 51 unique genes, only proteins from 50 genes are pinned', async ({
+    page,
+  }) => {
+    const oneGeneWithManyProteins = geneWithMultipleProteinsTMT.uniProtIds.map(
+      (uniProtId) => `${geneWithMultipleProteinsTMT.ensemblId}${uniProtId}`,
+    );
+    const allProteins = [...fiftyProteinsToFiftyUniqueGenesTMT, ...oneGeneWithManyProteins];
+    const expectedPinnedProteins = [
+      ...fiftyProteinsToFiftyUniqueGenesTMT.slice(0, -1),
+      ...oneGeneWithManyProteins,
+    ];
 
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam(allProteins)}`;
 
-      await page.goto(url);
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm counts', async () => {
-        await expectPinnedGenesCountText(page, 50);
-        await confirmPinnedItemsCount(page, expectedPinnedProteins.length);
-        await expectPinnedProteinsCountText(page, expectedPinnedProteins.length);
-      });
-    },
-  );
+    await test.step('confirm counts', async () => {
+      await expectPinnedGenesCountText(page, 50);
+      await confirmPinnedItemsCount(page, expectedPinnedProteins.length);
+      await expectPinnedProteinsCountText(page, expectedPinnedProteins.length);
+    });
+  });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme(
-    'when Protein url includes invalid protein, that protein is dropped from the url',
-    async ({ page }) => {
-      const validGeneProtein = fiftyProteinsToFiftyUniqueGenesTMT[1];
-      const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam([
-        validGeneProtein,
-        'invalidGeneProtein',
-      ])}`;
-      await page.goto(url);
+  test('when Protein url includes invalid protein, that protein is dropped from the url', async ({
+    page,
+  }) => {
+    const validGeneProtein = fiftyProteinsToFiftyUniqueGenesTMT[1];
+    const url = `${URL_GCT_PROTEIN_TMT}&${formatPinnedGenesQueryParam([
+      validGeneProtein,
+      'invalidGeneProtein',
+    ])}`;
+    await page.goto(url);
 
-      await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
+    await expectGctPageLoaded(page, GCT_CATEGORIES.PROTEIN, GCT_PROTEIN_SUBCATEGORIES.TMT);
 
-      await test.step('confirm toast not shown', async () => {
-        await expect(page.getByRole('alert')).toBeHidden();
-      });
+    await test.step('confirm toast not shown', async () => {
+      await expect(page.getByRole('alert')).toBeHidden();
+    });
 
-      await test.step('confirm only pinned 1 protein', async () => {
-        await expectPinnedGenesCountText(page, 1);
-        await confirmPinnedItemsCount(page, 1);
-        await expectPinnedProteinsCountText(page, 1);
-      });
+    await test.step('confirm only pinned 1 protein', async () => {
+      await expectPinnedGenesCountText(page, 1);
+      await confirmPinnedItemsCount(page, 1);
+      await expectPinnedProteinsCountText(page, 1);
+    });
 
-      await test.step('confirm url dropped invalid protein', () => {
-        const geneProteins = getPinnedItemsFromUrl(page.url());
-        expect(geneProteins).toHaveLength(1);
-        expect(geneProteins).toEqual([validGeneProtein]);
-      });
-    },
-  );
+    await test.step('confirm url dropped invalid protein', () => {
+      const geneProteins = getPinnedItemsFromUrl(page.url());
+      expect(geneProteins).toHaveLength(1);
+      expect(geneProteins).toEqual([validGeneProtein]);
+    });
+  });
 });

--- a/apps/agora/app/e2e/gene-comparison-tool.spec.ts
+++ b/apps/agora/app/e2e/gene-comparison-tool.spec.ts
@@ -22,8 +22,7 @@ test.describe('specific viewport block', () => {
     await expect(page).toHaveTitle('Gene Comparison | Visual comparison tool for AD genes');
   });
 
-  // TODO: re-enable as part of AG-1739
-  test.fixme('protein has sub-category of SRM by default', async ({ page }) => {
+  test('protein has sub-category of SRM by default', async ({ page }) => {
     // set category for Protein - Differential Expression
     await page.goto(URL_GCT_PROTEIN);
 

--- a/apps/agora/app/e2e/gene-details.spec.ts
+++ b/apps/agora/app/e2e/gene-details.spec.ts
@@ -1,8 +1,9 @@
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { baseURL } from '../playwright.config';
+import { GCT_RNA_SUBCATEGORIES } from './helpers/constants';
 import { waitForSpinnerNotVisible } from './helpers/utils';
 
-test.describe('specific viewport block', () => {
+test.describe('gene details', () => {
   test.slow();
   test.use({ viewport: { width: 1600, height: 1200 } });
 
@@ -28,6 +29,24 @@ test.describe('specific viewport block', () => {
     const header = page.getByRole('heading', { name: 'Consistency of Change in Expression' });
     await expect(header).toBeInViewport();
   });
+
+  test('can navigate to new gene via search bar', async ({ page }) => {
+    const gene1 = { name: 'PLEC', id: 'ENSG00000178209' };
+    const gene2 = { name: 'PTEN', id: 'ENSG00000171862' };
+
+    await page.goto(`/genes/${gene1.id}`);
+    await waitForSpinnerNotVisible(page);
+
+    await expect(page.getByRole('heading', { name: gene1.name, exact: true })).toBeVisible();
+
+    const searchInput = page.getByRole('textbox', { name: 'Search genes' });
+    await searchInput.pressSequentially(gene2.id); // will navigate automatically via ensembl gene id
+
+    await expect(page).toHaveURL(`${baseURL}/genes/${gene2.id}`);
+    await waitForSpinnerNotVisible(page);
+
+    await expect(page.getByRole('heading', { name: gene2.name, exact: true })).toBeVisible();
+  });
 });
 
 test.describe('legacy url redirects', () => {
@@ -35,4 +54,28 @@ test.describe('legacy url redirects', () => {
     await page.goto('/genes/(genes-router:gene-details/ENSG00000135940)');
     await expect(page).toHaveURL(`${baseURL}/genes/ENSG00000135940`);
   });
+});
+
+test.describe('gene details - query parameter sets initial selected model', () => {
+  const path = '/genes/ENSG00000178209/evidence/rna';
+  function buildUrlWithModelQueryParam(model: string) {
+    return `${path}?model=${model}`;
+  }
+  async function confirmDropdown(page: Page, model: string) {
+    await expect(page.getByRole('combobox', { name: model })).toBeVisible();
+  }
+
+  test('default model is used when there is no query parameter', async ({ page }) => {
+    await page.goto(path);
+    await waitForSpinnerNotVisible(page);
+    await confirmDropdown(page, GCT_RNA_SUBCATEGORIES.AD);
+  });
+
+  for (const model of Object.values(GCT_RNA_SUBCATEGORIES)) {
+    test(`model ${model} is used when query parameter is set`, async ({ page }) => {
+      await page.goto(buildUrlWithModelQueryParam(model));
+      await waitForSpinnerNotVisible(page);
+      await confirmDropdown(page, model);
+    });
+  }
 });

--- a/apps/agora/app/src/app/app.config.ts
+++ b/apps/agora/app/src/app/app.config.ts
@@ -4,7 +4,6 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import {
   provideRouter,
   UrlSerializer,
-  withComponentInputBinding,
   withEnabledBlockingInitialNavigation,
   withInMemoryScrolling,
 } from '@angular/router';
@@ -69,7 +68,6 @@ export const appConfig: ApplicationConfig = {
     },
     provideRouter(
       routes,
-      withComponentInputBinding(),
       withEnabledBlockingInitialNavigation(),
       withInMemoryScrolling({
         scrollPositionRestoration: 'enabled',

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.ts
@@ -1,16 +1,14 @@
-/* eslint-disable @angular-eslint/no-input-rename */
 import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   Component,
   inject,
-  Input,
   OnDestroy,
   OnInit,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import {
   DistributionService,
   GCTGene,
@@ -86,18 +84,12 @@ import { GeneComparisonToolLegendPanelComponent } from './components/gene-compar
 })
 export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDestroy {
   router = inject(Router);
+  route = inject(ActivatedRoute);
   geneService = inject(GenesService);
   distributionService = inject(DistributionService);
   helperService = inject(HelperService);
   messageService = inject(MessageService);
   filterService = inject(FilterService);
-
-  /* Query Parameters ------------------------------------------------------ */
-  @Input('category') categoryParam = '';
-  @Input('subCategory') subCategoryParam = '';
-  @Input('sortField') sortFieldParam = '';
-  @Input('sortOrder') sortOrderParam = '';
-  @Input('significance') significanceParam = '';
 
   isLoading = true;
 
@@ -106,8 +98,7 @@ export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDes
 
   /* Categories ------------------------------------------------------------ */
   categories: GCTSelectOption[] = cloneDeep(variables.categories);
-  category: 'RNA - Differential Expression' | 'Protein - Differential Expression' =
-    'RNA - Differential Expression';
+  category: 'RNA - Differential Expression' | 'Protein - Differential Expression';
   subCategories: GCTSelectOption[] = [];
   subCategory = '';
   subCategoryLabel = '';
@@ -180,31 +171,27 @@ export class GeneComparisonToolComponent implements OnInit, AfterViewInit, OnDes
   @ViewChild('scorePanel') scorePanel!: ScorePanelComponent;
   @ViewChild('pinnedGenesModal') pinnedGenesModal!: PinnedGenesModalComponent;
 
+  constructor() {
+    this.category = 'RNA - Differential Expression';
+  }
+
   ngOnInit() {
-    this.category = this.categoryParam ? this.categoryParam : this.categories[0].value;
+    this.urlParamsSubscription = this.route.queryParams.subscribe((params) => {
+      this.urlParams = params || {};
 
-    if (this.subCategoryParam) {
-      this.subCategory = this.subCategoryParam;
-    }
-    this.updateSubCategories();
+      this.category = this.urlParams['category'] || this.categories[0].value;
+      this.subCategory = this.urlParams['subCategory'] || '';
+      this.updateSubCategories();
 
-    if (this.sortFieldParam) {
-      this.sortField = this.sortFieldParam;
-    }
+      this.sortField = this.urlParams['sortField'] || '';
+      this.sortOrder = '1' === this.urlParams['sortOrder'] ? 1 : -1;
 
-    if (this.sortOrderParam) {
-      this.sortOrder = this.sortOrderParam === '1' ? 1 : -1;
-    }
+      this.significanceThreshold =
+        this.urlParams['significance'] || this.DEFAULT_SIGNIFICANCE_THRESHOLD;
+      this.significanceThresholdActive = !!this.urlParams['significance'];
 
-    if (this.significanceParam) {
-      const parsedValue = parseFloat(this.significanceParam);
-      if (!isNaN(parsedValue)) {
-        this.significanceThreshold = parsedValue;
-        this.significanceThresholdActive = true;
-      }
-    }
-
-    this.loadGenes();
+      this.loadGenes();
+    });
 
     this.filterService.register('intersect', helpers.intersectFilterCallback);
     this.filterService.register(

--- a/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-details/gene-details.component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @angular-eslint/no-input-rename */
 /* eslint-disable @typescript-eslint/no-this-alias */
 import { CommonModule, Location } from '@angular/common';
 import {
@@ -7,10 +6,9 @@ import {
   Component,
   HostListener,
   inject,
-  Input,
   OnInit,
 } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
@@ -50,15 +48,11 @@ interface Panel {
   styleUrls: ['./gene-details.component.scss'],
 })
 export class GeneDetailsComponent implements OnInit, AfterViewInit, AfterViewChecked {
+  route = inject(ActivatedRoute);
   router = inject(Router);
   location = inject(Location);
   helperService = inject(HelperService);
   geneService = inject(GenesService);
-
-  /* Query Parameters ------------------------------------------------------ */
-  @Input('id') idParam = '';
-  @Input('tab') tabParam = '';
-  @Input('subtab') subtabParam = '';
 
   faAngleRight = faAngleRight;
   faAngleLeft = faAngleLeft;
@@ -158,64 +152,66 @@ export class GeneDetailsComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   ngOnInit() {
-    this.reset();
-    this.helperService.setLoading(true);
+    this.route.paramMap.subscribe((params: ParamMap) => {
+      this.reset();
+      this.helperService.setLoading(true);
 
-    if (this.idParam) {
-      this.geneService.getGene(this.idParam).subscribe((gene) => {
-        if (!gene) {
-          this.helperService.setLoading(false);
-          // https://github.com/angular/angular/issues/45202
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          this.router.navigateByUrl('/404-not-found', { skipLocationChange: true });
-        } else {
-          this.gene = gene;
+      if (params.get('id')) {
+        this.geneService.getGene(params.get('id') as string).subscribe((gene) => {
+          if (!gene) {
+            this.helperService.setLoading(false);
+            // https://github.com/angular/angular/issues/45202
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.router.navigateByUrl('/404-not-found', { skipLocationChange: true });
+          } else {
+            this.gene = gene;
 
-          this.panels.forEach((p: Panel) => {
-            if (p.name == 'nominations' && !this.gene?.total_nominations) {
-              p.disabled = true;
-            } else if (
-              p.name == 'experimental-validation' &&
-              !this.gene?.experimental_validation?.length
-            ) {
-              p.disabled = true;
-            } else {
-              p.disabled = false;
+            this.panels.forEach((p: Panel) => {
+              if (p.name == 'nominations' && !this.gene?.total_nominations) {
+                p.disabled = true;
+              } else if (
+                p.name == 'experimental-validation' &&
+                !this.gene?.experimental_validation?.length
+              ) {
+                p.disabled = true;
+              } else {
+                p.disabled = false;
+              }
+            });
+
+            const nominationsPanel = this.panels.find((p) => p.name == 'nominations');
+            if (nominationsPanel) {
+              nominationsPanel.disabled = !this.gene.total_nominations ? true : false;
             }
-          });
 
-          const nominationsPanel = this.panels.find((p) => p.name == 'nominations');
-          if (nominationsPanel) {
-            nominationsPanel.disabled = !this.gene.total_nominations ? true : false;
+            const experimentalValidationPanel = this.panels.find(
+              (p) => p.name == 'experimental-validation',
+            );
+            if (experimentalValidationPanel) {
+              experimentalValidationPanel.disabled = !this.gene.experimental_validation?.length
+                ? true
+                : false;
+            }
+
+            this.helperService.setLoading(false);
           }
-
-          const experimentalValidationPanel = this.panels.find(
-            (p) => p.name == 'experimental-validation',
-          );
-          if (experimentalValidationPanel) {
-            experimentalValidationPanel.disabled = !this.gene.experimental_validation?.length
-              ? true
-              : false;
-          }
-
-          this.helperService.setLoading(false);
-        }
-      });
-    }
-
-    if (this.subtabParam) {
-      this.activePanel = this.subtabParam;
-      this.activeParent = this.tabParam;
-    } else if (this.tabParam) {
-      const panel = this.panels.find((p: Panel) => p.name === this.tabParam);
-      if (panel?.children) {
-        this.activePanel = panel.children[0].name;
-        this.activeParent = panel.name;
-      } else if (panel) {
-        this.activePanel = panel.name;
-        this.activeParent = '';
+        });
       }
-    }
+
+      if (params.get('subtab')) {
+        this.activePanel = params.get('subtab') as string;
+        this.activeParent = params.get('tab') as string;
+      } else if (params.get('tab')) {
+        const panel = this.panels.find((p: Panel) => p.name === params.get('tab'));
+        if (panel?.children) {
+          this.activePanel = panel.children[0].name;
+          this.activeParent = panel.name;
+        } else if (panel) {
+          this.activePanel = panel.name;
+          this.activeParent = '';
+        }
+      }
+    });
   }
 
   ngAfterViewInit() {

--- a/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-model-selector/gene-model-selector.component.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @angular-eslint/no-input-rename */
 import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { removeParenthesis } from '@sagebionetworks/agora/util';
 import { SelectModule } from 'primeng/select';
 
@@ -16,7 +16,7 @@ interface Option {
   styleUrls: ['./gene-model-selector.component.scss'],
 })
 export class GeneModelSelectorComponent implements OnInit {
-  @Input('model') modelParam = '';
+  route = inject(ActivatedRoute);
 
   _options: Option[] = [];
   get options(): Option[] {
@@ -39,13 +39,16 @@ export class GeneModelSelectorComponent implements OnInit {
   @Output() changeEvent: EventEmitter<object> = new EventEmitter<object>();
 
   ngOnInit() {
-    let index = this._options.findIndex((o) => o.value === this.modelParam);
-    if (index === -1) {
-      // default to first option if page is loaded without a model parameter
-      index = 0;
-    }
-    this.selected = this._options[index];
-    this._onChange();
+    this.route.queryParams.subscribe((params) => {
+      const modelFromURL = params['model'];
+      let index = this._options.findIndex((o) => o.value === modelFromURL);
+      if (index === -1) {
+        // default to first option if page is loaded without a model parameter
+        index = 0;
+      }
+      this.selected = this._options[index];
+      this._onChange();
+    });
   }
 
   _onChange() {

--- a/libs/agora/genes/src/lib/components/gene-similar/gene-similar.component.ts
+++ b/libs/agora/genes/src/lib/components/gene-similar/gene-similar.component.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @angular-eslint/no-input-rename */
-import { Component, inject, Input, OnInit } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { Component, inject, OnInit } from '@angular/core';
+import { ActivatedRoute, ParamMap, Router, RouterLink } from '@angular/router';
 import { Gene, GenesService } from '@sagebionetworks/agora/api-client-angular';
 import { HelperService } from '@sagebionetworks/agora/services';
 import { ModalLinkComponent, SvgIconComponent } from '@sagebionetworks/agora/shared';
@@ -20,12 +19,10 @@ interface TableColumn {
   styleUrls: ['./gene-similar.component.scss'],
 })
 export class GeneSimilarComponent implements OnInit {
+  route = inject(ActivatedRoute);
   router = inject(Router);
   geneService = inject(GenesService);
   helperService = inject(HelperService);
-
-  /* Query Parameters ------------------------------------------------------ */
-  @Input('id') idParam = '';
 
   gene: Gene = {} as Gene;
   genes: Gene[] = [];
@@ -58,20 +55,22 @@ export class GeneSimilarComponent implements OnInit {
   gctLink: { [key: string]: string } | undefined;
 
   ngOnInit() {
-    if (this.idParam) {
-      this.helperService.setLoading(true);
-      this.geneService.getGene(this.idParam).subscribe((gene: Gene | null) => {
-        if (!gene) {
-          this.helperService.setLoading(false);
-          // https://github.com/angular/angular/issues/45202
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          this.router.navigateByUrl('/404-not-found', { skipLocationChange: true });
-        } else {
-          this.gene = gene;
-          this.init();
-        }
-      });
-    }
+    this.route.paramMap.subscribe((params: ParamMap) => {
+      if (params.get('id')) {
+        this.helperService.setLoading(true);
+        this.geneService.getGene(params.get('id') as string).subscribe((gene: Gene | null) => {
+          if (!gene) {
+            this.helperService.setLoading(false);
+            // https://github.com/angular/angular/issues/45202
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this.router.navigateByUrl('/404-not-found', { skipLocationChange: true });
+          } else {
+            this.gene = gene;
+            this.init();
+          }
+        });
+      }
+    });
   }
 
   init() {


### PR DESCRIPTION
## Description

We recently updated Agora to use `@Input` to bind route information to components (#3042), but ran into a number of issues (see #3075). We need to create additional tests to capture the expected functionality related to URL/route handling in the GCT and Gene Details components to prevent unexpected regressions before attempting the refactor recommended in [AG-1713](https://sagebionetworks.jira.com/browse/AG-1713). For now, we will revert to using `ActivatedRoute` in GCT and Gene Details components.

## Related Issues

- [AG-1713](https://sagebionetworks.jira.com/browse/AG-1713)
- [AG-1739](https://sagebionetworks.jira.com/browse/AG-1739)
- [AG-1745](https://sagebionetworks.jira.com/browse/AG-1745)

## Changelog

- Reverts changes from #3042 to GCT and GeneDetails components, but keeps `MetaTagService`
- Adds e2e test for deriving the Gene Details RNA Evidence initially selected model from query parameter
- Adds e2e test for navigating to a new Gene Details page via search on Gene Details page
- Re-enables GCT e2e tests that involve query parameters

[AG-1713]: https://sagebionetworks.jira.com/browse/AG-1713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1713]: https://sagebionetworks.jira.com/browse/AG-1713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1739]: https://sagebionetworks.jira.com/browse/AG-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1745]: https://sagebionetworks.jira.com/browse/AG-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ