### PR TITLE
chore(sage-monorepo): add VS Code extension for Caddyfiles

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -162,6 +162,7 @@
         "GitHub.vscode-pull-request-github",
         "Gruntfuggly.todo-tree",
         "humao.rest-client",
+        "matthewpi.caddyfile-support",
         "mhutchie.git-graph",
         "mongodb.mongodb-vscode",
         "ms-playwright.playwright",


### PR DESCRIPTION
## Description

This PR adds the official VS Code extension for Caddy files.

- Prevent the issue described in the related ticket.
- Provides syntax highlight and intellisense.

## Related Issues

- Closes https://sagebionetworks.jira.com/browse/SMR-128

## Preview

<img width="937" alt="image" src="https://github.com/user-attachments/assets/a94f32de-f376-4225-937e-5c995a27c1da" />
