### PR TITLE
chore(sage-monorepo): fix Java auto-import loop (SMR-78)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   "java.compile.nullAnalysis.mode": "disabled",
   "java.configuration.updateBuildConfiguration": "automatic",
   "java.autobuild.enabled": false,
-  "java.import.gradle.enabled": false,
+  "java.import.gradle.enabled": true,
   "java.import.maven.enabled": false,
   "css.validate": false,
   "less.validate": false,

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -30,6 +30,8 @@ function workspace-install-python-dependencies {
 function workspace-install {
   workspace-install-nodejs-dependencies
   workspace-install-python-dependencies
+  workspace-install-java-lib-projects
+
   nx run-many --target=create-config
   # Projects that can be prepared in parallel
   nx run-many --target=prepare --projects=!tag:language:java
@@ -40,11 +42,20 @@ function workspace-install {
 function workspace-install-affected {
   workspace-install-nodejs-dependencies
   workspace-install-python-dependencies
+  workspace-install-java-lib-projects
+
   nx affected --target=create-config
   # Projects that can be prepared in parallel
   nx affected --target=prepare --exclude='tag:language:java'
   # Java projects must be installed one at a time
   nx affected --target=prepare --exclude='!tag:language:java' --parallel=1
+}
+
+# TODO: This is needed when developing inside VS Code. The CI workflows don't need it.
+function workspace-install-java-lib-projects {
+  # Install Java libraries only so that the Java Language Server can find them when auto importing
+  # the projects that depend on them.
+  nx run-many --target=install --exclude='!tag:language:java'
 }
 
 # Setup Python virtualenvs

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -30,28 +30,31 @@ function workspace-install-python-dependencies {
 function workspace-install {
   workspace-install-nodejs-dependencies
   workspace-install-python-dependencies
-  workspace-install-java-lib-projects
 
   nx run-many --target=create-config
   # Projects that can be prepared in parallel
   nx run-many --target=prepare --projects=!tag:language:java
   # Java projects must be installed one at a time
   nx run-many --target=prepare --projects=tag:language:java --parallel=1
+
+  # See https://sagebionetworks.jira.com/browse/SMR-78
+  workspace-install-java-lib-projects
 }
 
 function workspace-install-affected {
   workspace-install-nodejs-dependencies
   workspace-install-python-dependencies
-  workspace-install-java-lib-projects
 
   nx affected --target=create-config
   # Projects that can be prepared in parallel
   nx affected --target=prepare --exclude='tag:language:java'
   # Java projects must be installed one at a time
   nx affected --target=prepare --exclude='!tag:language:java' --parallel=1
+
+  # See https://sagebionetworks.jira.com/browse/SMR-78
+  workspace-install-java-lib-projects
 }
 
-# TODO: This is needed when developing inside VS Code. The CI workflows don't need it.
 function workspace-install-java-lib-projects {
   # Install Java libraries only so that the Java Language Server can find them when auto importing
   # the projects that depend on them.


### PR DESCRIPTION
Closes https://sagebionetworks.jira.com/browse/SMR-78

## Description

This PR enables Java developers to benefit from the intellisense features provided for the Java projects by fixing a bug that was preventing the successful auto-import of these Java project by the Java language server.

The issue was that in a clean environment, the auto import would try to download the dependencies, including dependencies that are expected to be found in the local Maven cache. However, in a clean environment, the local Maven cache is empty.

The solution implemented by this PR is to update the `workspace-install` command to build and install all the Java library projects to the local Maven cache. The auto import can then be triggered by opening a Java file.

## Development workflow

From now on (once this PR is merged and the local `main` branch is up to date):

1. Closes and reopen VS Code.
2. Run `workspace-install`, which will now build and install the Java library projects to the local Maven cache.
3. Open a Java file to trigger the launch of the Java language server.
4. The Java projects should be imported (see Preview below).

## Preview

The Java language server is ready. It was previously showing an infinite loop while synchronizing the Java projects.

![image](https://github.com/user-attachments/assets/776e34c3-0dc7-4640-bd60-5e170dbc9559)

The "Java Projects" section in VS Code shows the list of Java project imported. If a project is not in that list, the intellisense features provided by the Java language server like tooltip for imported classes and auto fixes won't be available for that project.

![image](https://github.com/user-attachments/assets/a0af12f4-91c4-4a72-ba85-250b5dc3b099)
