### PR TITLE
refactor(openchallenges): revert to building MCP server for JVM to improve DevEx

### DIFF
--- a/apps/openchallenges/mcp-server/Dockerfile
+++ b/apps/openchallenges/mcp-server/Dockerfile
@@ -1,6 +1,10 @@
-FROM busybox:1.36.1 AS busybox
+# Base image containing the app built for the JVM.
+FROM ghcr.io/sage-bionetworks/openchallenges-mcp-server-base:local
 
-FROM scratch
-COPY --from=busybox /tmp /tmp
-COPY build/native/nativeCompile/openchallenges-mcp-server /openchallenges-mcp-server
-ENTRYPOINT ["/openchallenges-mcp-server"]
+# Alternative: Build a statically linked native binary of the app using GraalVM.
+# FROM busybox:1.36.1 AS busybox
+
+# FROM scratch
+# COPY --from=busybox /tmp /tmp
+# COPY build/native/nativeCompile/openchallenges-mcp-server /openchallenges-mcp-server
+# ENTRYPOINT ["/openchallenges-mcp-server"]

--- a/apps/openchallenges/mcp-server/build.gradle.kts
+++ b/apps/openchallenges/mcp-server/build.gradle.kts
@@ -62,3 +62,7 @@ tasks.withType<Test>().configureEach {
     events("passed", "skipped", "failed")
   }
 }
+
+tasks.named<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>("bootBuildImage") {
+  imageName.set("ghcr.io/sage-bionetworks/${project.name}-base:local")
+}

--- a/apps/openchallenges/mcp-server/project.json
+++ b/apps/openchallenges/mcp-server/project.json
@@ -22,7 +22,7 @@
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/build"],
       "options": {
-        "command": "./gradlew nativeCompile",
+        "command": "./gradlew build",
         "cwd": "{projectRoot}"
       },
       "dependsOn": ["^install"]
@@ -57,6 +57,14 @@
         "command": "docker/openchallenges/serve-detach.sh {projectName}"
       },
       "dependsOn": []
+    },
+    "build-image-base": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./gradlew bootBuildImage",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^install"]
     },
     "scan-image": {
       "executor": "nx:run-commands",

--- a/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
@@ -13,9 +13,9 @@ export async function buildImageTarget(
       target: 'build-image-base',
     });
     // This dependency is required for Java apps build with GraalVM.
-    dependsOn.push({
-      target: 'build',
-    });
+    // dependsOn.push({
+    //   target: 'build',
+    // });
   } else if (projectBuilder === 'webpack' && projectFramework === 'angular') {
     dependsOn.push({
       // TODO: the task `server` is more about Angular that the build itself. To revisit. Also,


### PR DESCRIPTION
## Description

The goal of this PR is to revert to building the OC MCP server for JVM, for which building a Docker image is much faster than building it with GraalVM for optimizing the cold start of the server. This change is motivated by the fact the deployment of the MCP server to production is delayed as the server is still too early in its development phase.

By then, I'm hoping to find a way so that the developer don't have to build the server with GraalVM when deploying the app with Docker Compose inside the development environment. Instead, the MCP server should be built and tested with GraalVM by the CI/CD workflow.

## Changelog

- Revert back to the standard way to build Docker images for Gradle projects.
- Remove the dependency of `build-image` on `build` for Java projects.