### PR TITLE
fix(sage-monorepo): run the `build` task before `build-image` for Java projects built with GraalVM (SMR-126)

### DIFF
--- a/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
@@ -12,6 +12,10 @@ export async function buildImageTarget(
     dependsOn.push({
       target: 'build-image-base',
     });
+    // This dependency is required for Java apps build with GraalVM.
+    dependsOn.push({
+      target: 'build',
+    });
   } else if (projectBuilder === 'webpack' && projectFramework === 'angular') {
     dependsOn.push({
       // TODO: the task `server` is more about Angular that the build itself. To revisit. Also,


### PR DESCRIPTION
## Related Issues

- https://sagebionetworks.jira.com/browse/SMR-126

## Preview

The task `build-image` now depends on the task `build` in addition to `build-image-base`.

```bash
nx show project openchallenges-mcp-server
```

![image](https://github.com/user-attachments/assets/3014c2f7-e70b-4fae-8b08-d1756cb3d360)

> [!NOTE]
> Technically, we have two types of projects: 1) built with JVM and 2) built with GraalVM. The former tasks need to run `build-image-base` only. the latter tasks need to run `build` only. There is currently a bit of wasted resources for the former type of projects. The latter projects do not waste resources because they don't implement `build-image-base`. The efficiency will be improved in a future PR. This PR aims to fix a broken chain of dependencies so that developers can continue to contribute.
