### PR TITLE
docs(observability,agora): show how to use Profiles data in Grafana to streamline GCT endpoint implementation

### DIFF
--- a/apps/agora/gene-api/src/main/java/org/sagebionetworks/agora/gene/api/service/GCTGenesService.java
+++ b/apps/agora/gene-api/src/main/java/org/sagebionetworks/agora/gene/api/service/GCTGenesService.java
@@ -167,7 +167,6 @@ public class GCTGenesService {
       );
   }
 
-  // 2.23 mins spent in this function
   private GCTGeneDto getComparisonGene(
     GeneDocument gene,
     List<TeamDocument> teams,

--- a/apps/agora/gene-api/src/main/java/org/sagebionetworks/agora/gene/api/service/GCTGenesService.java
+++ b/apps/agora/gene-api/src/main/java/org/sagebionetworks/agora/gene/api/service/GCTGenesService.java
@@ -89,6 +89,17 @@ public class GCTGenesService {
       List<OverallScoresDocument> scores = overallScoresRepository.findAll();
       List<BioDomainsDocument> allBiodomains = bioDomainsRepository.findAll();
 
+      Map<String, BioDomainsDocument> biodomainByGeneId = allBiodomains
+        .stream()
+        .filter(b -> b.getEnsemblGeneId() != null)
+        .collect(
+          Collectors.toMap(
+            BioDomainsDocument::getEnsemblGeneId,
+            b -> b,
+            (existing, replacement) -> replacement // in case of duplicates
+          )
+        );
+
       for (RnaDifferentialExpressionDocument exp : differentialExpression) {
         String ensemblGeneId = exp.getEnsemblGeneId();
         if (!genes.containsKey(ensemblGeneId)) {
@@ -101,7 +112,7 @@ public class GCTGenesService {
           }
 
           // Compute the GCTGeneDto and add it to the genes list
-          genes.put(ensemblGeneId, getComparisonGene(gene, teams, scores, allBiodomains));
+          genes.put(ensemblGeneId, getComparisonGene(gene, teams, scores, biodomainByGeneId));
         }
 
         // Add tissue data to the gene
@@ -142,26 +153,33 @@ public class GCTGenesService {
       );
   }
 
+  private boolean isSameEnsemblGeneIdForScores(OverallScoresDocument s, GeneDocument gene) {
+    return s.getEnsemblGeneId().equals(gene.getEnsemblGeneId());
+  }
+
+  // private boolean isSameEnsemblGeneIdForBiodomains(BioDomainsDocument b, GeneDocument gene) {
+  //   return b.getEnsemblGeneId().equals(gene.getEnsemblGeneId());
+  // }
+
+  // 2.23 mins spent in this function
   private GCTGeneDto getComparisonGene(
     GeneDocument gene,
     List<TeamDocument> teams,
     List<OverallScoresDocument> scores,
-    List<BioDomainsDocument> allBiodomains
+    Map<String, BioDomainsDocument> biodomainByGeneId
   ) {
     // Find scores for this gene
     OverallScoresDocument geneScores = scores
       .stream()
-      .filter(s -> s.getEnsemblGeneId().equals(gene.getEnsemblGeneId()))
+      .filter(s -> isSameEnsemblGeneIdForScores(s, gene))
       .findFirst()
       .orElse(null);
 
     // Find biodomains for this gene
-    List<String> geneBiodomains = allBiodomains
-      .stream()
-      .filter(b -> b.getEnsemblGeneId().equals(gene.getEnsemblGeneId()))
-      .findFirst()
-      .map(b -> b.getGeneBioDomains().stream().map(BioDomainDocument::getBioDomain).toList())
-      .orElse(null);
+    BioDomainsDocument bioDomainsDoc = biodomainByGeneId.get(gene.getEnsemblGeneId());
+    List<String> geneBiodomains = bioDomainsDoc != null
+      ? bioDomainsDoc.getGeneBioDomains().stream().map(BioDomainDocument::getBioDomain).toList()
+      : null;
 
     // TODO: Remove after changing the type of associations in the API description
     List<BigDecimal> associations = getComparisonGeneAssociations(gene)


### PR DESCRIPTION
## Changelog

- Replace two full scans by maps for fast O(1) lookups.
- Document the process of using profiling data in Grafana to optimize execution time in Java code.

## Preview

The initial (quasi) rewrite of the Gene Comparison Tool (GCT) endpoint for RNA took 1.98 minutes to execute its main function `getComparisonGenes`. This is illustrated in the [flame graph](https://github.com/brendangregg/FlameGraph) below, which was captured using Pyroscope and visualized in Grafana.

![image](https://github.com/user-attachments/assets/eaa9cf3a-85ce-4fa1-a37c-8070a134a008)

A previous version of this view revealed that most of the execution time was spent in Java lambdas. Since several lambdas were used within the same function, Grafana displayed a generic name for their execution, making it difficult to correlate the profiling data with the specific Java stream calls. This issue can be resolved by extracting inline lambdas into named functions (see Files changed). Once named, the functions appear in the flame graph, such as in the tooltip shown above, providing clearer insight into performance bottlenecks.

One invocation of the GCT endpoint spent 42 seconds executing the lambda function shown in the tooltip, making it the most time-consuming of all the lambdas and the primary candidate for optimization. Rather than performing full scans of the BioDomains for each gene, a more efficient strategy was implemented: building a map once and using it for subsequent fast O(1) lookups. This optimization reduced the total execution time of the `getComparisonGenes` function from approximately 2 minutes to 53 seconds (see screenshot below). Note that this reflects a single measurement, and some variability or inaccuracy may be present.

![image](https://github.com/user-attachments/assets/dbd97f55-32d4-443f-81ad-d6862c11fdac)

We apply the same approach to the second full scan:

![image](https://github.com/user-attachments/assets/48faa6f7-3e31-47e5-be2b-d5bf8abedd68)

A single execution of the `getComparisonGenes` function now takes approximately 18 seconds.

![image](https://github.com/user-attachments/assets/0591b6ce-9b13-4d58-ad0f-c29f5f2b4197)

Of this, 11 seconds are consumed by a database call, followed by an additional 5 seconds spent constructing a map of genes from the returned objects. While further optimizations, such as caching, are possible, they are beyond the scope of this demonstration. Still, this optimization represents a significant step forward—one made possible through insights gained from Profiles data available in Grafana.

