### PR TITLE
feat(openchallenges): containerize the OC MCP Server (SMR-101, SMR-108)

### DIFF
--- a/apps/openchallenges/mcp-server/Dockerfile
+++ b/apps/openchallenges/mcp-server/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/sage-bionetworks/openchallenges-mcp-server-base:local

--- a/apps/openchallenges/mcp-server/build.gradle.kts
+++ b/apps/openchallenges/mcp-server/build.gradle.kts
@@ -25,3 +25,7 @@ dependencies {
 tasks.withType<Test> {
 	useJUnitPlatform()
 }
+
+tasks.named<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>("bootBuildImage") {
+  imageName.set("ghcr.io/sage-bionetworks/${project.name}-base:local")
+}

--- a/apps/openchallenges/mcp-server/project.json
+++ b/apps/openchallenges/mcp-server/project.json
@@ -54,7 +54,7 @@
     "serve-detach": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "docker/amp-als/serve-detach.sh {projectName}"
+        "command": "docker/openchallenges/serve-detach.sh {projectName}"
       },
       "dependsOn": []
     },

--- a/apps/openchallenges/mcp-server/project.json
+++ b/apps/openchallenges/mcp-server/project.json
@@ -4,6 +4,13 @@
   "sourceRoot": "apps/openchallenges/mcp-server/src",
   "projectType": "application",
   "targets": {
+    "create-config": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
+      }
+    },
     "prepare": {
       "executor": "nx:run-commands",
       "options": {
@@ -43,6 +50,28 @@
         "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
+    },
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker/amp-als/serve-detach.sh {projectName}"
+      },
+      "dependsOn": []
+    },
+    "build-image-base": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/{projectName}:local --quiet",
+        "color": true
+      }
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],

--- a/docker/openchallenges/serve-detach.sh
+++ b/docker/openchallenges/serve-detach.sh
@@ -14,6 +14,7 @@ args=(
   --file docker/openchallenges/services/image-service.yml
   --file docker/openchallenges/services/kafka.yml
   --file docker/openchallenges/services/mariadb.yml
+  --file docker/openchallenges/services/mcp-server.yml
   --file docker/openchallenges/services/organization-service.yml
   --file docker/openchallenges/services/service-registry.yml
   --file docker/openchallenges/services/thumbor.yml

--- a/docker/openchallenges/services/apex.yml
+++ b/docker/openchallenges/services/apex.yml
@@ -18,6 +18,8 @@ services:
         condition: service_healthy
       openchallenges-app:
         condition: service_started
+      openchallenges-mcp-server:
+        condition: service_healthy
       openchallenges-zipkin:
         condition: service_healthy
     deploy:

--- a/docker/openchallenges/services/mcp-server.yml
+++ b/docker/openchallenges/services/mcp-server.yml
@@ -1,0 +1,24 @@
+services:
+  openchallenges-mcp-server:
+    image: ghcr.io/sage-bionetworks/openchallenges-mcp-server:${OPENCHALLENGES_VERSION:-local}
+    container_name: openchallenges-mcp-server
+    restart: always
+    env_file:
+      - ../../../apps/openchallenges/mcp-server/.env
+    networks:
+      - openchallenges
+    ports:
+      - '8887:8887'
+    depends_on:
+      openchallenges-api-gateway:
+        condition: service_healthy
+      openchallenges-challenge-service:
+        condition: service_started
+      # openchallenges-image-service:
+      #   condition: service_healthy
+      # openchallenges-organization-service:
+      #   condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 1G


### PR DESCRIPTION
## Related Issues
- closes https://sagebionetworks.jira.com/browse/SMR-101
- closes https://sagebionetworks.jira.com/browse/SMR-108

## Changelog
- containerize the OC MCP server

## Preview

Build the Docker image of MCP Server

```console
nx build-image openchallenges-mcp-server
```

Start the MCP Server container in detach mode

```console
nx serve-detach openchallenges-mcp-server

> nx run openchallenges-mcp-server:serve-detach

> docker/openchallenges/serve-detach.sh openchallenges-mcp-server

[+] Running 8/8
 ✔ Network openchallenges                      Created                                                                                        0.1s 
 ✔ Container openchallenges-config-server      Healthy                                                                                       21.3s 
 ✔ Container openchallenges-elasticsearch      Healthy                                                                                       36.3s 
 ✔ Container openchallenges-mariadb            Healthy                                                                                       31.8s 
 ✔ Container openchallenges-service-registry   Healthy                                                                                       42.2s 
 ✔ Container openchallenges-api-gateway        Healthy                                                                                       46.1s 
 ✔ Container openchallenges-challenge-service  Started                                                                                       43.0s 
 ✔ Container openchallenges-mcp-server         Started                                                                                       46.7s 

——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target serve-detach for project openchallenges-mcp-server (48s)
```


### Verify the response from the endpoint:
```console
curl -i http://openchallenges-mcp-server:8887/sse
HTTP/1.1 200 
Cache-Control: no-cache
Content-Type: text/event-stream
Transfer-Encoding: chunked
Date: Thu, 08 May 2025 02:16:13 GMT

id:ffe6369c-c734-4f0d-85db-b5bf6894bc75
event:endpoint
data:/mcp/message?sessionId=ffe6369c-c734-4f0d-85db-b5bf6894bc75
```
