### PR TITLE
chore(sage): provide testEnvironmentOptions via setupZoneTestEnv (SMR-56)

### DIFF
--- a/apps/agora/app/src/test-setup.ts
+++ b/apps/agora/app/src/test-setup.ts
@@ -1,10 +1,5 @@
-// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-globalThis.ngJest = {
-  testEnvironmentOptions: {
-    errorOnUnknownElements: true,
-    errorOnUnknownProperties: true,
-  },
-};
-
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
-setupZoneTestEnv();
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});

--- a/apps/model-ad/app/src/test-setup.ts
+++ b/apps/model-ad/app/src/test-setup.ts
@@ -1,10 +1,5 @@
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
-setupZoneTestEnv();
-
-// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-globalThis.ngJest = {
-  testEnvironmentOptions: {
-    errorOnUnknownElements: true,
-    errorOnUnknownProperties: true,
-  },
-};
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});

--- a/apps/openchallenges/app/src/test-setup.ts
+++ b/apps/openchallenges/app/src/test-setup.ts
@@ -1,9 +1,5 @@
-// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-globalThis.ngJest = {
-  testEnvironmentOptions: {
-    errorOnUnknownElements: true,
-    errorOnUnknownProperties: true,
-  },
-};
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
-setupZoneTestEnv();
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});

--- a/apps/sandbox/angular-app/src/test-setup.ts
+++ b/apps/sandbox/angular-app/src/test-setup.ts
@@ -1,9 +1,5 @@
-// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-globalThis.ngJest = {
-  testEnvironmentOptions: {
-    errorOnUnknownElements: true,
-    errorOnUnknownProperties: true,
-  },
-};
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
-setupZoneTestEnv();
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});

--- a/libs/sandbox/angular-lib/src/test-setup.ts
+++ b/libs/sandbox/angular-lib/src/test-setup.ts
@@ -1,9 +1,5 @@
-// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
-globalThis.ngJest = {
-  testEnvironmentOptions: {
-    errorOnUnknownElements: true,
-    errorOnUnknownProperties: true,
-  },
-};
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
-setupZoneTestEnv();
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});


### PR DESCRIPTION
## Description

Setting `testEnvironmentOptions` via `globalThis.ngJest` has been deprecated, so we should provide `testEnvironmentOptions` via `setupZoneTestEnv` instead. 

## Related issue

- [SMR-56](https://sagebionetworks.jira.com/browse/SMR-56)

## Changelog

- Provide `testEnvironmentOptions` via `setupZoneTestEnv`.

[SMR-56]: https://sagebionetworks.jira.com/browse/SMR-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ