### PR TITLE
chore(sage-monorepo): warn where new Angular control flow should be used

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,7 @@
       "parser": "@angular-eslint/template-parser",
       "plugins": ["@angular-eslint/template"],
       "rules": {
-        "@angular-eslint/template/prefer-control-flow": "error"
+        "@angular-eslint/template/prefer-control-flow": "warn"
       }
     }
   ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,14 @@
         "@typescript-eslint/no-extra-semi": "error",
         "no-extra-semi": "off"
       }
+    },
+    {
+      "files": ["*.html"],
+      "parser": "@angular-eslint/template-parser",
+      "plugins": ["@angular-eslint/template"],
+      "rules": {
+        "@angular-eslint/template/prefer-control-flow": "warn"
+      }
     }
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,7 @@
       "parser": "@angular-eslint/template-parser",
       "plugins": ["@angular-eslint/template"],
       "rules": {
-        "@angular-eslint/template/prefer-control-flow": "warn"
+        "@angular-eslint/template/prefer-control-flow": "error"
       }
     }
   ]


### PR DESCRIPTION
## Description

Update the global ESLint configuration to warn where new Angular control flow should be used.

To see the warnings, the developers must run the `lint` tasks on their projects, e.g.:

```bash
nx run-many --target=lint --projects=agora-*
```

> [!NOTE]
> `lint-staged` lints the affected projects when committing code. `lint-staged` does not show the warning messages from the linter but will show the errors. Moreover, note that only the affected projects are linted by `lint-staged`. To lint all the Agora projects, e.g., run the command provide above.

## Related Issues

- https://sagebionetworks.jira.com/browse/SMR-136

## Preview

### This PR

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/7c65a4ab-272a-423c-8d35-28cb8df89d80" />

### Future: CI/CD will throw errors if this rule is set to `error`

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/25dacf34-7dbd-4b1c-bf3e-7f955328c80a" />
