### PR TITLE
chore(openchallenges): update to Spring AI 1.0.0 M8

### DIFF
--- a/apps/openchallenges/mcp-server/gradle/libs.versions.toml
+++ b/apps/openchallenges/mcp-server/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 graalvm = "0.10.6"
 junit-platform = "1.10.2"
 openchallenges = "0.0.1-SNAPSHOT"
-spring-ai = "1.0.0-M7"
+spring-ai = "1.0.0-M8"
 spring-boot = "3.4.5"
 spring-dependency-management = "1.1.7"
 

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
@@ -16,7 +16,7 @@ public class McpServerApplication {
   }
 
   @Bean
-  public List<ToolCallback> tools(
+  public List<ToolCallback> toolCallbacks(
     ChallengeAnalyticsService challengeAnalyticsService,
     ChallengePlatformService challengePlatformService
   ) {


### PR DESCRIPTION
## Changelog

- Rename `tools` by `toolCallbacks` as documented in the M8 release notes (see References).

## References

- https://github.com/spring-projects/spring-ai/tags
- https://spring.io/blog/2025/04/30/spring-ai-1-0-0-m8-released