### PR TITLE
chore(sage-monorepo): add musl to the dev container (SMR-113)

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -52,6 +52,8 @@ RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
     shellcheck \
     # Required by canvas (npm package)
     build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+    # Required to build statically linked binaries.
+    musl musl-dev musl-tools \
   # Add Node.js repository.
   && curl -fsSL https://deb.nodesource.com/setup_${nodeVersionMajor}.x -o nodesource_setup.sh \
   && bash nodesource_setup.sh \

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -26,6 +26,8 @@ ARG sonarScannerVersion="7.1.0.4889"
 ARG hadolintVersion="2.12.0"
 # https://pinterest.github.io/ktlint/latest/install/cli/#download-and-verification
 ARG ktlintVersion="1.5.0"
+# https://zlib.net/fossils
+ARG zlibVersion="1.3.1"
 # The version of this dev container image.
 ARG devcontainerVersion=""
 # The username of the non-root user.
@@ -152,6 +154,15 @@ RUN echo "$user:$user" | chpasswd \
   # While this introduces a slight security risk, it is acceptable in a
   # controlled development environment
   && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Build zlib with musl from source
+RUN curl -O "https://zlib.net/fossils/zlib-${zlibVersion}.tar.gz" && \
+  tar -xzf "zlib-${zlibVersion}.tar.gz" && \
+  pushd "zlib-${zlibVersion}" && \
+  CC=musl-gcc ./configure --static && \
+  make && cp libz.a /usr/lib/x86_64-linux-musl/. && \
+  popd && \
+  rm -rf "zlib-${zlibVersion}" "zlib-${zlibVersion}.tar.gz"
 
 # Switch to the non-root user.
 USER $user


### PR DESCRIPTION
## Description

Add musl system packages to the dev container to build statically linked binaries such as the native images build with GraalVM.

## Related Issues

- Contributes to https://sagebionetworks.jira.com/browse/SMR-113

## Changelog

- Add musl dev system libraries to the dev container.
- Build zlib with musl from source and place it where GraalVM's `native-image` builder will find it.