### PR TITLE
feat(amp-als): dockerize the Spring Boot 3 stub for AMP-ALS dataset service (SMR-63)

### DIFF
--- a/apps/amp-als/dataset-service-next/Dockerfile
+++ b/apps/amp-als/dataset-service-next/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/sage-bionetworks/amp-als-dataset-service-next-base:local

--- a/apps/amp-als/dataset-service-next/build.gradle.kts
+++ b/apps/amp-als/dataset-service-next/build.gradle.kts
@@ -44,3 +44,7 @@ tasks.withType<JavaCompile> {
 tasks.withType<Javadoc> {
     options.encoding = "UTF-8"
 }
+
+tasks.named<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>("bootBuildImage") {
+    imageName.set("ghcr.io/sage-bionetworks/${project.name}-base:local")
+}

--- a/docker/amp-als/serve-detach.sh
+++ b/docker/amp-als/serve-detach.sh
@@ -5,6 +5,7 @@ args=(
   --file docker/amp-als/services/apex.yml
   --file docker/amp-als/services/api-docs.yml
   --file docker/amp-als/services/dataset-service.yml
+  --file docker/amp-als/services/dataset-service-next.yml
   --file docker/amp-als/services/elasticsearch.yml
   --file docker/amp-als/services/keycloak.yml
   --file docker/amp-als/services/mariadb.yml

--- a/docker/amp-als/services/dataset-service-next.yml
+++ b/docker/amp-als/services/dataset-service-next.yml
@@ -1,0 +1,20 @@
+services:
+  amp-als-dataset-service-next:
+    image: ghcr.io/sage-bionetworks/amp-als-dataset-service-next:${AMP_ALS_VERSION:-local}
+    container_name: amp-als-dataset-service-next
+    restart: always
+    env_file:
+      - ../../../apps/amp-als/dataset-service-next/.env
+    networks:
+      - amp-als
+    ports:
+      - '8404:8404'
+    # depends_on:
+    #   amp-als-mariadb:
+    #     condition: service_healthy
+    #   amp-als-elasticsearch:
+    #     condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 1G

--- a/docker/amp-als/services/dataset-service-next.yml
+++ b/docker/amp-als/services/dataset-service-next.yml
@@ -17,4 +17,4 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1G
+          memory: 500M

--- a/libs/sage-monorepo/nx-plugin/src/plugins/project-metadata.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/project-metadata.ts
@@ -56,7 +56,9 @@ function inferBuilder(
   localProjectConfiguration: ProjectConfiguration,
 ): Builder | null {
   if (siblingFiles.includes('uv.lock')) return 'uv';
-  if (siblingFiles.includes('build.gradle')) return 'gradle';
+  if (['build.gradle', 'build.gradle.kts'].some((file) => siblingFiles.includes(file))) {
+    return 'gradle';
+  }
 
   const executor = localProjectConfiguration?.targets?.['build']?.executor ?? '';
   const webpackExecutors = [


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-63

## Description

The Docker image is built in two stages:

1. Using Paketo to create a lean and secure image.
2. Using an Nx Docker plugin to manage image tagging more effectively.

A current limitation is that images built with the latest version of Paketo do not include a shell (e.g., sh) or a package manager. This design choice helps minimize the attack surface but prevents us from easily installing tools like `curl` and `jq`, which are typically used for health check commands in Spring Boot 2 applications.

For now, I’ve chosen to align with Paketo’s philosophy and omit a `HEALTHCHECK` instruction from the Docker image. We can revisit this decision if it becomes a problem in the future.

## Changelog

- Dockerize the project `amp-als-dataset-service-next`.
- Update the monorepo Nx plugin to detect Gradle-Kotlin projects.

## Preview

### Build the Docker image

```bash
nx build-image amp-als-dataset-service-next
```

### Start the app with Docker Compose

```bash
nx serve-detach amp-als-dataset-service-next
```

### Compute usage

```console
$ docker stats
CONTAINER ID   NAME                           CPU %     MEM USAGE / LIMIT   MEM %     NET I/O           BLOCK I/O     PIDS
254ac54739fe   amp-als-dataset-service-next   0.13%     163.5MiB / 1GiB     15.97%    24.1kB / 1.86MB   0B / 586kB    30
```