### PR TITLE
feat(amp-als): migrate AMP-ALS dataset service logic from Spring Boot 2 to 3 (SMR-65)

### DIFF
--- a/apps/amp-als/dataset-service-next/.openapi-generator/FILES
+++ b/apps/amp-als/dataset-service-next/.openapi-generator/FILES
@@ -1,4 +1,3 @@
-src/main/java/org/sagebionetworks/amp/als/dataset/service/OpenApiGeneratorApplication.java
 src/main/java/org/sagebionetworks/amp/als/dataset/service/RFC3339DateFormat.java
 src/main/java/org/sagebionetworks/amp/als/dataset/service/api/ApiUtil.java
 src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApi.java
@@ -15,4 +14,3 @@ src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetSortD
 src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetsPageDto.java
 src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/PageMetadataDto.java
 src/main/resources/openapi.yaml
-src/test/java/org/sagebionetworks/amp/als/dataset/service/OpenApiGeneratorApplicationTests.java

--- a/apps/amp-als/dataset-service-next/build.gradle.kts
+++ b/apps/amp-als/dataset-service-next/build.gradle.kts
@@ -20,9 +20,9 @@ repositories {
 
 dependencies {
     // Spring Boot
-    // implementation(libs.spring.boot.starter.actuator)
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.boot.starter.jdbc)
+    implementation(libs.spring.boot.starter.security)
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.spring.boot.starter.web)
     runtimeOnly(libs.spring.boot.devtools)

--- a/apps/amp-als/dataset-service-next/gradle/libs.versions.toml
+++ b/apps/amp-als/dataset-service-next/gradle/libs.versions.toml
@@ -12,10 +12,10 @@ springdoc = "2.8.6"
 
 [libraries]
 # Spring Boot
-# spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "spring-boot" }
 spring-boot-devtools = { module = "org.springframework.boot:spring-boot-devtools", version.ref = "spring-boot" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "spring-boot" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc", version.ref = "spring-boot" }
+spring-boot-starter-security = { group = "org.springframework.boot", name = "spring-boot-starter-security", version.ref = "spring-boot" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation", version.ref = "spring-boot" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "spring-boot" }

--- a/apps/amp-als/dataset-service-next/openapitools.json
+++ b/apps/amp-als/dataset-service-next/openapitools.json
@@ -19,7 +19,8 @@
           "modelPackage": "org.sagebionetworks.amp.als.dataset.service.model.dto",
           "useTags": true,
           "openApiNullable": false,
-          "useSpringBoot3": true
+          "useSpringBoot3": true,
+          "generateBuilders": true
         }
       }
     }

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/api/DatasetApiDelegateImpl.java
@@ -1,0 +1,54 @@
+package org.sagebionetworks.amp.als.dataset.service.api;
+
+import java.util.List;
+import java.util.Optional;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
+import org.sagebionetworks.amp.als.dataset.service.service.DatasetService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.NativeWebRequest;
+
+@Component
+public class DatasetApiDelegateImpl implements DatasetApiDelegate {
+
+  private static final MediaType APPLICATION_JSON = MediaType.valueOf("application/json");
+
+  private final DatasetService datasetService;
+
+  private final NativeWebRequest request;
+
+  public DatasetApiDelegateImpl(DatasetService datasetService, NativeWebRequest request) {
+    this.datasetService = datasetService;
+    this.request = request;
+  }
+
+  @Override
+  public Optional<NativeWebRequest> getRequest() {
+    return Optional.ofNullable(request);
+  }
+
+  @Override
+  public ResponseEntity<DatasetDto> getDataset(Long datasetId) {
+    for (MediaType mediaType : getAcceptedMediaTypes(getRequest())) {
+      if (mediaType.isCompatibleWith(APPLICATION_JSON)) {
+        return ResponseEntity.ok(datasetService.getDataset(datasetId));
+      }
+    }
+    // TODO: Return an error object if this API does not support any of the accepted types
+    return ResponseEntity.ok(datasetService.getDataset(datasetId));
+  }
+
+  @Override
+  public ResponseEntity<DatasetsPageDto> listDatasets(DatasetSearchQueryDto query) {
+    return ResponseEntity.ok(datasetService.listDatasets(query));
+  }
+
+  public List<MediaType> getAcceptedMediaTypes(Optional<NativeWebRequest> requestOpt) {
+    return requestOpt
+      .map(request -> MediaType.parseMediaTypes(request.getHeader("Accept")))
+      .orElseGet(List::of);
+  }
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/configuration/SecurityConfiguration.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/configuration/SecurityConfiguration.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.amp.als.dataset.service.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(jsr250Enabled = true) // Replaces @EnableGlobalMethodSecurity
+public class SecurityConfiguration {
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+      .csrf(csrf -> csrf.disable())
+      .cors(cors -> cors.disable())
+      .authorizeHttpRequests(authz ->
+        authz.requestMatchers("/**").permitAll().anyRequest().authenticated()
+      )
+      .httpBasic(Customizer.withDefaults());
+    return http.build();
+  }
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/BadRequestException.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/BadRequestException.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+public class BadRequestException extends SimpleDatasetGlobalException {
+
+  public BadRequestException(String detail) {
+    super(
+      ErrorConstants.BAD_REQUEST.getType(),
+      ErrorConstants.BAD_REQUEST.getTitle(),
+      ErrorConstants.BAD_REQUEST.getStatus(),
+      detail
+    );
+  }
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/DatasetNotFoundException.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/DatasetNotFoundException.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+public class DatasetNotFoundException extends SimpleDatasetGlobalException {
+
+  public DatasetNotFoundException(String detail) {
+    super(
+      ErrorConstants.ENTITY_NOT_FOUND.getType(),
+      ErrorConstants.ENTITY_NOT_FOUND.getTitle(),
+      ErrorConstants.ENTITY_NOT_FOUND.getStatus(),
+      detail
+    );
+  }
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/ErrorConstants.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/ErrorConstants.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorConstants {
+  ENTITY_NOT_FOUND("DATASET-SERVICE-1000", "Entity not found", HttpStatus.NOT_FOUND),
+  BAD_REQUEST("DATASET-SERVICE-1001", "Bad request", HttpStatus.BAD_REQUEST);
+
+  private String type;
+  private String title;
+  private HttpStatus status;
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/SimpleDatasetGlobalException.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/exception/SimpleDatasetGlobalException.java
@@ -1,0 +1,23 @@
+package org.sagebionetworks.amp.als.dataset.service.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimpleDatasetGlobalException extends RuntimeException {
+
+  private String type;
+  private String title;
+  private HttpStatus status;
+  private String detail;
+
+  public SimpleDatasetGlobalException(String details) {
+    super(details);
+  }
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/BasicErrorDto.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/BasicErrorDto.java
@@ -166,5 +166,81 @@ public class BasicErrorDto {
     }
     return o.toString().replace("\n", "\n    ");
   }
+  
+  public static class Builder {
+
+    private BasicErrorDto instance;
+
+    public Builder() {
+      this(new BasicErrorDto());
+    }
+
+    protected Builder(BasicErrorDto instance) {
+      this.instance = instance;
+    }
+
+    protected Builder copyOf(BasicErrorDto value) { 
+      this.instance.setTitle(value.title);
+      this.instance.setStatus(value.status);
+      this.instance.setDetail(value.detail);
+      this.instance.setType(value.type);
+      return this;
+    }
+
+    public BasicErrorDto.Builder title(String title) {
+      this.instance.title(title);
+      return this;
+    }
+    
+    public BasicErrorDto.Builder status(Integer status) {
+      this.instance.status(status);
+      return this;
+    }
+    
+    public BasicErrorDto.Builder detail(String detail) {
+      this.instance.detail(detail);
+      return this;
+    }
+    
+    public BasicErrorDto.Builder type(String type) {
+      this.instance.type(type);
+      return this;
+    }
+    
+    /**
+    * returns a built BasicErrorDto instance.
+    *
+    * The builder is not reusable (NullPointerException)
+    */
+    public BasicErrorDto build() {
+      try {
+        return this.instance;
+      } finally {
+        // ensure that this.instance is not reused
+        this.instance = null;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return getClass() + "=(" + instance + ")";
+    }
+  }
+
+  /**
+  * Create a builder with no initialized field (except for the default values).
+  */
+  public static BasicErrorDto.Builder builder() {
+    return new BasicErrorDto.Builder();
+  }
+
+  /**
+  * Create a builder with a shallow copy of this instance.
+  */
+  public BasicErrorDto.Builder toBuilder() {
+    BasicErrorDto.Builder builder = new BasicErrorDto.Builder();
+    return builder.copyOf(this);
+  }
+
 }
 

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetDto.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetDto.java
@@ -197,5 +197,87 @@ public class DatasetDto {
     }
     return o.toString().replace("\n", "\n    ");
   }
+  
+  public static class Builder {
+
+    private DatasetDto instance;
+
+    public Builder() {
+      this(new DatasetDto());
+    }
+
+    protected Builder(DatasetDto instance) {
+      this.instance = instance;
+    }
+
+    protected Builder copyOf(DatasetDto value) { 
+      this.instance.setId(value.id);
+      this.instance.setName(value.name);
+      this.instance.setDescription(value.description);
+      this.instance.setCreatedAt(value.createdAt);
+      this.instance.setUpdatedAt(value.updatedAt);
+      return this;
+    }
+
+    public DatasetDto.Builder id(Long id) {
+      this.instance.id(id);
+      return this;
+    }
+    
+    public DatasetDto.Builder name(String name) {
+      this.instance.name(name);
+      return this;
+    }
+    
+    public DatasetDto.Builder description(String description) {
+      this.instance.description(description);
+      return this;
+    }
+    
+    public DatasetDto.Builder createdAt(OffsetDateTime createdAt) {
+      this.instance.createdAt(createdAt);
+      return this;
+    }
+    
+    public DatasetDto.Builder updatedAt(OffsetDateTime updatedAt) {
+      this.instance.updatedAt(updatedAt);
+      return this;
+    }
+    
+    /**
+    * returns a built DatasetDto instance.
+    *
+    * The builder is not reusable (NullPointerException)
+    */
+    public DatasetDto build() {
+      try {
+        return this.instance;
+      } finally {
+        // ensure that this.instance is not reused
+        this.instance = null;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return getClass() + "=(" + instance + ")";
+    }
+  }
+
+  /**
+  * Create a builder with no initialized field (except for the default values).
+  */
+  public static DatasetDto.Builder builder() {
+    return new DatasetDto.Builder();
+  }
+
+  /**
+  * Create a builder with a shallow copy of this instance.
+  */
+  public DatasetDto.Builder toBuilder() {
+    DatasetDto.Builder builder = new DatasetDto.Builder();
+    return builder.copyOf(this);
+  }
+
 }
 

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetSearchQueryDto.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetSearchQueryDto.java
@@ -209,5 +209,93 @@ public class DatasetSearchQueryDto {
     }
     return o.toString().replace("\n", "\n    ");
   }
+  
+  public static class Builder {
+
+    private DatasetSearchQueryDto instance;
+
+    public Builder() {
+      this(new DatasetSearchQueryDto());
+    }
+
+    protected Builder(DatasetSearchQueryDto instance) {
+      this.instance = instance;
+    }
+
+    protected Builder copyOf(DatasetSearchQueryDto value) { 
+      this.instance.setPageNumber(value.pageNumber);
+      this.instance.setPageSize(value.pageSize);
+      this.instance.setSort(value.sort);
+      this.instance.setSortSeed(value.sortSeed);
+      this.instance.setDirection(value.direction);
+      this.instance.setSearchTerms(value.searchTerms);
+      return this;
+    }
+
+    public DatasetSearchQueryDto.Builder pageNumber(Integer pageNumber) {
+      this.instance.pageNumber(pageNumber);
+      return this;
+    }
+    
+    public DatasetSearchQueryDto.Builder pageSize(Integer pageSize) {
+      this.instance.pageSize(pageSize);
+      return this;
+    }
+    
+    public DatasetSearchQueryDto.Builder sort(DatasetSortDto sort) {
+      this.instance.sort(sort);
+      return this;
+    }
+    
+    public DatasetSearchQueryDto.Builder sortSeed(Integer sortSeed) {
+      this.instance.sortSeed(sortSeed);
+      return this;
+    }
+    
+    public DatasetSearchQueryDto.Builder direction(DatasetDirectionDto direction) {
+      this.instance.direction(direction);
+      return this;
+    }
+    
+    public DatasetSearchQueryDto.Builder searchTerms(String searchTerms) {
+      this.instance.searchTerms(searchTerms);
+      return this;
+    }
+    
+    /**
+    * returns a built DatasetSearchQueryDto instance.
+    *
+    * The builder is not reusable (NullPointerException)
+    */
+    public DatasetSearchQueryDto build() {
+      try {
+        return this.instance;
+      } finally {
+        // ensure that this.instance is not reused
+        this.instance = null;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return getClass() + "=(" + instance + ")";
+    }
+  }
+
+  /**
+  * Create a builder with no initialized field (except for the default values).
+  */
+  public static DatasetSearchQueryDto.Builder builder() {
+    return new DatasetSearchQueryDto.Builder();
+  }
+
+  /**
+  * Create a builder with a shallow copy of this instance.
+  */
+  public DatasetSearchQueryDto.Builder toBuilder() {
+    DatasetSearchQueryDto.Builder builder = new DatasetSearchQueryDto.Builder();
+    return builder.copyOf(this);
+  }
+
 }
 

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetsPageDto.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/DatasetsPageDto.java
@@ -256,5 +256,99 @@ public class DatasetsPageDto {
     }
     return o.toString().replace("\n", "\n    ");
   }
+  
+  public static class Builder {
+
+    private DatasetsPageDto instance;
+
+    public Builder() {
+      this(new DatasetsPageDto());
+    }
+
+    protected Builder(DatasetsPageDto instance) {
+      this.instance = instance;
+    }
+
+    protected Builder copyOf(DatasetsPageDto value) { 
+      this.instance.setNumber(value.number);
+      this.instance.setSize(value.size);
+      this.instance.setTotalElements(value.totalElements);
+      this.instance.setTotalPages(value.totalPages);
+      this.instance.setHasNext(value.hasNext);
+      this.instance.setHasPrevious(value.hasPrevious);
+      this.instance.setDatasets(value.datasets);
+      return this;
+    }
+
+    public DatasetsPageDto.Builder number(Integer number) {
+      this.instance.number(number);
+      return this;
+    }
+    
+    public DatasetsPageDto.Builder size(Integer size) {
+      this.instance.size(size);
+      return this;
+    }
+    
+    public DatasetsPageDto.Builder totalElements(Long totalElements) {
+      this.instance.totalElements(totalElements);
+      return this;
+    }
+    
+    public DatasetsPageDto.Builder totalPages(Integer totalPages) {
+      this.instance.totalPages(totalPages);
+      return this;
+    }
+    
+    public DatasetsPageDto.Builder hasNext(Boolean hasNext) {
+      this.instance.hasNext(hasNext);
+      return this;
+    }
+    
+    public DatasetsPageDto.Builder hasPrevious(Boolean hasPrevious) {
+      this.instance.hasPrevious(hasPrevious);
+      return this;
+    }
+    
+    public DatasetsPageDto.Builder datasets(List<DatasetDto> datasets) {
+      this.instance.datasets(datasets);
+      return this;
+    }
+    
+    /**
+    * returns a built DatasetsPageDto instance.
+    *
+    * The builder is not reusable (NullPointerException)
+    */
+    public DatasetsPageDto build() {
+      try {
+        return this.instance;
+      } finally {
+        // ensure that this.instance is not reused
+        this.instance = null;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return getClass() + "=(" + instance + ")";
+    }
+  }
+
+  /**
+  * Create a builder with no initialized field (except for the default values).
+  */
+  public static DatasetsPageDto.Builder builder() {
+    return new DatasetsPageDto.Builder();
+  }
+
+  /**
+  * Create a builder with a shallow copy of this instance.
+  */
+  public DatasetsPageDto.Builder toBuilder() {
+    DatasetsPageDto.Builder builder = new DatasetsPageDto.Builder();
+    return builder.copyOf(this);
+  }
+
 }
 

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/PageMetadataDto.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/dto/PageMetadataDto.java
@@ -218,5 +218,93 @@ public class PageMetadataDto {
     }
     return o.toString().replace("\n", "\n    ");
   }
+  
+  public static class Builder {
+
+    private PageMetadataDto instance;
+
+    public Builder() {
+      this(new PageMetadataDto());
+    }
+
+    protected Builder(PageMetadataDto instance) {
+      this.instance = instance;
+    }
+
+    protected Builder copyOf(PageMetadataDto value) { 
+      this.instance.setNumber(value.number);
+      this.instance.setSize(value.size);
+      this.instance.setTotalElements(value.totalElements);
+      this.instance.setTotalPages(value.totalPages);
+      this.instance.setHasNext(value.hasNext);
+      this.instance.setHasPrevious(value.hasPrevious);
+      return this;
+    }
+
+    public PageMetadataDto.Builder number(Integer number) {
+      this.instance.number(number);
+      return this;
+    }
+    
+    public PageMetadataDto.Builder size(Integer size) {
+      this.instance.size(size);
+      return this;
+    }
+    
+    public PageMetadataDto.Builder totalElements(Long totalElements) {
+      this.instance.totalElements(totalElements);
+      return this;
+    }
+    
+    public PageMetadataDto.Builder totalPages(Integer totalPages) {
+      this.instance.totalPages(totalPages);
+      return this;
+    }
+    
+    public PageMetadataDto.Builder hasNext(Boolean hasNext) {
+      this.instance.hasNext(hasNext);
+      return this;
+    }
+    
+    public PageMetadataDto.Builder hasPrevious(Boolean hasPrevious) {
+      this.instance.hasPrevious(hasPrevious);
+      return this;
+    }
+    
+    /**
+    * returns a built PageMetadataDto instance.
+    *
+    * The builder is not reusable (NullPointerException)
+    */
+    public PageMetadataDto build() {
+      try {
+        return this.instance;
+      } finally {
+        // ensure that this.instance is not reused
+        this.instance = null;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return getClass() + "=(" + instance + ")";
+    }
+  }
+
+  /**
+  * Create a builder with no initialized field (except for the default values).
+  */
+  public static PageMetadataDto.Builder builder() {
+    return new PageMetadataDto.Builder();
+  }
+
+  /**
+  * Create a builder with a shallow copy of this instance.
+  */
+  public PageMetadataDto.Builder toBuilder() {
+    PageMetadataDto.Builder builder = new PageMetadataDto.Builder();
+    return builder.copyOf(this);
+  }
+
 }
 

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/mapper/DatasetMapper.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/mapper/DatasetMapper.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.amp.als.dataset.service.model.mapper;
+
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.sagebionetworks.util.model.mapper.BaseMapper;
+import org.springframework.beans.BeanUtils;
+
+public class DatasetMapper extends BaseMapper<DatasetEntity, DatasetDto> {
+
+  @Override
+  public DatasetEntity convertToEntity(DatasetDto dto, Object... args) {
+    DatasetEntity entity = new DatasetEntity();
+    if (dto != null) {
+      BeanUtils.copyProperties(dto, entity);
+    }
+    return entity;
+  }
+
+  @Override
+  public DatasetDto convertToDto(DatasetEntity entity, Object... args) {
+    DatasetDto dto = new DatasetDto();
+    if (entity != null) {
+      BeanUtils.copyProperties(entity, dto);
+    }
+    return dto;
+  }
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepository.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepository.java
@@ -1,0 +1,10 @@
+package org.sagebionetworks.amp.als.dataset.service.model.repository;
+
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomDatasetRepository {
+  Page<DatasetEntity> findAll(Pageable pageable, DatasetSearchQueryDto query, String... fields);
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepositoryImpl.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/CustomDatasetRepositoryImpl.java
@@ -1,0 +1,186 @@
+package org.sagebionetworks.amp.als.dataset.service.model.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
+import org.hibernate.search.engine.search.common.BooleanOperator;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.search.sort.SearchSort;
+import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
+import org.hibernate.search.engine.search.sort.dsl.SortOrder;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.sagebionetworks.amp.als.dataset.service.exception.BadRequestException;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDirectionDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CustomDatasetRepositoryImpl implements CustomDatasetRepository {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Override
+  public Page<DatasetEntity> findAll(
+    Pageable pageable,
+    DatasetSearchQueryDto query,
+    String... fields
+  ) {
+    SearchResult<DatasetEntity> result = getSearchResult(pageable, query, fields);
+    return new PageImpl<>(result.hits(), pageable, result.total().hitCount());
+  }
+
+  private SearchResult<DatasetEntity> getSearchResult(
+    Pageable pageable,
+    DatasetSearchQueryDto query,
+    String[] fields
+  ) {
+    SearchSession searchSession = Search.session(entityManager);
+    SearchPredicateFactory pf = searchSession.scope(DatasetEntity.class).predicate();
+    SearchSortFactory sf = searchSession.scope(DatasetEntity.class).sort();
+    List<SearchPredicate> predicates = new ArrayList<>();
+
+    if (query.getSearchTerms() != null && !query.getSearchTerms().isBlank()) {
+      predicates.add(getSearchTermsPredicate(pf, query, fields));
+    }
+
+    SearchSort sort = getSearchSort(sf, query);
+    SearchPredicate sortPredicate = getSearchSortPredicate(pf, query);
+    if (sortPredicate != null) {
+      predicates.add(sortPredicate);
+    }
+
+    SearchPredicate topLevelPredicate = buildTopLevelPredicate(pf, predicates);
+
+    SearchResult<DatasetEntity> result = searchSession
+      .search(DatasetEntity.class)
+      .where(topLevelPredicate)
+      .sort(sort)
+      .fetch((int) pageable.getOffset(), pageable.getPageSize());
+    return result;
+  }
+
+  /**
+   * Searches the datasets using the search terms specified.
+   *
+   * @param pf
+   * @param query
+   * @param fields
+   * @return
+   */
+  private SearchPredicate getSearchTermsPredicate(
+    SearchPredicateFactory pf,
+    DatasetSearchQueryDto query,
+    String[] fields
+  ) {
+    return pf
+      .simpleQueryString()
+      .fields(fields)
+      .matching(query.getSearchTerms())
+      .defaultOperator(BooleanOperator.AND)
+      .toPredicate();
+  }
+
+  /**
+   * Combines the dataset search predicates.
+   *
+   * @param pf
+   * @param predicates
+   * @return
+   */
+  private SearchPredicate buildTopLevelPredicate(
+    SearchPredicateFactory pf,
+    List<SearchPredicate> predicates
+  ) {
+    return pf
+      .bool(b -> {
+        b.must(f -> f.matchAll());
+        for (SearchPredicate predicate : predicates) {
+          b.must(predicate);
+        }
+      })
+      .toPredicate();
+  }
+
+  /**
+   * Sorts the datasets according to the sort and direction values specified.
+   *
+   * @param sf
+   * @param query
+   * @return
+   */
+  private SearchSort getSearchSort(SearchSortFactory sf, DatasetSearchQueryDto query) {
+    // SortOrder orderWithDefaultAsc = query.getDirection() == DatasetDirectionDto.DESC
+    //   ? SortOrder.DESC
+    //   : SortOrder.ASC;
+    SortOrder orderWithDefaultDesc = query.getDirection() == DatasetDirectionDto.ASC
+      ? SortOrder.ASC
+      : SortOrder.DESC;
+
+    SearchSort createdSort = sf.field("created_at").order(orderWithDefaultDesc).toSort();
+    SearchSort scoreSort = sf.score().order(orderWithDefaultDesc).toSort();
+    SearchSort relevanceSort = (query.getSearchTerms() == null || query.getSearchTerms().isBlank())
+      ? createdSort
+      : scoreSort;
+
+    switch (query.getSort()) {
+      case CREATED -> {
+        return createdSort;
+      }
+      case RANDOM -> {
+        return scoreSort;
+      }
+      case RELEVANCE -> {
+        return relevanceSort;
+      }
+      default -> {
+        throw new BadRequestException(
+          String.format("Unhandled sorting strategy '%s'", query.getSort())
+        );
+      }
+    }
+  }
+
+  private SearchPredicate getSearchSortPredicate(
+    SearchPredicateFactory pf,
+    DatasetSearchQueryDto query
+  ) {
+    switch (query.getSort()) {
+      case RANDOM -> {
+        Integer seed = query.getSortSeed();
+        if (seed == null) {
+          SecureRandom rand = new SecureRandom();
+          seed = rand.nextInt(Integer.MAX_VALUE);
+        }
+        return pf
+          .extension(ElasticsearchExtension.get())
+          .fromJson(
+            "{" +
+            "  \"function_score\": {" +
+            "    \"random_score\": {" +
+            "      \"seed\": " +
+            seed +
+            "," +
+            "      \"field\": \"_seq_no\"" +
+            "    }" +
+            "  }" +
+            "}"
+          )
+          .toPredicate();
+      }
+      default -> {
+        return null;
+      }
+    }
+  }
+}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/DatasetRepository.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/model/repository/DatasetRepository.java
@@ -1,0 +1,7 @@
+package org.sagebionetworks.amp.als.dataset.service.model.repository;
+
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DatasetRepository
+  extends JpaRepository<DatasetEntity, Long>, CustomDatasetRepository {}

--- a/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
+++ b/apps/amp-als/dataset-service-next/src/main/java/org/sagebionetworks/amp/als/dataset/service/service/DatasetService.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.amp.als.dataset.service.service;
+
+import java.util.Arrays;
+import java.util.List;
+import org.sagebionetworks.amp.als.dataset.service.exception.DatasetNotFoundException;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetSearchQueryDto;
+import org.sagebionetworks.amp.als.dataset.service.model.dto.DatasetsPageDto;
+import org.sagebionetworks.amp.als.dataset.service.model.entity.DatasetEntity;
+import org.sagebionetworks.amp.als.dataset.service.model.mapper.DatasetMapper;
+import org.sagebionetworks.amp.als.dataset.service.model.repository.DatasetRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DatasetService {
+
+  private final DatasetRepository datasetRepository;
+
+  public DatasetService(DatasetRepository datasetRepository) {
+    this.datasetRepository = datasetRepository;
+  }
+
+  private DatasetMapper datasetMapper = new DatasetMapper();
+
+  private static final List<String> SEARCHABLE_FIELDS = Arrays.asList("name", "description");
+
+  @Transactional(readOnly = true)
+  public DatasetsPageDto listDatasets(DatasetSearchQueryDto query) {
+    Pageable pageable = PageRequest.of(query.getPageNumber(), query.getPageSize());
+
+    List<String> fieldsToSearchBy = SEARCHABLE_FIELDS;
+    Page<DatasetEntity> datasetEntitiesPage = datasetRepository.findAll(
+      pageable,
+      query,
+      fieldsToSearchBy.toArray(new String[0])
+    );
+
+    List<DatasetDto> datasets = datasetMapper.convertToDtoList(datasetEntitiesPage.getContent());
+
+    return DatasetsPageDto.builder()
+      .datasets(datasets)
+      .number(datasetEntitiesPage.getNumber())
+      .size(datasetEntitiesPage.getSize())
+      .totalElements(datasetEntitiesPage.getTotalElements())
+      .totalPages(datasetEntitiesPage.getTotalPages())
+      .hasNext(datasetEntitiesPage.hasNext())
+      .hasPrevious(datasetEntitiesPage.hasPrevious())
+      .build();
+  }
+
+  @Transactional(readOnly = true)
+  public DatasetDto getDataset(Long datasetId) {
+    DatasetEntity datasetEntity = getDatasetEntity(datasetId);
+    return datasetMapper.convertToDto(datasetEntity);
+  }
+
+  private DatasetEntity getDatasetEntity(Long datasetId) throws DatasetNotFoundException {
+    return datasetRepository
+      .findById(datasetId)
+      .orElseThrow(() ->
+        new DatasetNotFoundException(
+          String.format("The dataset with ID %d does not exist.", datasetId)
+        )
+      );
+  }
+}


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-65

## Changelog

- Copy the logic of `amp-als-dataset-service` (Spring Boot 2) to `amp-als-dataset-service-next`.
- Adapt Security Configuration for Spring Boot 3.

> [!TIP]
> Builders were previously added to DTOs using custom template and Lombok. It is now possible to generate builders by settings the OpenAPI generator option `generateBuilders` to `true`.

## Preview

### List datasets

```bash
curl -X 'GET' \
  'http://localhost:8404/v1/datasets?pageNumber=0&pageSize=10&sort=created&sortSeed=2147483647&direction=asc&searchTerms=clinical' \
  -H 'accept: application/json' | jq
```

Output:

```json
{
  "number": 0,
  "size": 10,
  "totalElements": 2,
  "totalPages": 1,
  "hasNext": false,
  "hasPrevious": false,
  "datasets": [
    {
      "id": 3,
      "name": "Mock Dataset 3",
      "description": "Registry of patients enrolled in various oncology clinical trials",
      "createdAt": "2025-04-19T01:00:27Z",
      "updatedAt": "2025-04-19T01:00:27Z"
    },
    {
      "id": 1,
      "name": "Mock Dataset 1",
      "description": "Clinical data from patients with cardiovascular conditions",
      "createdAt": "2025-04-19T01:00:27Z",
      "updatedAt": "2025-04-19T01:00:27Z"
    }
  ]
}
```

### Get dataset by ID

```bash
curl -s -X 'GET' \
  'http://localhost:8404/v1/datasets/3' \
  -H 'accept: application/json' | jq
```

Output:

```json
{
  "id": 3,
  "name": "Mock Dataset 3",
  "description": "Registry of patients enrolled in various oncology clinical trials",
  "createdAt": "2025-04-19T01:00:27Z",
  "updatedAt": "2025-04-19T01:00:27Z"
}
```