### PR TITLE
fix(agora): removing chiclet updates GCT (AG-1750)

### DIFF
--- a/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.html
+++ b/libs/agora/gene-comparison-tool/src/lib/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.html
@@ -15,7 +15,7 @@
           [item]=""
           [description]="'Significance &leq; ' + significanceThreshold"
           [isVisible]="significanceThresholdActive"
-          (onClear)="removeSignificanceThresholdFilter()"
+          (clearEvent)="removeSignificanceThresholdFilter()"
         ></agora-gene-comparison-tool-filter-list-item>
         <ng-container *ngFor="let filter of filters; index as i">
           <ng-container *ngFor="let option of filter.options; index as j">
@@ -24,7 +24,7 @@
               [title]="filter.short || ''"
               [description]="option.label"
               [isVisible]="option.selected || false"
-              (onClear)="clearSelectedFilters(option)"
+              (clearEvent)="clearSelectedFilters(option)"
             ></agora-gene-comparison-tool-filter-list-item>
           </ng-container>
         </ng-container>


### PR DESCRIPTION
## Description

Fixes a bug where removing a chiclet filter did not update the GCT.

## Related issues

- [AG-1750](https://sagebionetworks.jira.com/browse/AG-1750)

## Validation

https://github.com/user-attachments/assets/c03552b7-65f1-4bb1-bc8b-481ba71b2b31


[AG-1750]: https://sagebionetworks.jira.com/browse/AG-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ