### PR TITLE
feat(sage-monorepo): enable developers to start multiple stacks with Docker Compose (SMR-150)

### DIFF
--- a/docker/agora/serve-detach.sh
+++ b/docker/agora/serve-detach.sh
@@ -13,7 +13,7 @@ args=(
   --file docker/agora/networks.yml
   --file docker/agora/volumes.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/agora/serve-detach.sh
+++ b/docker/agora/serve-detach.sh
@@ -13,6 +13,8 @@ args=(
   --file docker/agora/networks.yml
   --file docker/agora/volumes.yml
 
+  --project-name agora
+
   up $1 --detach
 )
 

--- a/docker/agora/serve-detach.sh
+++ b/docker/agora/serve-detach.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 
+product_name="agora"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/agora/services/apex.yml
-  --file docker/agora/services/api-docs.yml
-  --file docker/agora/services/api.yml
-  --file docker/agora/services/app.yml
-  --file docker/agora/services/data.yml
-  --file docker/agora/services/gene-api.yml
-  --file docker/agora/services/mongo.yml
+  --file docker/"$product_name"/services/apex.yml
+  --file docker/"$product_name"/services/api-docs.yml
+  --file docker/"$product_name"/services/api.yml
+  --file docker/"$product_name"/services/app.yml
+  --file docker/"$product_name"/services/data.yml
+  --file docker/"$product_name"/services/gene-api.yml
+  --file docker/"$product_name"/services/mongo.yml
 
-  --file docker/agora/networks.yml
-  --file docker/agora/volumes.yml
+  --file docker/"$product_name"/networks.yml
+  --file docker/"$product_name"/volumes.yml
 
-  --project-name agora
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/amp-als/serve-detach.sh
+++ b/docker/amp-als/serve-detach.sh
@@ -11,6 +11,8 @@ args=(
 
   --file docker/amp-als/networks.yml
 
+  --project-name amp-als
+
   up $1 --detach
 )
 

--- a/docker/amp-als/serve-detach.sh
+++ b/docker/amp-als/serve-detach.sh
@@ -11,7 +11,7 @@ args=(
 
   --file docker/amp-als/networks.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/amp-als/serve-detach.sh
+++ b/docker/amp-als/serve-detach.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 
+product_name="amp-als"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/amp-als/services/apex.yml
-  --file docker/amp-als/services/api-docs.yml
-  --file docker/amp-als/services/dataset-service.yml
-  --file docker/amp-als/services/keycloak.yml
-  --file docker/amp-als/services/mariadb.yml
-  --file docker/amp-als/services/opensearch.yml
+  --file docker/"$product_name"/services/apex.yml
+  --file docker/"$product_name"/services/api-docs.yml
+  --file docker/"$product_name"/services/dataset-service.yml
+  --file docker/"$product_name"/services/keycloak.yml
+  --file docker/"$product_name"/services/mariadb.yml
+  --file docker/"$product_name"/services/opensearch.yml
 
-  --file docker/amp-als/networks.yml
+  --file docker/"$product_name"/networks.yml
 
-  --project-name amp-als
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/iatlas/serve-detach.sh
+++ b/docker/iatlas/serve-detach.sh
@@ -9,6 +9,8 @@ args=(
   --file docker/iatlas/networks.yml
   --file docker/iatlas/volumes.yml
 
+  --project-name iatlas
+
   up $1 --detach
 )
 

--- a/docker/iatlas/serve-detach.sh
+++ b/docker/iatlas/serve-detach.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
+product_name="iatlas"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/iatlas/services/api.yml
-  --file docker/iatlas/services/data.yml
-  --file docker/iatlas/services/postgres.yml
+  --file docker/"$product_name"/services/api.yml
+  --file docker/"$product_name"/services/data.yml
+  --file docker/"$product_name"/services/postgres.yml
 
-  --file docker/iatlas/networks.yml
-  --file docker/iatlas/volumes.yml
+  --file docker/"$product_name"/networks.yml
+  --file docker/"$product_name"/volumes.yml
 
-  --project-name iatlas
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/iatlas/serve-detach.sh
+++ b/docker/iatlas/serve-detach.sh
@@ -9,7 +9,7 @@ args=(
   --file docker/iatlas/networks.yml
   --file docker/iatlas/volumes.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/model-ad/serve-detach.sh
+++ b/docker/model-ad/serve-detach.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 
+product_name="model-ad"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/model-ad/services/apex.yml
-  --file docker/model-ad/services/api-docs.yml
-  --file docker/model-ad/services/api.yml
-  --file docker/model-ad/services/app.yml
-  --file docker/model-ad/services/data.yml
-  --file docker/model-ad/services/mongo.yml
+  --file docker/"$product_name"/services/apex.yml
+  --file docker/"$product_name"/services/api-docs.yml
+  --file docker/"$product_name"/services/api.yml
+  --file docker/"$product_name"/services/app.yml
+  --file docker/"$product_name"/services/data.yml
+  --file docker/"$product_name"/services/mongo.yml
 
-  --file docker/model-ad/networks.yml
-  --file docker/model-ad/volumes.yml
+  --file docker/"$product_name"/networks.yml
+  --file docker/"$product_name"/volumes.yml
 
-  --project-name model-ad
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/model-ad/serve-detach.sh
+++ b/docker/model-ad/serve-detach.sh
@@ -12,7 +12,7 @@ args=(
   --file docker/model-ad/networks.yml
   --file docker/model-ad/volumes.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/model-ad/serve-detach.sh
+++ b/docker/model-ad/serve-detach.sh
@@ -12,6 +12,8 @@ args=(
   --file docker/model-ad/networks.yml
   --file docker/model-ad/volumes.yml
 
+  --project-name model-ad
+
   up $1 --detach
 )
 

--- a/docker/observability/serve-detach.sh
+++ b/docker/observability/serve-detach.sh
@@ -2,10 +2,11 @@
 
 args=(
   # List of services in alphanumeric order
+  --file docker/observability/networks.yml
   --file docker/observability/services/grafana.yml
   --file docker/observability/services/prometheus.yml
 
-  --file docker/observability/networks.yml
+  --project-name observability
 
   up $1 --detach
 )

--- a/docker/observability/serve-detach.sh
+++ b/docker/observability/serve-detach.sh
@@ -2,9 +2,10 @@
 
 args=(
   # List of services in alphanumeric order
-  --file docker/observability/networks.yml
   --file docker/observability/services/grafana.yml
   --file docker/observability/services/prometheus.yml
+
+  --file docker/observability/networks.yml
 
   --project-name observability
 

--- a/docker/observability/serve-detach.sh
+++ b/docker/observability/serve-detach.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+product_name="observability"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/observability/services/grafana.yml
-  --file docker/observability/services/prometheus.yml
+  --file docker/"$product_name"/services/grafana.yml
+  --file docker/"$product_name"/services/prometheus.yml
 
-  --file docker/observability/networks.yml
+  --file docker/"$product_name"/networks.yml
 
-  --project-name observability
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/observability/serve-detach.sh
+++ b/docker/observability/serve-detach.sh
@@ -7,7 +7,7 @@ args=(
 
   --file docker/observability/networks.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/openchallenges/serve-detach.sh
+++ b/docker/openchallenges/serve-detach.sh
@@ -23,7 +23,7 @@ args=(
   --file docker/openchallenges/networks.yml
   --file docker/openchallenges/volumes.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/openchallenges/serve-detach.sh
+++ b/docker/openchallenges/serve-detach.sh
@@ -23,6 +23,8 @@ args=(
   --file docker/openchallenges/networks.yml
   --file docker/openchallenges/volumes.yml
 
+  --project-name openchallenges
+
   up $1 --detach
 )
 

--- a/docker/openchallenges/serve-detach.sh
+++ b/docker/openchallenges/serve-detach.sh
@@ -1,29 +1,31 @@
 #!/usr/bin/env bash
 
+product_name="openchallenges"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/openchallenges/services/apex.yml
-  --file docker/openchallenges/services/api-docs.yml
-  --file docker/openchallenges/services/api-gateway.yml
-  --file docker/openchallenges/services/app.yml
-  --file docker/openchallenges/services/challenge-service.yml
-  --file docker/openchallenges/services/config-server.yml
-  --file docker/openchallenges/services/data-lambda.yml
-  --file docker/openchallenges/services/edam-etl.yml
-  --file docker/openchallenges/services/elasticsearch.yml
-  --file docker/openchallenges/services/image-service.yml
-  --file docker/openchallenges/services/kafka.yml
-  --file docker/openchallenges/services/mariadb.yml
-  --file docker/openchallenges/services/mcp-server.yml
-  --file docker/openchallenges/services/organization-service.yml
-  --file docker/openchallenges/services/service-registry.yml
-  --file docker/openchallenges/services/thumbor.yml
-  --file docker/openchallenges/services/zipkin.yml
+  --file docker/"$product_name"/services/apex.yml
+  --file docker/"$product_name"/services/api-docs.yml
+  --file docker/"$product_name"/services/api-gateway.yml
+  --file docker/"$product_name"/services/app.yml
+  --file docker/"$product_name"/services/challenge-service.yml
+  --file docker/"$product_name"/services/config-server.yml
+  --file docker/"$product_name"/services/data-lambda.yml
+  --file docker/"$product_name"/services/edam-etl.yml
+  --file docker/"$product_name"/services/elasticsearch.yml
+  --file docker/"$product_name"/services/image-service.yml
+  --file docker/"$product_name"/services/kafka.yml
+  --file docker/"$product_name"/services/mariadb.yml
+  --file docker/"$product_name"/services/mcp-server.yml
+  --file docker/"$product_name"/services/organization-service.yml
+  --file docker/"$product_name"/services/service-registry.yml
+  --file docker/"$product_name"/services/thumbor.yml
+  --file docker/"$product_name"/services/zipkin.yml
 
-  --file docker/openchallenges/networks.yml
-  --file docker/openchallenges/volumes.yml
+  --file docker/"$product_name"/networks.yml
+  --file docker/"$product_name"/volumes.yml
 
-  --project-name openchallenges
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/openchallenges/serve.sh
+++ b/docker/openchallenges/serve.sh
@@ -7,6 +7,8 @@ args=(
   --file docker/openchallenges/networks.yml
   --file docker/openchallenges/volumes.yml
 
+  --project-name openchallenges
+
   up $1
 )
 

--- a/docker/openchallenges/serve.sh
+++ b/docker/openchallenges/serve.sh
@@ -7,7 +7,7 @@ args=(
   --file docker/openchallenges/networks.yml
   --file docker/openchallenges/volumes.yml
 
-  up $1 --remove-orphans
+  up $1
 )
 
 docker compose "${args[@]}"

--- a/docker/openchallenges/serve.sh
+++ b/docker/openchallenges/serve.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+product_name="openchallenges"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/openchallenges/services/data-lambda.yml
+  --file docker/"$product_name"/services/data-lambda.yml
 
-  --file docker/openchallenges/networks.yml
-  --file docker/openchallenges/volumes.yml
+  --file docker/"$product_name"/networks.yml
+  --file docker/"$product_name"/volumes.yml
 
-  --project-name openchallenges
+  --project-name "$product_name"
 
   up $1
 )

--- a/docker/sage/serve-detach.sh
+++ b/docker/sage/serve-detach.sh
@@ -6,6 +6,8 @@ args=(
 
   --file docker/sage/networks.yml
 
+  --project-name sage
+
   up $1 --detach
 )
 

--- a/docker/sage/serve-detach.sh
+++ b/docker/sage/serve-detach.sh
@@ -6,7 +6,7 @@ args=(
 
   --file docker/sage/networks.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/sage/serve-detach.sh
+++ b/docker/sage/serve-detach.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
+product_name="sage"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/sage/services/otel-collector.yml
+  --file docker/"$product_name"/services/otel-collector.yml
 
-  --file docker/sage/networks.yml
+  --file docker/"$product_name"/networks.yml
 
-  --project-name sage
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/sandbox/serve-detach.sh
+++ b/docker/sandbox/serve-detach.sh
@@ -7,6 +7,8 @@ args=(
   --file docker/sandbox/networks.yml
   --file docker/sandbox/volumes.yml
 
+  --project-name sandbox
+
   up $1 --detach
 )
 

--- a/docker/sandbox/serve-detach.sh
+++ b/docker/sandbox/serve-detach.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+product_name="sandbox"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/sandbox/services/lambda-nodejs.yml
+  --file docker/"$product_name"/services/lambda-nodejs.yml
 
-  --file docker/sandbox/networks.yml
-  --file docker/sandbox/volumes.yml
+  --file docker/"$product_name"/networks.yml
+  --file docker/"$product_name"/volumes.yml
 
-  --project-name sandbox
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/sandbox/serve-detach.sh
+++ b/docker/sandbox/serve-detach.sh
@@ -7,7 +7,7 @@ args=(
   --file docker/sandbox/networks.yml
   --file docker/sandbox/volumes.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/sandbox/serve.sh
+++ b/docker/sandbox/serve.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+product_name="sandbox"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/sandbox/services/lambda-nodejs.yml
+  --file docker/"$product_name"/services/lambda-nodejs.yml
 
-  --file docker/sandbox/networks.yml
-  --file docker/sandbox/volumes.yml
+  --file docker/"$product_name"/networks.yml
+  --file docker/"$product_name"/volumes.yml
 
-  --project-name sandbox
+  --project-name "$product_name"
 
   up $1
 )

--- a/docker/sandbox/serve.sh
+++ b/docker/sandbox/serve.sh
@@ -7,7 +7,7 @@ args=(
   --file docker/sandbox/networks.yml
   --file docker/sandbox/volumes.yml
 
-  up $1 --remove-orphans
+  up $1
 )
 
 docker compose "${args[@]}"

--- a/docker/sandbox/serve.sh
+++ b/docker/sandbox/serve.sh
@@ -7,6 +7,8 @@ args=(
   --file docker/sandbox/networks.yml
   --file docker/sandbox/volumes.yml
 
+  --project-name sandbox
+
   up $1
 )
 

--- a/docker/synapse/serve-detach.sh
+++ b/docker/synapse/serve-detach.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
+product_name="synapse"
+
 args=(
   # List of services in alphanumeric order
-  --file docker/synapse/services/api-docs.yml
+  --file docker/"$product_name"/services/api-docs.yml
 
-  --file docker/synapse/networks.yml
+  --file docker/"$product_name"/networks.yml
 
-  --project-name sandbox
+  --project-name "$product_name"
 
   up $1 --detach
 )

--- a/docker/synapse/serve-detach.sh
+++ b/docker/synapse/serve-detach.sh
@@ -6,7 +6,7 @@ args=(
 
   --file docker/synapse/networks.yml
 
-  up $1 --detach --remove-orphans
+  up $1 --detach
 )
 
 docker compose "${args[@]}"

--- a/docker/synapse/serve-detach.sh
+++ b/docker/synapse/serve-detach.sh
@@ -6,6 +6,8 @@ args=(
 
   --file docker/synapse/networks.yml
 
+  --project-name sandbox
+
   up $1 --detach
 )
 


### PR DESCRIPTION
## Related Issues

- https://sagebionetworks.jira.com/browse/SMR-150

## Changelog

- Remove `--remove-orphans` from Docker Compose files.
- Add `--project-name {project-name}` to Docker Compose files.
- Parametrize the product name in Docker Compose files.

## Preview

The containers will appeared grouped by product/stack name in the Containers Tool extension for VS Code:

<img width="571" alt="image" src="https://github.com/user-attachments/assets/b093f3d0-477a-4af6-9d01-48898e6ed76d" />

Before this PR, starting a stack with `nx serve-detach` would stop any containers that had been started with `nx serve-detach`. For example:

```console
$ nx serve-detach observability-tempo

> nx run observability-tempo:serve-detach

> docker/observability/serve-detach.sh observability-tempo

[+] Running 7/7
 ✔ Container agora-mongo          Removed                                                                                                       1.0s 
 ✔ Container agora-apex           Removed                                                                                                       0.6s 
 ✔ Container agora-data           Removed                                                                                                       0.2s 
 ✔ Container agora-api            Removed                                                                                                      10.7s 
 ✔ Container agora-app            Removed                                                                                                      10.8s 
 ✔ Container agora-api-docs       Removed                                                                                                       0.8s 
 ✔ Container observability-tempo  Started
```

After merging this PR, starting a stack with `nx serve-detach` will no longer stop containers.

```console
$ nx serve-detach agora-apex && nx serve-detach amp-als-apex

> nx run agora-apex:serve-detach

> docker/agora/serve-detach.sh agora-apex

[+] Running 0/1
 ⠋ Network agora  Creating                                                                                                                      0.1s 
[+] Running 7/7me "agora-mongo-data" already exists but was created for project "services" (expected "agora"). Use `external: true` to use an existin
 ✔ Network agora             Created                                                                                                            0.2s 
 ✔ Container agora-api-docs  Healthy                                                                                                           77.4s 
 ✔ Container agora-mongo     Started                                                                                                            1.1s 
 ✔ Container agora-data      Exited                                                                                                            76.1s 
 ✔ Container agora-api       Healthy                                                                                                           77.4s 
 ✔ Container agora-app       Healthy                                                                                                           82.3s 
 ✔ Container agora-apex      Started                                                                                                           83.1s 

————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target serve-detach for project agora-apex (1m)


 NX   Nx detected a flaky task

  agora-apex:serve-detach

Flaky tasks can disrupt your CI pipeline. Automatically retry them with Nx Cloud. Learn more at https://nx.dev/ci/features/flaky-tasks


> nx run amp-als-apex:serve-detach

> docker/amp-als/serve-detach.sh amp-als-apex

[+] Running 6/6
 ✔ Network amp-als                    Created                                                                                                   0.2s 
 ✔ Container amp-als-mariadb          Healthy                                                                                                  31.6s 
 ✔ Container amp-als-api-docs         Healthy                                                                                                  32.9s 
 ✔ Container amp-als-opensearch       Healthy                                                                                                  28.6s 
 ✔ Container amp-als-dataset-service  Started                                                                                                  32.3s 
 ✔ Container amp-als-apex             Started                                                                                                  33.6s 

————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target serve-detach for project amp-als-apex (34s)
```

List of containers:

```console
$ docker ps --format '{{.Names}}'
amp-als-apex
amp-als-dataset-service
amp-als-api-docs
amp-als-opensearch
amp-als-mariadb
agora-apex
agora-app
agora-api
agora-api-docs
agora-mongo
```