### PR TITLE
fix(openchallenges): filter `challenges` by non-empty string status

### DIFF
--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -39,7 +39,8 @@ def get_challenge_data(wks, sheet_name="challenges"):
     df = pd.DataFrame(wks.worksheet(sheet_name).get_all_records()).fillna("")
     df.loc[df._platform == "Other", "platform"] = "\\N"
 
-    challenges = df[
+    # Only keep challenges with a defined status.
+    challenges = df[df["status"] != ""][
         [
             "id",
             "slug",
@@ -57,7 +58,7 @@ def get_challenge_data(wks, sheet_name="challenges"):
             "created_at",
             "updated_at",
         ]
-    ].dropna(subset=["status"])  # Remove rows where status is missing.
+    ]
     challenges = (
         challenges.replace({r"\s+$": "", r"^\s+": ""}, regex=True)
         .replace(r"\n", " ", regex=True)


### PR DESCRIPTION
Previous fix suggestion (#3200 ) handled the incorrect use-case: `status == None`

But the one we want is: `status == ""`

Verified that the tests passed this time 😅 

```
$ pytest test_update_db_csv.py 
========================================================================= test session starts =========================================================================
collected 5 items                                                                                                                                                     

scripts/test_update_db_csv.py .....                                                                                                                             [100%]

========================================================================== 5 passed in 0.79s ==========================================================================
```