### PR TITLE
feat(observability): configure Grafana data sources using a YAML configuration file (SMR-156)

### DIFF
--- a/apps/observability/grafana/datasources/datasources.yml
+++ b/apps/observability/grafana/datasources/datasources.yml
@@ -1,0 +1,28 @@
+apiVersion: 1
+
+datasources:
+  - name: Grafana Pyroscope
+    type: grafana-pyroscope-datasource
+    url: http://observability-pyroscope:8511
+    jsonData:
+      minStep: '15s'
+    editable: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://observability-loki:8503
+    editable: true
+
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://observability-prometheus:8502
+    isDefault: true
+    editable: true
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://observability-tempo:8505
+    editable: true

--- a/apps/observability/grafana/datasources/datasources.yml
+++ b/apps/observability/grafana/datasources/datasources.yml
@@ -1,13 +1,6 @@
 apiVersion: 1
 
 datasources:
-  - name: Grafana Pyroscope
-    type: grafana-pyroscope-datasource
-    url: http://observability-pyroscope:8511
-    jsonData:
-      minStep: '15s'
-    editable: true
-
   - name: Loki
     type: loki
     access: proxy
@@ -19,6 +12,13 @@ datasources:
     access: proxy
     url: http://observability-prometheus:8502
     isDefault: true
+    editable: true
+
+  - name: Pyroscope
+    type: grafana-pyroscope-datasource
+    url: http://observability-pyroscope:8511
+    jsonData:
+      minStep: '15s'
     editable: true
 
   - name: Tempo

--- a/docker/observability/services/grafana.yml
+++ b/docker/observability/services/grafana.yml
@@ -7,6 +7,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SERVER_HTTP_PORT=8501
+    volumes:
+      - ../../../apps/observability/grafana/datasources:/etc/grafana/provisioning/datasources:ro
     networks:
       - observability
     ports:


### PR DESCRIPTION
## Description

Configure Grafana data sources for Loki, Tempo, Prometheus and Pyroscope in Grafana using a YAML config file.

## Related Issues

- [SMR-156](https://sagebionetworks.jira.com/browse/SMR-156)

## Changelog

- Configure Grafana data sources using a YAML configuration file.

[SMR-156]: https://sagebionetworks.jira.com/browse/SMR-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Validation

1. Build and start the observability stack:
      ```bash
      observability-build-images
      observability-docker-start
      ```
2. In a browser, navigate to the Grafana web UI at http://localhost:8501.
3. Log in using the default credentials: admin / admin.
4. Click Skip to bypass setting new credentials.
5. In the left-hand menu, go to Connections > Data sources.
6. You should see data sources listed for Pyroscope, Loki, Prometheus, and Tempo.
7. Test each data source:
      - Click on a data source.
      - Scroll to the bottom of its configuration page.
      - Click Save and test.
      - Ensure that the message "Data source is working" appears.