### PR TITLE
feat(openchallenges): create project-specific config for the OC MCP server (SMR-112)

### DIFF
--- a/apps/openchallenges/mcp-server/.env.example
+++ b/apps/openchallenges/mcp-server/.env.example
@@ -1,1 +1,1 @@
-API_BASE_URL=http://openchallenges-api-gateway:8082/api/v1
+# API_BASE_URL=http://openchallenges-api-gateway:8082/api/v1

--- a/apps/openchallenges/mcp-server/.env.example
+++ b/apps/openchallenges/mcp-server/.env.example
@@ -1,2 +1,2 @@
-WELCOME_MESSAGE='Welcome to the OpenChallenges MCP Server'
-API_BASE_URL=http://openchallenges-api-gateway:8082/api/v1
+OPENCHALLENGES_MCP_SERVER_WELCOME_MESSAGE='Welcome to the OpenChallenges MCP Server'
+OPENCHALLENGES_MCP_SERVER_API_BASE_URL=http://openchallenges-api-gateway:8082/api/v1

--- a/apps/openchallenges/mcp-server/.env.example
+++ b/apps/openchallenges/mcp-server/.env.example
@@ -1,0 +1,1 @@
+API_BASE_URL=http://openchallenges-api-gateway:8082/api/v1

--- a/apps/openchallenges/mcp-server/.env.example
+++ b/apps/openchallenges/mcp-server/.env.example
@@ -1,1 +1,2 @@
-# API_BASE_URL=http://openchallenges-api-gateway:8082/api/v1
+WELCOME_MESSAGE='Welcome to the OpenChallenges MCP Server'
+API_BASE_URL=http://openchallenges-api-gateway:8082/api/v1

--- a/apps/openchallenges/mcp-server/build.gradle.kts
+++ b/apps/openchallenges/mcp-server/build.gradle.kts
@@ -49,7 +49,11 @@ repositories {
 dependencies {
 	implementation(libs.spring.ai.starter.mcp.server.webmvc)
   implementation(libs.openchallenges.api.client.java)
+  compileOnly(libs.lombok)
+  annotationProcessor(libs.lombok)
 	testImplementation(libs.spring.boot.starter.test)
+  testCompileOnly(libs.lombok)
+  testAnnotationProcessor(libs.lombok)
 	testRuntimeOnly(libs.junit.platform.launcher)
 }
 

--- a/apps/openchallenges/mcp-server/gradle/libs.versions.toml
+++ b/apps/openchallenges/mcp-server/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 graalvm = "0.10.6"
 junit-platform = "1.10.2"
+lombok = "1.18.38"
 openchallenges = "0.0.1-SNAPSHOT"
 spring-ai = "1.0.0-M8"
 spring-boot = "3.4.5"
@@ -8,6 +9,7 @@ spring-dependency-management = "1.1.7"
 
 [libraries]
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 openchallenges-api-client-java = { module = "org.sagebionetworks.openchallenges:openchallenges-api-client-java", version.ref = "openchallenges" }
 spring-ai-starter-mcp-server-webmvc = { module = "org.springframework.ai:spring-ai-starter-mcp-server-webmvc", version.ref = "spring-ai" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
@@ -29,7 +29,7 @@ public class McpServerApplication implements CommandLineRunner {
 
   @Override
   public void run(String... args) throws Exception {
-    logger.info(mcpServerConfigData.getApiBaseUrl());
+    logger.info(mcpServerConfigData.getWelcomeMessage());
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
@@ -29,7 +29,7 @@ public class McpServerApplication implements CommandLineRunner {
 
   @Override
   public void run(String... args) throws Exception {
-    logger.info(mcpServerConfigData.getWelcomeMessage());
+    logger.info(mcpServerConfigData.getWelcome().getMessage());
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
@@ -2,17 +2,34 @@ package org.sagebionetworks.openchallenges.mcp.server;
 
 import java.util.Arrays;
 import java.util.List;
+import org.sagebionetworks.openchallenges.mcp.server.config.McpServerConfigData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbacks;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
-public class McpServerApplication {
+public class McpServerApplication implements CommandLineRunner {
+
+  private static final Logger logger = LoggerFactory.getLogger(McpServerApplication.class);
+
+  private final McpServerConfigData mcpServerConfigData;
+
+  public McpServerApplication(McpServerConfigData mcpServerConfigData) {
+    this.mcpServerConfigData = mcpServerConfigData;
+  }
 
   public static void main(String[] args) {
     SpringApplication.run(McpServerApplication.class, args);
+  }
+
+  @Override
+  public void run(String... args) throws Exception {
+    logger.info(mcpServerConfigData.getApiBaseUrl());
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/McpServerApplication.java
@@ -29,7 +29,7 @@ public class McpServerApplication implements CommandLineRunner {
 
   @Override
   public void run(String... args) throws Exception {
-    logger.info(mcpServerConfigData.getWelcome().getMessage());
+    logger.info(mcpServerConfigData.getWelcomeMessage());
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Data
 @Configuration
-@ConfigurationProperties
+@ConfigurationProperties(prefix = "openchallenges-mcp-server")
 public class McpServerConfigData {
 
   private String welcomeMessage;

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
@@ -9,24 +9,6 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties
 public class McpServerConfigData {
 
-  private Welcome welcome;
-  private Api api;
-
-  @Data
-  public static class Welcome {
-
-    private String message;
-  }
-
-  @Data
-  public static class Api {
-
-    private Base base;
-
-    @Data
-    public static class Base {
-
-      private String url;
-    }
-  }
+  private String welcomeMessage;
+  private String apiBaseUrl;
 }

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.openchallenges.mcp.server.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "openchallenges-mcp-server")
+public class McpServerConfigData {
+
+  private String apiBaseUrl;
+}

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
@@ -6,9 +6,27 @@ import org.springframework.context.annotation.Configuration;
 
 @Data
 @Configuration
-@ConfigurationProperties(prefix = "openchallenges-mcp-server")
+@ConfigurationProperties
 public class McpServerConfigData {
 
-  private String welcomeMessage;
-  private String apiBaseUrl;
+  private Welcome welcome;
+  private Api api;
+
+  @Data
+  public static class Welcome {
+
+    private String message;
+  }
+
+  @Data
+  public static class Api {
+
+    private Base base;
+
+    @Data
+    public static class Base {
+
+      private String url;
+    }
+  }
 }

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/McpServerConfigData.java
@@ -9,5 +9,6 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "openchallenges-mcp-server")
 public class McpServerConfigData {
 
+  private String welcomeMessage;
   private String apiBaseUrl;
 }

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
@@ -15,7 +15,7 @@ public class OpenChallengesApiClientConfig {
 
   public OpenChallengesApiClientConfig(McpServerConfigData mcpServerConfigData) {
     this.apiClient = new ApiClient();
-    this.apiClient.setBasePath(mcpServerConfigData.getApiBaseUrl());
+    this.apiClient.setBasePath(mcpServerConfigData.getApi().getBase().getUrl());
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
@@ -5,7 +5,6 @@ import org.sagebionetworks.openchallenges.api.client.api.ChallengeAnalyticsApi;
 import org.sagebionetworks.openchallenges.api.client.api.ChallengeApi;
 import org.sagebionetworks.openchallenges.api.client.api.ChallengePlatformApi;
 import org.sagebionetworks.openchallenges.api.client.api.EdamConceptApi;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,9 +13,9 @@ public class OpenChallengesApiClientConfig {
 
   private final ApiClient apiClient;
 
-  public OpenChallengesApiClientConfig(@Value("${api.base.url}") String apiBaseUrl) {
+  public OpenChallengesApiClientConfig(McpServerConfigData mcpServerConfigData) {
     this.apiClient = new ApiClient();
-    this.apiClient.setBasePath(apiBaseUrl);
+    this.apiClient.setBasePath(mcpServerConfigData.getApiBaseUrl());
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
@@ -15,7 +15,7 @@ public class OpenChallengesApiClientConfig {
 
   public OpenChallengesApiClientConfig(McpServerConfigData mcpServerConfigData) {
     this.apiClient = new ApiClient();
-    this.apiClient.setBasePath(mcpServerConfigData.getApi().getBase().getUrl());
+    this.apiClient.setBasePath(mcpServerConfigData.getApiBaseUrl());
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
+++ b/apps/openchallenges/mcp-server/src/main/java/org/sagebionetworks/openchallenges/mcp/server/config/OpenChallengesApiClientConfig.java
@@ -5,6 +5,7 @@ import org.sagebionetworks.openchallenges.api.client.api.ChallengeAnalyticsApi;
 import org.sagebionetworks.openchallenges.api.client.api.ChallengeApi;
 import org.sagebionetworks.openchallenges.api.client.api.ChallengePlatformApi;
 import org.sagebionetworks.openchallenges.api.client.api.EdamConceptApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,9 +14,9 @@ public class OpenChallengesApiClientConfig {
 
   private final ApiClient apiClient;
 
-  public OpenChallengesApiClientConfig() {
+  public OpenChallengesApiClientConfig(@Value("${api.base.url}") String apiBaseUrl) {
     this.apiClient = new ApiClient();
-    this.apiClient.setBasePath("http://openchallenges-api-gateway:8082/api/v1");
+    this.apiClient.setBasePath(apiBaseUrl);
   }
 
   @Bean

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,5 +1,5 @@
-welcome.message: 'Welcome to the OpenChallenges MCP Server - dev mode'
-api.base.url: http://openchallenges-api-gateway:8082/api/v1
+welcome-message: ${WELCOME_MESSAGE:'Welcome to the OpenChallenges MCP Server - dev mode'}
+api-base-url: ${API_BASE_URL:http://openchallenges-api-gateway:8082/api/v1}
 
 server:
   port: 8887

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 openchallenges-mcp-server:
-  welcome-message: 'Welcome to the OpenChallenges MCP Server'
-  api-base-url: http://openchallenges-api-gateway:8082/api/v1
+  welcomeMessage: 'Welcome to the OpenChallenges MCP Server - dev mode'
+  apiBaseUrl: http://openchallenges-api-gateway:8082/api/v1
 
 server:
   port: 8887

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,6 +1,5 @@
-openchallenges-mcp-server:
-  welcomeMessage: 'Welcome to the OpenChallenges MCP Server - dev mode'
-  apiBaseUrl: http://openchallenges-api-gateway:8082/api/v1
+welcome.message: 'Welcome to the OpenChallenges MCP Server - dev mode'
+api.base.url: http://openchallenges-api-gateway:8082/api/v1
 
 server:
   port: 8887

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,5 +1,5 @@
-welcome-message: ${WELCOME_MESSAGE:'Welcome to the OpenChallenges MCP Server - dev mode'}
-api-base-url: ${API_BASE_URL:http://openchallenges-api-gateway:8082/api/v1}
+welcomeMessage: 'Welcome to the OpenChallenges MCP Server - dev mode'
+apiBaseUrl: http://openchallenges-api-gateway:8082/api/v1
 
 server:
   port: 8887

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 openchallenges-mcp-server:
+  welcomeMessage: 'Welcome to the OpenChallenges MCP Server'
   api-base-url: http://openchallenges-api-gateway:8082/api/v1
 
 server:

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+openchallenges-mcp-server:
+  api-base-url: http://openchallenges-api-gateway:8082/api/v1
+
 server:
   port: 8887
 spring:

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 openchallenges-mcp-server:
-  welcomeMessage: 'Welcome to the OpenChallenges MCP Server'
+  welcome-message: 'Welcome to the OpenChallenges MCP Server'
   api-base-url: http://openchallenges-api-gateway:8082/api/v1
 
 server:

--- a/apps/openchallenges/mcp-server/src/main/resources/application.yml
+++ b/apps/openchallenges/mcp-server/src/main/resources/application.yml
@@ -1,5 +1,6 @@
-welcomeMessage: 'Welcome to the OpenChallenges MCP Server - dev mode'
-apiBaseUrl: http://openchallenges-api-gateway:8082/api/v1
+openchallenges-mcp-server:
+  welcome-message: 'Welcome to the OpenChallenges MCP Server - dev mode'
+  api-base-url: :http://openchallenges-api-gateway:8082/api/v1
 
 server:
   port: 8887


### PR DESCRIPTION
## Related Issue

closes https://sagebionetworks.jira.com/browse/SMR-112

## Changelog
- Config API base url via the environment variable for `openchallenges-mcp-server`
- Add a welcome message for `openchallenges-mcp-server`


## Preview

I tested three configuration binding approaches below in the `application.yml`, while keeping `.env` file with snake-cased variables (e.g., `WELCOME_MESSAGE`):

- Dotted case - [9dc4990](https://github.com/Sage-Bionetworks/sage-monorepo/pull/3180/commits/9dc499001afcdf071c7e2373fad60c33906914be)
- Kebab case - [11032ad](https://github.com/Sage-Bionetworks/sage-monorepo/pull/3180/commits/11032ad7aea1d7a9cb7c780f1c1b6d717704f07d)
- Camel case - [2d9050f](https://github.com/Sage-Bionetworks/sage-monorepo/pull/3180/commits/2d9050fe30cf0f3838ae4c1ad00a23a1e5449b5e)

Selected approach is ~~**Camel case**~~ **Kebab case**.

### Running in Dev Mode
```
cd apps/openchallenges/mcp-server && ./gradlew clean bootRun
```

You should see the following welcome message in the terminal logs:

```console
o.s.o.mcp.server.McpServerApplication    : Welcome to the OpenChallenges MCP Server - dev mode
```

### Running as Container

> [!NOTE]
> Make sure to run `workspace-install` or copy the contents of `.env_example` into a `.env` file in the `openchallenges-mcp-server` project for the first run.

```
cd /workspaces/sage-monorepo && \
  nx build-openchallenges-mcp-server \
  nx serve-detach openchallenges-mcp-server \
  docker logs openchallenges-mcp-server
```

You should see the following welcome message in the container logs:

```console
o.s.o.mcp.server.McpServerApplication    : Welcome to the OpenChallenges MCP Server
```
