### PR TITLE
refactor(openchallenges): integrate the Java API client for OC into the MCP server (SMR-104)

### DIFF
--- a/apps/openchallenges/mcp-server/Dockerfile
+++ b/apps/openchallenges/mcp-server/Dockerfile
@@ -1,29 +1,6 @@
-# Build in a container with Oracle GraalVM Native Image and MUSL
-FROM container-registry.oracle.com/graalvm/native-image:21-muslib AS nativebuild
-WORKDIR /build
-
-# hadolint ignore=DL3040,DL3041
-RUN microdnf -y install wget xz unzip findutils
-
-# Install Gradle
-ARG GRADLE_VERSION=8.14
-ARG GRADLE_ARCHIVE=gradle-${GRADLE_VERSION}-bin.zip
-RUN wget -q https://services.gradle.org/distributions/${GRADLE_ARCHIVE} && \
-    unzip ${GRADLE_ARCHIVE} && \
-    rm -f ${GRADLE_ARCHIVE}
-
-ENV PATH="/build/gradle-${GRADLE_VERSION}/bin:$PATH"
-
-# Build the native image
-COPY gradle gradle
-COPY build.gradle* gradle* settings.gradle* ./
-COPY src src
-RUN gradle clean nativeCompile --no-daemon
-
 FROM busybox:1.36.1 AS busybox
 
-# Prepare the final image
 FROM scratch
 COPY --from=busybox /tmp /tmp
-COPY --from=nativebuild /build/build/native/nativeCompile/openchallenges-mcp-server /openchallenges-mcp-server
+COPY build/native/nativeCompile/openchallenges-mcp-server /openchallenges-mcp-server
 ENTRYPOINT ["/openchallenges-mcp-server"]

--- a/apps/openchallenges/mcp-server/build.gradle.kts
+++ b/apps/openchallenges/mcp-server/build.gradle.kts
@@ -34,10 +34,12 @@ graalvmNative {
 
 repositories {
 	mavenCentral()
+  mavenLocal()
 }
 
 dependencies {
 	implementation(libs.spring.ai.starter.mcp.server.webmvc)
+  implementation(libs.openchallenges.api.client.java)
 	testImplementation(libs.spring.boot.starter.test)
 	testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/apps/openchallenges/mcp-server/gradle/libs.versions.toml
+++ b/apps/openchallenges/mcp-server/gradle/libs.versions.toml
@@ -1,12 +1,14 @@
 [versions]
 graalvm = "0.10.6"
 junit-platform = "1.10.2"
+openchallenges = "0.0.1-SNAPSHOT"
 spring-ai = "1.0.0-M7"
 spring-boot = "3.4.5"
 spring-dependency-management = "1.1.7"
 
 [libraries]
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+openchallenges-api-client-java = { module = "org.sagebionetworks.openchallenges:openchallenges-api-client-java", version.ref = "openchallenges" }
 spring-ai-starter-mcp-server-webmvc = { module = "org.springframework.ai:spring-ai-starter-mcp-server-webmvc", version.ref = "spring-ai" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }
 

--- a/apps/openchallenges/mcp-server/project.json
+++ b/apps/openchallenges/mcp-server/project.json
@@ -22,7 +22,7 @@
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/build"],
       "options": {
-        "command": "./gradlew build",
+        "command": "./gradlew nativeCompile",
         "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]

--- a/apps/openchallenges/mcp-server/project.json
+++ b/apps/openchallenges/mcp-server/project.json
@@ -73,5 +73,5 @@
     }
   },
   "tags": ["type:service", "scope:backend", "language:java", "package-manager:gradle"],
-  "implicitDependencies": []
+  "implicitDependencies": ["openchallenges-api-client-java"]
 }

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/ChallengeAnalyticsService.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/ChallengeAnalyticsService.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.openchallenges.mcp.server;
 
-import org.sagebionetworks.openchallenges.api.client.ApiClient;
 import org.sagebionetworks.openchallenges.api.client.api.ChallengeAnalyticsApi;
 import org.sagebionetworks.openchallenges.api.client.model.ChallengesPerYear;
 import org.springframework.ai.tool.annotation.Tool;
@@ -11,10 +10,8 @@ public class ChallengeAnalyticsService {
 
   private final ChallengeAnalyticsApi challengeAnalyticsApi;
 
-  public ChallengeAnalyticsService() {
-    ApiClient defaultClient = new ApiClient();
-    defaultClient.setBasePath("http://openchallenges-api-gateway:8082/api/v1");
-    challengeAnalyticsApi = new ChallengeAnalyticsApi(defaultClient);
+  public ChallengeAnalyticsService(ChallengeAnalyticsApi challengeAnalyticsApi) {
+    this.challengeAnalyticsApi = challengeAnalyticsApi;
   }
 
   @Tool(

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/ChallengeAnalyticsService.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/ChallengeAnalyticsService.java
@@ -1,18 +1,20 @@
 package org.sagebionetworks.openchallenges.mcp.server;
 
+import org.sagebionetworks.openchallenges.api.client.ApiClient;
+import org.sagebionetworks.openchallenges.api.client.api.ChallengeAnalyticsApi;
+import org.sagebionetworks.openchallenges.api.client.model.ChallengesPerYear;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
 
 @Service
 public class ChallengeAnalyticsService {
 
-  private final RestClient restClient;
+  private final ChallengeAnalyticsApi challengeAnalyticsApi;
 
   public ChallengeAnalyticsService() {
-    this.restClient = RestClient.builder()
-      .baseUrl("http://openchallenges-api-gateway:8082/api/v1")
-      .build();
+    ApiClient defaultClient = new ApiClient();
+    defaultClient.setBasePath("http://openchallenges-api-gateway:8082/api/v1");
+    challengeAnalyticsApi = new ChallengeAnalyticsApi(defaultClient);
   }
 
   @Tool(
@@ -20,10 +22,6 @@ public class ChallengeAnalyticsService {
     description = "Get the number of challenges tracked per year"
   )
   public ChallengesPerYear getChallengesPerYear() {
-    return restClient
-      .get()
-      .uri("/challengeAnalytics/challengesPerYear")
-      .retrieve()
-      .body(ChallengesPerYear.class);
+    return challengeAnalyticsApi.getChallengesPerYear();
   }
 }

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/ChallengesPerYear.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/ChallengesPerYear.java
@@ -1,9 +1,0 @@
-package org.sagebionetworks.openchallenges.mcp.server;
-
-import java.util.List;
-
-public record ChallengesPerYear(
-  List<String> years,
-  List<Integer> challengeCounts,
-  int undatedChallengeCount
-) {}

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
@@ -1,0 +1,22 @@
+package org.sagebionetworks.openchallenges.mcp.server.config;
+
+import org.sagebionetworks.openchallenges.api.client.ApiClient;
+import org.sagebionetworks.openchallenges.api.client.api.ChallengeAnalyticsApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenChallengesApiClientConfig {
+
+  private final ApiClient apiClient;
+
+  public OpenChallengesApiClientConfig() {
+    this.apiClient = new ApiClient();
+    this.apiClient.setBasePath("http://openchallenges-api-gateway:8082/api/v1");
+  }
+
+  @Bean
+  public ChallengeAnalyticsApi challengeAnalyticsApi() {
+    return new ChallengeAnalyticsApi(apiClient);
+  }
+}

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/ReflectionHintsConfig.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/ReflectionHintsConfig.java
@@ -1,10 +1,14 @@
 package org.sagebionetworks.openchallenges.mcp.server.config;
 
 import org.sagebionetworks.openchallenges.mcp.server.ChallengePlatformsPage;
-import org.sagebionetworks.openchallenges.mcp.server.ChallengesPerYear;
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@RegisterReflectionForBinding({ ChallengesPerYear.class, ChallengePlatformsPage.class })
+@RegisterReflectionForBinding(
+  {
+    org.sagebionetworks.openchallenges.api.client.model.ChallengesPerYear.class,
+    ChallengePlatformsPage.class,
+  }
+)
 public class ReflectionHintsConfig {}


### PR DESCRIPTION
## Description

This PR uses the new Java API client for OC generated with OpenAPI Generator to fetch data for an MCP tool.

## Related Issues

- Closes https://sagebionetworks.jira.com/browse/SMR-104

## Changelog

- Update `openchallenges-mcp-server:build` to build the native image with GraalVM.
- Update `openchallenges-mcp-server:build-image` to package the native image generated by the `build` task.
- Import the Java API client for OC into the MCP server project.
- Use the Java API client for OC to fetch data from the OC challenge analytics data endpoint.