### PR TITLE
fix(synapse): fix synapse-api-client-angular build

### DIFF
--- a/libs/synapse/api-client-angular/project.json
+++ b/libs/synapse/api-client-angular/project.json
@@ -7,25 +7,25 @@
   "targets": {
     "build": {
       "executor": "@nx/angular:ng-packagr-lite",
-      "outputs": ["{workspaceRoot}/dist/libs/openchallenges/api-client-angular"],
+      "outputs": ["{workspaceRoot}/dist/libs/synapse/api-client-angular"],
       "options": {
-        "project": "libs/openchallenges/api-client-angular/ng-package.json"
+        "project": "libs/synapse/api-client-angular/ng-package.json"
       },
       "configurations": {
         "production": {
-          "tsConfig": "libs/openchallenges/api-client-angular/tsconfig.lib.prod.json"
+          "tsConfig": "libs/synapse/api-client-angular/tsconfig.lib.prod.json"
         },
         "development": {
-          "tsConfig": "libs/openchallenges/api-client-angular/tsconfig.lib.json"
+          "tsConfig": "libs/synapse/api-client-angular/tsconfig.lib.json"
         }
       },
       "defaultConfiguration": "production"
     },
     "test": {
       "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/libs/openchallenges/api-client-angular"],
+      "outputs": ["{workspaceRoot}/coverage/libs/synapse/api-client-angular"],
       "options": {
-        "jestConfig": "libs/openchallenges/api-client-angular/jest.config.ts"
+        "jestConfig": "libs/synapse/api-client-angular/jest.config.ts"
       }
     },
     "lint-fix": {


### PR DESCRIPTION
The paths in `synapse/api-client-angular` incorrectly point at the `openchallenges` project, so the build is failing since #3135 removed `ng-package.json` from `openchallenges`. This PR corrects the `synapse/api-client-angular` paths.