### PR TITLE
feat(sage-monorepo): add VS Code extension for Redolcy OpenAPI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -175,6 +175,7 @@
         "njpwerner.autodocstring",
         "Orta.vscode-jest",
         "pranaygp.vscode-css-peek",
+        "Redocly.openapi-vs-code",
         "ritwickdey.LiveServer",
         "shengchen.vscode-checkstyle",
         "SonarSource.sonarlint-vscode",

--- a/libs/amp-als/api-description/project.json
+++ b/libs/amp-als/api-description/project.json
@@ -26,7 +26,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "redocly lint --config tools/redocly/config.yaml {projectName}"
+        "command": "redocly lint --config redocly.yaml {projectName}"
       },
       "dependsOn": ["build"]
     }

--- a/libs/model-ad/api-description/project.json
+++ b/libs/model-ad/api-description/project.json
@@ -14,7 +14,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "redocly lint --config tools/redocly/config.yaml {projectName}"
+        "command": "redocly lint --config redocly.yaml {projectName}"
       },
       "dependsOn": ["build"]
     }

--- a/libs/openchallenges/api-description/project.json
+++ b/libs/openchallenges/api-description/project.json
@@ -29,7 +29,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "redocly lint --config tools/redocly/config.yaml {projectName}"
+        "command": "redocly lint --config redocly.yaml {projectName}"
       },
       "dependsOn": ["build"]
     }

--- a/libs/synapse/api-description/project.json
+++ b/libs/synapse/api-description/project.json
@@ -21,7 +21,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "redocly lint --config tools/redocly/config.yaml {projectName}"
+        "command": "redocly lint --config redocly.yaml {projectName}"
       },
       "dependsOn": ["build"]
     }

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -12,15 +12,15 @@ rules:
 # The path to the API description files is relative to the location of this file.
 apis:
   amp-als-api-description:
-    root: ../../libs/amp-als/api-description/openapi/openapi.yaml
+    root: libs/amp-als/api-description/openapi/openapi.yaml
   agora-api-description:
-    root: ../../libs/agora/api-description/openapi/openapi.yaml
+    root: libs/agora/api-description/openapi/openapi.yaml
   model-ad-api-description:
-    root: ../../libs/model-ad/api-description/build/openapi.yaml
+    root: libs/model-ad/api-description/build/openapi.yaml
   openchallenges-api-description:
-    root: ../../libs/openchallenges/api-description/openapi/openapi.yaml
+    root: libs/openchallenges/api-description/openapi/openapi.yaml
   synapse-api-description:
-    root: ../../libs/synapse/api-description/openapi/openapi.json
+    root: libs/synapse/api-description/openapi/openapi.json
     rules:
       operation-4xx-response: off
       operation-operationId-url-safe: off


### PR DESCRIPTION
## Related Issues

- Closes https://sagebionetworks.jira.com/browse/SMR-130

## Changelog

- Add the VS Code extension Redocly OpenAPI to the dev container.
- Move the Redocly configuration to the workspace folder where the extension can find it.

## Preview

### Now

The OpenAPI description files are not interactive.

![image](https://github.com/user-attachments/assets/bad45426-143f-42f9-bed0-3c756c20d9ce)

### With this PR

Hints on how to fix validation warnings are shown upon placing the pointer over them.

<img width="926" alt="image" src="https://github.com/user-attachments/assets/324b85d6-8604-4eb0-8dee-deefe48c96ad" />

On Mac: **Hold Command + move the pointer over a reference** to show its preview in a tooltip.

<img width="895" alt="image" src="https://github.com/user-attachments/assets/44440470-22f1-4a65-be96-e0783762d4a3" />

On Mac: **Hold Command + click on a reference** to open its definition.

<img width="820" alt="image" src="https://github.com/user-attachments/assets/6504beef-1e65-47f3-962b-210d3475f721" />

Alternatively, **right-click a reference** and select **Peek** > **Peek Definition** to view and edit the definition directly within the current YAML file. No need to open it in a separate file.

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/95ba6e84-0dc2-42e2-92fd-033a1bd92f14" />

