### PR TITLE
fix(agora): fix gene-table column header row formatting and height (AG-1743)

### DIFF
--- a/libs/agora/styles/src/lib/components/_table.scss
+++ b/libs/agora/styles/src/lib/components/_table.scss
@@ -24,17 +24,17 @@
     }
   }
 
-  .p-datatable-wrapper {
+  .p-datatable-table-container {
     height: 344px;
   }
 
   p-table.fullscreen-table {
-    .p-datatable-wrapper {
+    .p-datatable-table-container {
       height: calc(100vh - 58px);
     }
   }
 
-  table {
+  .p-datatable-table {
     background-color: #fff;
 
     &,
@@ -92,6 +92,6 @@
   }
 }
 
-.similar-gene-table .p-datatable-wrapper {
+.similar-gene-table .p-datatable-table-container {
   height: 638px;
 }


### PR DESCRIPTION
## Description

Fixes the header row formatting and table height of the gene tables (nominated targets, similar genes).

## Related Issues

- [AG-1743](https://sagebionetworks.jira.com/browse/AG-1743) 

## Validation

path | current dev | new dev | fix
:---:|:---:|:---:|:---:
similar genes |  <img width="1759" alt="currentdev_similar_genes" src="https://github.com/user-attachments/assets/aa52fc94-8838-42ab-a0c0-81211af9bc7a" /> | <img width="1770" alt="newdev_similar_genes" src="https://github.com/user-attachments/assets/78bada2d-7c61-465f-b9d8-c58548320586" /> | <img width="1763" alt="fix_similar_genes" src="https://github.com/user-attachments/assets/f1e28326-a309-4ebc-ae9c-30b8117e0def" />
nominated targets | <img width="1655" alt="currentdev_nominated_targets" src="https://github.com/user-attachments/assets/4e29d1db-0435-4616-a6c0-3c3b941a83eb" /> | <img width="1654" alt="newdev_nominated_targets" src="https://github.com/user-attachments/assets/16b28817-fdf9-4e52-b61e-2b720a7ed417" /> | <img width="1654" alt="fix_nominated_targets" src="https://github.com/user-attachments/assets/f6f99dbb-10f0-424e-978f-b9cd70c95bb1" />

[AG-1743]: https://sagebionetworks.jira.com/browse/AG-1743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ