### PR TITLE
chore(sage-monorepo): update JDK ms distrib and install GraalVM-enabled distrib

### DIFF
--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
       "installDockerComposeSwitch": false
     },
     "ghcr.io/devcontainers/features/java:1.6.3": {
-      "version": "21"
+      "version": "21.0.7-ms",
+      "additionalVersions": ["21.0.7-graal"]
     },
     "ghcr.io/devcontainers/features/go:1.3.1": {
       "version": "1.23.5",


### PR DESCRIPTION
## Related Issues

- Contributes to https://sagebionetworks.jira.com/browse/SMR-111

## Preview

```console
ubuntu@ea7541c96628:/$ sdk list java | grep installed
               |     | 21.0.7       | graal   | installed  | 21.0.7-graal        
 Microsoft     | >>> | 21.0.7       | ms      | installed  | 21.0.7-ms
```