### PR TITLE
chore(sage): update explorers codeowners and add explorers to pr scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,3 +31,5 @@
 /docker/model-ad/ @Sage-Bionetworks/sage-monorepo-agora
 /libs/model-ad/ @Sage-Bionetworks/sage-monorepo-agora
 /libs/results-visualization-framework/ @Sage-Bionetworks/sage-monorepo-agora
+
+/libs/explorers/ @Sage-Bionetworks/sage-monorepo-agora

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -28,6 +28,7 @@ jobs:
             amp-als
             bridge2ai
             common
+            explorers
             iatlas
             model-ad
             openchallenges


### PR DESCRIPTION
We recently added the `explorers` project to house components shared between `agora` and `model-ad`. This PR sets the `@Sage-Bionetworks/sage-monorepo-agora` team as the CODEOWNER for `explorers` and adds `explorers` as a valid PR scope, so we can use `explorers` as a PR title when the changes are specific to these shared components.