### PR TITLE
fix(agora): fix displayed genes count (AG-1749), fix close button size in GCT help dialog (AG-1747), fix teams page placeholder image background (AG-1705)

### DIFF
--- a/apps/agora/app/e2e/helpers/gct-pinning.ts
+++ b/apps/agora/app/e2e/helpers/gct-pinning.ts
@@ -17,6 +17,15 @@ export const formatPinnedGenesQueryParam = (pinnedGenes: string[]) => {
   return convertToQueryParam(pinnedGenes, 'pinned');
 };
 
+export const getGenesTableCount = async (page: Page) => {
+  const paginator = (await page.getByText('1-10').textContent()) ?? '';
+  return Number(paginator.split(' ')[2]);
+};
+
+export const expectDisplayedGenesCountText = async (page: Page, nGenes: number) => {
+  await expect(page.getByTestId('gene-count')).toHaveText(nGenes.toString());
+};
+
 export const expectPinnedGenesCountText = async (page: Page, nGenes: number) => {
   await expect(page.getByText(`Pinned Genes (${nGenes}/50)`)).toBeVisible();
 };

--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-how-to-panel/gene-comparison-tool-how-to-panel.component.html
@@ -46,7 +46,12 @@
         ></p-button>
       }
       @if (activePane === panes.length - 1) {
-        <p-button label="Close" (click)="isActive = !isActive" [rounded]="true"></p-button>
+        <p-button
+          label="Close"
+          (click)="isActive = !isActive"
+          [rounded]="true"
+          size="small"
+        ></p-button>
       }
     </div>
   </ng-template>

--- a/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/gene-comparison-tool.component.html
@@ -52,8 +52,8 @@
           <div class="gct-controls-inner">
             <div class="gct-controls-left">
               <div class="gene-label">DISPLAYED GENES</div>
-              <div *ngIf="genesTable" class="gene-count">
-                {{ (genesTable?._totalRecords || 0) + (pinnedTable?.dataToRender?.length || 0) }}
+              <div *ngIf="genesTable" class="gene-count" data-testid="gene-count">
+                {{ (genesTable?._totalRecords || 0) + uniquePinnedGenesCount }}
               </div>
               <div class="gct-search">
                 <svg

--- a/libs/agora/teams/src/lib/team-member-list/team-member-list.component.scss
+++ b/libs/agora/teams/src/lib/team-member-list/team-member-list.component.scss
@@ -23,7 +23,7 @@
     background-repeat: no-repeat;
     background-color: var(--color-primary);
     background-image: url('/agora-assets/images/team-member.svg');
-    background-size: cover;
+    background-size: 60%;
     background-position: center;
     margin: 0 auto 10px;
     overflow: hidden;


### PR DESCRIPTION
## Description

This PR fixes a functional and two aesthetic bugs.

## Related Issues

- [AG-1749](https://sagebionetworks.jira.com/browse/AG-1749)
- [AG-1747](https://sagebionetworks.jira.com/browse/AG-1747)
- [AG-1705](https://sagebionetworks.jira.com/browse/AG-1705)

## Changelog

- Fixes bug where GCT displayed genes count did not accurately count pinned genes and adds related e2e test
- Fixes close button size in GCT help dialog 
- Fixes teams page placeholder image

## Validation

#### Displayed genes count

Initial displayed genes count matches the genes table count:

<img width="1845" alt="displayed_genes_count" src="https://github.com/user-attachments/assets/d9097b79-b5e5-4023-88e7-9ab4d8e09cd8" />

Pinning a gene does not change the displayed genes count, but does change the genes table count: 

https://github.com/user-attachments/assets/e99ed3e6-5467-40c0-935c-f6715c83009a

#### Close button

<img width="635" alt="gct_close_button" src="https://github.com/user-attachments/assets/18633746-d1b1-4042-a575-4ebfe864ec5c" />

#### Teams page placeholder image

<img width="1129" alt="teams_background_image" src="https://github.com/user-attachments/assets/6aab154b-c640-4926-9785-04e12ed96e40" />

[AG-1749]: https://sagebionetworks.jira.com/browse/AG-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1747]: https://sagebionetworks.jira.com/browse/AG-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1705]: https://sagebionetworks.jira.com/browse/AG-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ