### PR TITLE
fix(openchallenges): ignore challenges with missing status

### DIFF
--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -57,7 +57,7 @@ def get_challenge_data(wks, sheet_name="challenges"):
             "created_at",
             "updated_at",
         ]
-    ]
+    ].dropna(subset=["status"])  # Remove rows where status is missing.
     challenges = (
         challenges.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
         .replace(r"\n", " ", regex=True)


### PR DESCRIPTION
Related to #3198 , in that some challenges included in the dump file lack a status. Since `status` can only be one of: [`active`, `upcoming`, `closed`], having `status = ""` will cause an error in the OC app (as we have previously seen in SMR-124).

This PR will address the need of excluding any challenges with missing statuses from the dump file.