### PR TITLE
chore(openchallenges): remove the remainder about updating `*JsonLd.ts` models

### DIFF
--- a/libs/openchallenges/api-client-angular/project.json
+++ b/libs/openchallenges/api-client-angular/project.json
@@ -19,7 +19,6 @@
           "rm -fr src/lib/*",
           "openapi-generator-cli generate",
           "prettier --write \"src/**/*{.ts,.md}\"",
-          "echo 'TODO: fix JSON-LD properties in **/*JsonLd.ts'",
           "echo 'TODO: fix services that return JSON-LD objects in **/*.service.ts'"
         ],
         "cwd": "{projectRoot}",


### PR DESCRIPTION
## Description

Remove a remainder that is no longer needed after updating to OpenAPI Generator v7.11.0.