### PR TITLE
feat(model-ad): use @testing-library/angular for model-ad unit tests (MG-81)

### DIFF
--- a/libs/model-ad/home/src/lib/home.component.spec.ts
+++ b/libs/model-ad/home/src/lib/home.component.spec.ts
@@ -1,21 +1,14 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
 import { HomeComponent } from './home.component';
 
+async function setup() {
+  await render(HomeComponent);
+}
+
 describe('HomeComponent', () => {
-  let component: HomeComponent;
-  let fixture: ComponentFixture<HomeComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [],
-      providers: [],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(HomeComponent);
-    component = fixture.componentInstance;
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should display home button', async () => {
+    await setup();
+    const button = screen.getByRole('button', { name: /model-ad/i });
+    expect(button).toBeInTheDocument();
   });
 });

--- a/libs/model-ad/home/src/test-setup.ts
+++ b/libs/model-ad/home/src/test-setup.ts
@@ -1,2 +1,3 @@
+import '@testing-library/jest-dom';
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 setupZoneTestEnv();

--- a/libs/model-ad/not-found/src/lib/not-found.component.spec.ts
+++ b/libs/model-ad/not-found/src/lib/not-found.component.spec.ts
@@ -1,30 +1,19 @@
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-// import { ConfigService } from '@sagebionetworks/openchallenges/config';
-
+import { render, screen } from '@testing-library/angular';
 import { NotFoundComponent } from './not-found.component';
 
+async function setup() {
+  await render(NotFoundComponent, {
+    providers: [provideHttpClient()],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  });
+}
+
 describe('NotFoundComponent', () => {
-  let component: NotFoundComponent;
-  let fixture: ComponentFixture<NotFoundComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HttpClientModule, RouterTestingModule, NotFoundComponent],
-      providers: [],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(NotFoundComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should display heading', async () => {
+    await setup();
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('Page Not Found');
   });
 });

--- a/libs/model-ad/not-found/src/test-setup.ts
+++ b/libs/model-ad/not-found/src/test-setup.ts
@@ -1,2 +1,3 @@
+import '@testing-library/jest-dom';
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 setupZoneTestEnv();

--- a/libs/model-ad/ui/src/lib/footer/footer.component.spec.ts
+++ b/libs/model-ad/ui/src/lib/footer/footer.component.spec.ts
@@ -1,25 +1,13 @@
-import { HttpClientModule } from '@angular/common/http';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { render, screen } from '@testing-library/angular';
 import { FooterComponent } from './footer.component';
 
+async function setup() {
+  await render(FooterComponent);
+}
+
 describe('FooterComponent', () => {
-  let component: FooterComponent;
-  let fixture: ComponentFixture<FooterComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HttpClientModule, RouterTestingModule],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(FooterComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should include logo', async () => {
+    await setup();
+    expect(screen.getByAltText(/Model-AD logo/i)).toBeInTheDocument();
   });
 });

--- a/libs/model-ad/ui/src/lib/header/header.component.spec.ts
+++ b/libs/model-ad/ui/src/lib/header/header.component.spec.ts
@@ -1,23 +1,13 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
 import { HeaderComponent } from './header.component';
 
+async function setup() {
+  await render(HeaderComponent);
+}
+
 describe('HeaderComponent', () => {
-  let component: HeaderComponent;
-  let fixture: ComponentFixture<HeaderComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [],
-    }).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(HeaderComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should render text', async () => {
+    await setup();
+    expect(screen.getByText(/Model-AD header/i)).toBeInTheDocument();
   });
 });

--- a/libs/model-ad/ui/src/test-setup.ts
+++ b/libs/model-ad/ui/src/test-setup.ts
@@ -1,2 +1,3 @@
+import '@testing-library/jest-dom';
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 setupZoneTestEnv();


### PR DESCRIPTION
## Description

Use [`@testing-library/angular`](https://testing-library.com/docs/angular-testing-library/intro/) for `model-ad` tests.

## Related Issues

- [MG-81](https://sagebionetworks.jira.com/browse/MG-81)

## Changelog

- Converts `model-ad` tests to use `@testing-library/angular`

## Validation

Run all `model-ad` tests: 

```
$ nx run-many --target=test --projects=model-ad-* --skip-nx-cache

 NX   The following projects do not have a configuration for any of the provided targets ("test")

- model-ad-api-description
- model-ad-api-docs
- model-ad-styles
- model-ad-themes
- model-ad-mongo
- model-ad-apex


   ✔  nx run shared-java-util:build (4s)
   ✔  nx run model-ad-config:test (4s)
   ✔  nx run shared-java-util:install (3s)
   ✔  nx run model-ad-util:test (4s)
   ✔  nx run model-ad-api-client-angular:test (5s)
   ✔  nx run model-ad-ui:test (16s)
   ✔  nx run model-ad-api:test (5s)
   ✔  nx run model-ad-not-found:test (13s)
   ✔  nx run model-ad-app:test (3s)
   ✔  nx run model-ad-home:test (12s)

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target test for 8 projects and 2 tasks they depend on (25s)
```

[MG-81]: https://sagebionetworks.jira.com/browse/MG-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ