### PR TITLE
fix(agora): long urls resulting in 503 errors (AG-1754)

### DIFF
--- a/apps/agora/apex/Caddyfile
+++ b/apps/agora/apex/Caddyfile
@@ -1,4 +1,8 @@
 :80 {
+  limits {
+    header 64kb
+  }
+  
   handle_path /api-docs* {
     reverse_proxy {env.API_DOCS_HOST}:{env.API_DOCS_PORT}
   }


### PR DESCRIPTION
### Description
Long urls are causing errors when deployed.  

This PR updates:
- Sets a header limit (64kb) which should address the issue.