### PR TITLE
fix(agora): fix duplicate experimental validation filter values (AG-1758)

### DIFF
--- a/apps/agora/api/src/components/comparison.ts
+++ b/apps/agora/api/src/components/comparison.ts
@@ -102,8 +102,12 @@ function getComparisonGeneNominations(gene: Gene, teams: Team[]) {
     }
 
     // Validations
-    if (n.validation_study_details && !data.validations.includes(n.validation_study_details)) {
-      data.validations.push(n.validation_study_details.trim());
+    const validation_study_detail_clean = n.validation_study_details?.trim().toLowerCase();
+    if (
+      validation_study_detail_clean &&
+      !data.validations.includes(validation_study_detail_clean)
+    ) {
+      data.validations.push(validation_study_detail_clean);
     }
   });
 

--- a/apps/agora/api/src/components/comparison.ts
+++ b/apps/agora/api/src/components/comparison.ts
@@ -102,12 +102,11 @@ function getComparisonGeneNominations(gene: Gene, teams: Team[]) {
     }
 
     // Validations
-    const validation_study_detail_clean = n.validation_study_details?.trim().toLowerCase();
-    if (
-      validation_study_detail_clean &&
-      !data.validations.includes(validation_study_detail_clean)
-    ) {
-      data.validations.push(validation_study_detail_clean);
+    if (n.validation_study_details) {
+      const validation_study_detail_clean = n.validation_study_details.trim().toLowerCase();
+      if (!data.validations.includes(validation_study_detail_clean)) {
+        data.validations.push(validation_study_detail_clean);
+      }
     }
   });
 

--- a/libs/agora/api-client-angular/src/lib/model/targetNomination.ts
+++ b/libs/agora/api-client-angular/src/lib/model/targetNomination.ts
@@ -24,6 +24,6 @@ export interface TargetNomination {
   data_synapseid: string;
   study: string | null;
   input_data: string;
-  validation_study_details: string;
+  validation_study_details: string | null;
   initial_nomination: number;
 }

--- a/libs/agora/api-description/build/openapi.yaml
+++ b/libs/agora/api-description/build/openapi.yaml
@@ -367,6 +367,7 @@ components:
           type: string
         validation_study_details:
           type: string
+          nullable: true
         initial_nomination:
           type: number
       required:

--- a/libs/agora/api-description/src/components/schemas/TargetNomination.yaml
+++ b/libs/agora/api-description/src/components/schemas/TargetNomination.yaml
@@ -24,6 +24,7 @@ properties:
     type: string
   validation_study_details:
     type: string
+    nullable: true
   initial_nomination:
     type: number
 required:


### PR DESCRIPTION
## Description

We would like to remove the duplicate values displayed for the Experimental Validation filter in the GCT.

## Related issues

- [AG-1758](https://sagebionetworks.jira.com/browse/AG-1758)

## Changelog

- Update API to specify that `validation_study_details` is a nullable field
- Clean `validation_study_details` values before adding to set of available filters

## Validation

Confirmed that `validation_study_details` is a nullable field with this query:  

```
# data-version: 72
agora> db.geneinfo.countDocuments({  $or: [    { "target_nominations.validation_study_details": null },    { "target_nominations.validation_study_details": { $exists: false } }  ]})
35036
```

Experimental Validation filters have been updated: 

current dev | fix
:---:|:---:
<img width="1566" alt="experimental_validation_dev" src="https://github.com/user-attachments/assets/7c918de6-dd5c-42af-86c3-0c07cc92e1f2" /> | <img width="1571" alt="experimental_validation_fix" src="https://github.com/user-attachments/assets/08538772-6947-4e3f-8a2f-122f636b97f4" />

And applying the single filter vs combination of filters that differ only in whitespace or capitalization results in the same number of results returned: 

https://github.com/user-attachments/assets/7e42a7ae-6297-4676-96dd-cbe88ff5e715

https://github.com/user-attachments/assets/d9fe1600-caeb-487f-a2da-6c259aa541cd

[AG-1758]: https://sagebionetworks.jira.com/browse/AG-1758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ