### PR TITLE
fix(agora): upload data logs when step times out (AG-1800)

### DIFF
--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -126,11 +126,29 @@ jobs:
           fi
 
       - name: Start Explorer
+        id: start-explorer
+        timeout-minutes: 40
         env:
           cmd: 'nx run ${{ inputs.explorer }}-apex:serve-detach'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"
+
+      - name: Write out Explorer data logs
+        if: ${{ failure() }}
+        env:
+          cmd: 'docker logs ${{ inputs.explorer }}-data > data-logs.txt'
+        run: |
+          devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
+              && ${cmd}"
+
+      - name: Upload Explorer data logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'data-logs-${{ inputs.explorer }}'
+          path: data-logs.txt
+          retention-days: 5
 
       - name: Run Explorer e2e tests
         env:
@@ -145,7 +163,7 @@ jobs:
               && workspace-docker-stop"
 
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.start-explorer.conclusion != 'failure' }}
         with:
           name: 'playwright-report-${{ inputs.explorer }}'
           path: playwright-report/

--- a/libs/agora/storybook/project.json
+++ b/libs/agora/storybook/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "libs/agora/storybook/src",
   "prefix": "agora",
   "projectType": "library",
-  "tags": [],
+  "tags": ["type:docs", "scope:agora", "language:typescript"],
   "targets": {
     "lint": {
       "executor": "@nx/eslint:lint"


### PR DESCRIPTION
## Description

The Agora e2e tests have been timing out on the "Start Explorer" step. We would like to upload logs to help us debug.

## Related ticket

- [AG-1800](https://sagebionetworks.jira.com/browse/AG-1800)

## Changelog

- Add a timeout to the "Start Explorer" step, so that subsequent steps can run before hitting the job's overall timeout
- Attach logs from data service as an artifact on failure
- Make a minimal change to an Agora library, so that Agora is affected on this PR