### PR TITLE
fix(openchallenges): update regex so that plot generation will update again

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
@@ -29,7 +29,8 @@ public class ChallengeAnalyticsService {
       "2021",
       "2022",
       "2023",
-      "2024"
+      "2024",
+      "2025"
     );
 
     // The following line will be auto-updated by a script and should NOT be modified manually.

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
@@ -35,24 +35,25 @@ public class ChallengeAnalyticsService {
 
     // The following line will be auto-updated by a script and should NOT be modified manually.
     List<Integer> challengeCounts = /* AUTO-UPDATE MARKER */Arrays.asList(
-      6,
-      9,
-      13,
+      11,
       17,
-      23,
-      29,
+      25,
       34,
-      41,
-      49,
-      59,
-      86,
-      97,
-      116,
-      135,
-      183,
-      242,
-      306,
-      344
+      45,
+      53,
+      61,
+      73,
+      85,
+      100,
+      138,
+      154,
+      177,
+      202,
+      253,
+      315,
+      385,
+      449,
+      474
     );
     Integer undatedChallengeCount = 171;
 

--- a/apps/openchallenges/db-update/update_db_csv.py
+++ b/apps/openchallenges/db-update/update_db_csv.py
@@ -12,7 +12,7 @@ PLOT_FILE = (
     "apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/"
     "openchallenges/challenge/service/service/ChallengeAnalyticsService.java"
 )
-UPDATE_MARKER = r"(\/\* AUTO-UPDATE MARKER \*\/\s+)"  # capture as a group to preserve
+UPDATE_MARKER = r"(\/\* AUTO-UPDATE MARKER \*\/\s?)"  # capture as a group to preserve
 
 
 def output_csv(df, output_filename, output_folder="", print_row=False):
@@ -248,7 +248,7 @@ def main(gc):
     with open(PLOT_FILE, "r", encoding="utf-8") as file:
         curr_content = file.read()
     updated_content = re.sub(
-        UPDATE_MARKER + r"Arrays.asList\([\d, ]+\);",
+        UPDATE_MARKER + r"Arrays.asList\([\d, \n]+\);",
         r"\1" + updated_plot_numbers,  # replace but keep reserved group (\1)
         curr_content,
     )


### PR DESCRIPTION
I just noticed today that the Java file generating the challenges plot on our landing page wasn't getting updated with the `db-update` PRs.  Looking into it a bit, I found that the existing regex no longer matched the file now that it's in Prettier format, which prevented the proper updates.

## Changelog
* regex has been updated to match both non-Prettier and Prettier format
*  counts for `challengeCounts` has been updated (this is a one-time thing; it should now auto-update again with the future `db-update` PRs)
* add "2025" to the list of challenge years

## Preview

**Before**
![Screenshot 2025-05-28 at 2 53 38 PM](https://github.com/user-attachments/assets/d9299ccb-f0ce-4425-a14c-fd965d5a906b)

**After**
![Screenshot 2025-05-28 at 2 49 58 PM](https://github.com/user-attachments/assets/4e2f09f5-4ac1-45db-9dee-0b4784deb52d)

