### PR TITLE
feat(model-ad): add panel navigation tabs to model details (MG-244)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('model details', () => {
+  test('invalid model results in a 404 redirect', async ({ page }) => {
+    await page.goto('/models/DOES-NOT-EXIST');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+      ` This page isn't available right now. `,
+    );
+  });
+
+  test('valid model displays model name', async ({ page }) => {
+    await page.goto('/models/APOE4');
+    await expect(page.getByRole('heading', { level: 1, name: 'APOE4' })).toBeVisible();
+  });
+
+  test('default tab is omics', async ({ page }) => {
+    await page.goto('/models/APOE4');
+    await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
+  });
+
+  test('correct tab is loaded from url', async ({ page }) => {
+    await page.goto('/models/3xTg-AD/biomarkers');
+    await expect(page.getByRole('heading', { level: 2, name: 'Biomarkers' })).toBeVisible();
+  });
+
+  test('clicking on a tab updates url and displays correct content', async ({ page }) => {
+    const modelPath = '/models/3xTg-AD';
+    await page.goto(modelPath);
+
+    const biomarkersTab = page.getByRole('button', { name: 'Biomarkers' });
+    await biomarkersTab.click();
+    await page.waitForURL(`${modelPath}/biomarkers`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Biomarkers' })).toBeVisible();
+
+    const pathologyTab = page.getByRole('button', { name: 'Pathology' });
+    await pathologyTab.click();
+    await page.waitForURL(`${modelPath}/pathology`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Pathology' })).toBeVisible();
+
+    const resourcesTab = page.getByRole('button', { name: 'Resources' });
+    await resourcesTab.click();
+    await page.waitForURL(`${modelPath}/resources`);
+    await expect(
+      page.getByRole('heading', { level: 2, name: 'Model-Specific Resources' }),
+    ).toBeVisible();
+
+    const omicsTab = page.getByRole('button', { name: 'Omics' });
+    await omicsTab.click();
+    await page.waitForURL(`${modelPath}/omics`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
+  });
+});

--- a/apps/model-ad/app/playwright.config.ts
+++ b/apps/model-ad/app/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     url: `${baseURL}/health`,
     reuseExistingServer: !process.env['CI'],
     cwd: workspaceRoot,
-    timeout: 60000 * 3, // give time for agora-data to populate agora-mongo
+    timeout: 60000 * 3, // give time for model-ad-data to populate model-ad-mongo
   },
   projects: [
     {

--- a/apps/model-ad/app/src/app/app.routes.ts
+++ b/apps/model-ad/app/src/app/app.routes.ts
@@ -83,6 +83,16 @@ export const routes: Route[] = [
     },
   },
   {
+    path: 'models/:model/:tab',
+    loadChildren: () =>
+      import('@sagebionetworks/model-ad/model-details').then((routes) => routes.routes),
+  },
+  {
+    path: 'models/:model/:tab/:subtab',
+    loadChildren: () =>
+      import('@sagebionetworks/model-ad/model-details').then((routes) => routes.routes),
+  },
+  {
     path: 'terms-of-service',
     loadChildren: () =>
       import('@sagebionetworks/explorers/shared').then((routes) => routes.termsOfServiceRoute),

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="39"
+DATA_VERSION="57"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/libs/explorers/models/src/index.ts
+++ b/libs/explorers/models/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/loading-icon-colors';
 export * from './lib/navigation-link';
+export * from './lib/panel';
 export * from './lib/results-list';
 export * from './lib/synapse-wiki';
 export * from './lib/terms-of-use-info';

--- a/libs/explorers/models/src/lib/panel.ts
+++ b/libs/explorers/models/src/lib/panel.ts
@@ -1,0 +1,6 @@
+export interface Panel {
+  name: string; // Unique identifier for the panel
+  label: string; // Display name shown in the UI
+  disabled: boolean; // Flag to enable/disable panel
+  children?: Panel[]; // Optional sub-panels for hierarchical navigation
+}

--- a/libs/explorers/services/src/index.ts
+++ b/libs/explorers/services/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/helper.service';
 export * from './lib/meta-tag.service';
 export * from './lib/svg-icon.service';
 export * from './lib/synapse-api.service';

--- a/libs/explorers/services/src/lib/helper.service.spec.ts
+++ b/libs/explorers/services/src/lib/helper.service.spec.ts
@@ -1,0 +1,37 @@
+import { HelperService } from './helper.service';
+
+describe('Service: Helper', () => {
+  let helperService: HelperService;
+
+  beforeEach(async () => {
+    helperService = new HelperService();
+  });
+
+  it('should create', () => {
+    expect(helperService).toBeDefined();
+  });
+
+  it('should get scroll top', () => {
+    const res = helperService.getScrollTop();
+    expect(res).toEqual({ x: 0, y: 0 });
+  });
+
+  it('should get offset', () => {
+    const res = helperService.getOffset('');
+    expect(res).toEqual({ top: 0, left: 0 });
+  });
+
+  it('should construct url for panel with parent', () => {
+    const url = '/genes/ENSG123';
+    const expected = '/genes/ENSG123/evidence/rna';
+    const result = helperService.getPanelUrl(url, 'rna', 'evidence');
+    expect(result).toEqual(expected);
+  });
+
+  it('should construct url for panel without parent', () => {
+    const url = '/genes/ENSG123';
+    const expected = '/genes/ENSG123/summary';
+    const result = helperService.getPanelUrl(url, 'summary', '');
+    expect(result).toEqual(expected);
+  });
+});

--- a/libs/explorers/services/src/lib/helper.service.ts
+++ b/libs/explorers/services/src/lib/helper.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+import { Panel } from '@sagebionetworks/explorers/models';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HelperService {
+  getScrollTop() {
+    if (typeof window === 'undefined' || typeof document == 'undefined') {
+      return { x: 0, y: 0 };
+    }
+
+    const supportPageOffset = window.pageXOffset !== undefined;
+    const isCSS1Compat = (document.compatMode || '') === 'CSS1Compat';
+
+    if (supportPageOffset) {
+      return {
+        x: window.pageXOffset,
+        y: window.pageYOffset,
+      };
+    } else if (isCSS1Compat) {
+      return {
+        x: document.documentElement.scrollLeft,
+        y: document.documentElement.scrollTop,
+      };
+    } else {
+      return {
+        x: document.body.scrollLeft,
+        y: document.body.scrollTop,
+      };
+    }
+  }
+
+  getOffset(el: any) {
+    if (typeof window === 'undefined' || typeof document === 'undefined' || !el) {
+      return { top: 0, left: 0 };
+    }
+
+    const rect = el.getBoundingClientRect();
+    const scroll = this.getScrollTop();
+    return {
+      top: rect.top + scroll.y,
+      left: rect.left + scroll.x,
+    };
+  }
+
+  getPanelUrl(basePath: string, activePanel: string, activeParent: string) {
+    const panelPath = activeParent === '' ? activePanel : `${activeParent}/${activePanel}`;
+    return `${basePath}/${panelPath}`;
+  }
+
+  getActivePanelAndParent(
+    panels: Panel[],
+    panel: Panel,
+  ): { activePanel: string; activeParent: string } {
+    if (panel.children) {
+      return {
+        activePanel: panel.children[0].name,
+        activeParent: panel.name,
+      };
+    } else if (!panels.find((p: Panel) => p.name === panel.name)) {
+      const parent = panels.find((p: Panel) =>
+        p.children?.find((c: Panel) => c.name === panel.name),
+      );
+      return {
+        activePanel: panel.name,
+        activeParent: parent?.name ?? '',
+      };
+    } else {
+      return {
+        activePanel: panel.name,
+        activeParent: '',
+      };
+    }
+  }
+}

--- a/libs/explorers/styles/src/lib/_mixins.scss
+++ b/libs/explorers/styles/src/lib/_mixins.scss
@@ -35,12 +35,6 @@
   }
 }
 
-@mixin reset-ul() {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
 @mixin container($width: 'md') {
   max-width: var(--container-max-width-#{$width});
   padding-left: 0;

--- a/libs/explorers/styles/src/lib/_mixins.scss
+++ b/libs/explorers/styles/src/lib/_mixins.scss
@@ -35,6 +35,12 @@
   }
 }
 
+@mixin reset-ul() {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
 @mixin container($width: 'md') {
   max-width: var(--container-max-width-#{$width});
   padding-left: 0;

--- a/libs/explorers/ui/src/index.ts
+++ b/libs/explorers/ui/src/index.ts
@@ -2,6 +2,7 @@ export * from './lib/components/footer/footer.component';
 export * from './lib/components/header/header.component';
 export * from './lib/components/hero/hero.component';
 export * from './lib/components/home-card/home-card.component';
+export * from './lib/components/panel-navigation/panel-navigation.component';
 export * from './lib/components/resource-card/resource-card.component';
 export * from './lib/components/search-input/search-input.component';
 export * from './lib/components/svg-image/svg-image.component';

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.html
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.html
@@ -1,0 +1,61 @@
+<div class="panel-navigation" [ngClass]="{ 'has-active-child': activeParent() }">
+  <div class="panel-navigation-inner">
+    @if (navSlideIndex > 0) {
+      <button
+        class="panel-navigation-scroll panel-navigation-scroll-prev"
+        (click)="slideNavigation(-1)"
+      >
+        <fa-icon [icon]="faAngleLeft" />
+      </button>
+    }
+
+    <div class="panel-navigation-container">
+      <ul>
+        @for (item of panels(); track item.name) {
+          @if (!item.disabled) {
+            <li
+              class="panel-navigation-item"
+              [ngClass]="{
+                active: isPanelActive(item),
+              }"
+            >
+              <button (click)="onNavigationItemClick(item)">
+                {{ item.label }}
+                <span class="panel-navigation-icon"></span>
+              </button>
+
+              @if (item.children) {
+                <div class="panel-navigation-subnav">
+                  <ul>
+                    @for (subItem of item.children; track subItem.name) {
+                      @if (!subItem.disabled) {
+                        <li
+                          class="panel-navigation-subnav-item"
+                          [ngClass]="{ active: activePanel() === subItem.name }"
+                        >
+                          <button (click)="onNavigationItemClick(subItem)">
+                            {{ subItem.label }}
+                            <span class="panel-navigation-icon"></span>
+                          </button>
+                        </li>
+                      }
+                    }
+                  </ul>
+                </div>
+              }
+            </li>
+          }
+        }
+      </ul>
+    </div>
+
+    @if (navSlideIndex < getPanelCount() - 1) {
+      <button
+        class="panel-navigation-scroll panel-navigation-scroll-next"
+        (click)="slideNavigation(1)"
+      >
+        <fa-icon [icon]="faAngleRight" />
+      </button>
+    }
+  </div>
+</div>

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.scss
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.scss
@@ -56,8 +56,6 @@
   }
 
   ul {
-    @include mixins.reset-ul;
-
     display: flex;
     width: 100%;
     height: var(--panel-nav-height);

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.scss
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.scss
@@ -1,0 +1,193 @@
+/* stylelint-disable no-descending-specificity */
+
+@use 'libs/explorers/styles/src/lib/variables';
+@use 'libs/explorers/styles/src/lib/mixins';
+
+:host {
+  --panel-nav-height: 80px;
+  --panel-subnav-offset: -19px;
+  --panel-shadow: 0 4px 4px rgb(0 0 0 / 25%);
+}
+
+.panel-navigation {
+  position: relative;
+  height: var(--panel-nav-height);
+
+  button {
+    @include mixins.reset-button;
+
+    position: relative;
+    display: flex;
+    height: 100%;
+    padding: 8px 0;
+    font-size: var(--font-size-lg, 1.125rem);
+    font-weight: 700;
+    color: var(--color-text-secondary);
+    transition: var(--transition-duration);
+    align-items: center;
+    cursor: pointer;
+    white-space: nowrap;
+
+    &::after {
+      content: ' ';
+      position: absolute;
+      display: block;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 4px;
+      background-color: var(--color-action-primary);
+      border-radius: 2px;
+      opacity: 0;
+      visibility: hidden;
+      transition: var(--transition-duration);
+    }
+
+    &:not(.disabled) {
+      &:hover {
+        color: var(--color-action-primary);
+      }
+    }
+
+    &.disabled {
+      opacity: 0.3;
+      cursor: not-allowed;
+    }
+  }
+
+  ul {
+    @include mixins.reset-ul;
+
+    display: flex;
+    width: 100%;
+    height: var(--panel-nav-height);
+    align-items: center;
+    z-index: 50;
+
+    > li.active {
+      > button {
+        color: var(--color-action-primary);
+
+        &::after {
+          opacity: 1;
+          visibility: visible;
+        }
+      }
+    }
+  }
+
+  li {
+    padding: 0 30px;
+  }
+
+  .panel-navigation-inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 999;
+    background-color: #fff;
+    box-shadow: var(--panel-shadow);
+  }
+
+  .panel-navigation-subnav {
+    position: absolute;
+    height: var(--panel-nav-height);
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-top: var(--panel-subnav-offset);
+    background-color: var(--color-gray-100);
+    box-shadow: var(--panel-shadow);
+    opacity: 0;
+    visibility: hidden;
+
+    button {
+      &::after {
+        display: none;
+      }
+    }
+  }
+
+  .panel-navigation-scroll {
+    @include mixins.reset-button;
+
+    display: none;
+    position: absolute;
+    width: 50px;
+    top: 0;
+    height: var(--panel-nav-height);
+    align-items: center;
+    justify-content: center;
+    font-size: 22px;
+    color: var(--color-gray-600);
+    background-color: #fff;
+    z-index: 100;
+    cursor: pointer;
+
+    &.panel-navigation-scroll-prev {
+      left: 0;
+    }
+
+    &.panel-navigation-scroll-next {
+      right: 0;
+    }
+
+    &:hover {
+      color: var(--color-action-primary);
+    }
+  }
+
+  ul:not(.panel-navigation-subnav) > li.active {
+    .panel-navigation-subnav {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
+  &.sticky {
+    .panel-navigation-inner {
+      position: fixed;
+    }
+  }
+
+  &.has-active-child {
+    height: calc(var(--panel-nav-height) * 2 + var(--panel-subnav-offset));
+  }
+}
+
+.panel-navigation:not(.scrollable) {
+  ul {
+    margin-left: auto;
+    margin-right: auto;
+    justify-content: center;
+  }
+}
+
+.panel-navigation.scrollable {
+  --panel-nav-height: 60px;
+
+  user-select: none;
+
+  .panel-navigation-inner,
+  .panel-navigation-subnav {
+    padding-left: 50px;
+    padding-right: 50px;
+  }
+
+  .panel-navigation-container {
+    overflow: hidden;
+  }
+
+  .panel-navigation-scroll {
+    display: flex;
+  }
+
+  li {
+    padding: 0 20px;
+
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+}

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.spec.ts
@@ -1,0 +1,63 @@
+import { Panel } from '@sagebionetworks/explorers/models';
+import { HelperService } from '@sagebionetworks/explorers/services';
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { PanelNavigationComponent } from './panel-navigation.component';
+
+class MockHelperService {
+  getOffset = jest.fn().mockReturnValue({ top: 100 });
+}
+
+const panelChangeSpy = jest.fn();
+
+const panelsMock: Panel[] = [
+  { name: 'panel1', label: 'Panel1', disabled: false },
+  { name: 'panel2', label: 'Panel2', disabled: false },
+  { name: 'panel3', label: 'Panel3', disabled: true },
+];
+
+async function setup(panels: Panel[] = panelsMock, activePanel = 'panel1', activeParent = '') {
+  const user = userEvent.setup();
+  const component = await render(PanelNavigationComponent, {
+    providers: [{ provide: HelperService, useClass: MockHelperService }],
+    componentInputs: {
+      panels,
+      activePanel,
+      activeParent,
+    },
+    componentOutputs: {
+      panelChange: { emit: panelChangeSpy } as any,
+    },
+  });
+  return { component, user };
+}
+
+describe('PanelNavigationComponent', () => {
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit panelChange when clicking on a panel', async () => {
+    const { user } = await setup();
+    await user.click(screen.getByRole('button', { name: /panel2/i }));
+    expect(panelChangeSpy).toHaveBeenCalledWith(panelsMock[1]);
+  });
+
+  it('should hide disabled panels', async () => {
+    await setup();
+    expect(screen.getByRole('button', { name: /panel1/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /panel2/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /panel3/i })).not.toBeInTheDocument();
+  });
+
+  it('should display children panels', async () => {
+    const panelsMockWithChildren = [
+      { name: 'parent', label: 'Parent', disabled: false, children: panelsMock },
+    ];
+    await setup(panelsMockWithChildren, 'parent', '');
+    expect(screen.getByRole('button', { name: /parent/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /panel1/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /panel2/i })).toBeInTheDocument();
+  });
+});

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.spec.ts
@@ -33,6 +33,12 @@ async function setup(panels: Panel[] = panelsMock, activePanel = 'panel1', activ
 }
 
 describe('PanelNavigationComponent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
   it('should create', async () => {
     const { component } = await setup();
     expect(component).toBeTruthy();

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.stories.ts
@@ -1,0 +1,75 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { Panel } from '@sagebionetworks/explorers/models';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig } from '@storybook/angular';
+import { PanelNavigationComponent } from './panel-navigation.component';
+
+const meta: Meta<PanelNavigationComponent> = {
+  component: PanelNavigationComponent,
+  title: 'UI/PanelNavigationComponent',
+  decorators: [
+    applicationConfig({
+      providers: [provideRouter([]), provideHttpClient(withInterceptorsFromDi())],
+    }),
+  ],
+  argTypes: {
+    panelChange: { control: false },
+  },
+};
+export default meta;
+type Story = StoryObj<PanelNavigationComponent>;
+
+export const Demo: Story = {
+  args: {
+    panels: [
+      {
+        name: 'summary',
+        label: 'Summary',
+        disabled: false,
+      },
+      {
+        name: 'evidence',
+        label: 'Evidence',
+        disabled: false,
+        children: [
+          {
+            name: 'rna',
+            label: 'RNA',
+            disabled: false,
+          },
+          {
+            name: 'protein',
+            label: 'Protein',
+            disabled: false,
+          },
+          {
+            name: 'metabolomics',
+            label: 'Metabolomics',
+            disabled: false,
+          },
+        ],
+      },
+      {
+        name: 'resources',
+        label: 'Resources',
+        disabled: false,
+      },
+      {
+        name: 'nominations',
+        label: 'Nomination Details',
+        disabled: false,
+      },
+      {
+        name: 'experimental-validation',
+        label: 'Experimental Validation',
+        disabled: false,
+      },
+    ],
+    activePanel: 'summary',
+    activeParent: '',
+    panelChange: (panel: Panel) => {
+      console.log(panel);
+    },
+  },
+};

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.ts
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.ts
@@ -103,7 +103,7 @@ export class PanelNavigationComponent implements AfterViewInit, AfterViewChecked
     if (this.navSlideIndex < 0) {
       this.navSlideIndex = 0;
     } else if (this.navSlideIndex > this.getPanelCount() - 1) {
-      this.navSlideIndex = this.panels().length - 1;
+      this.navSlideIndex = this.getPanelCount() - 1;
     }
 
     const nav = document.querySelector<HTMLElement>('.panel-navigation');

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.ts
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.ts
@@ -1,0 +1,131 @@
+import { CommonModule } from '@angular/common';
+import {
+  AfterViewChecked,
+  AfterViewInit,
+  Component,
+  HostListener,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
+import { Panel } from '@sagebionetworks/explorers/models';
+import { HelperService } from '@sagebionetworks/explorers/services';
+
+@Component({
+  selector: 'explorers-panel-navigation',
+  standalone: true,
+  imports: [CommonModule, FontAwesomeModule],
+  templateUrl: './panel-navigation.component.html',
+  styleUrls: ['./panel-navigation.component.scss'],
+})
+export class PanelNavigationComponent implements AfterViewInit, AfterViewChecked {
+  helperService = inject(HelperService);
+
+  panels = input.required<Panel[]>();
+  activePanel = input.required<string>();
+  activeParent = input<string>('');
+  panelChange = output<Panel>();
+
+  faAngleRight = faAngleRight;
+  faAngleLeft = faAngleLeft;
+
+  private readonly DEFAULT_NAV_SLIDE_INDEX = 0;
+  navSlideIndex = this.DEFAULT_NAV_SLIDE_INDEX;
+
+  @HostListener('window:scroll', ['$event'])
+  onWindowScroll() {
+    const nav = document.querySelector<HTMLElement>('.panel-navigation');
+    const rect = nav?.getBoundingClientRect();
+
+    if (rect && rect.y <= 0) {
+      nav?.classList.add('sticky');
+    } else {
+      nav?.classList.remove('sticky');
+    }
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onWindowResize() {
+    const nav = document.querySelector<HTMLElement>('.panel-navigation');
+    const navContainer = nav?.querySelector<HTMLElement>('.panel-navigation-container');
+    const navList = nav?.querySelector<HTMLElement>('.panel-navigation-container > ul');
+    const navItems = nav?.querySelectorAll<HTMLElement>('.panel-navigation-container > ul > li');
+    let navItemsWidth = 0;
+    if (navItems) {
+      for (const element of Array.from(navItems)) {
+        navItemsWidth += element.offsetWidth;
+      }
+    }
+
+    if (navContainer && navList && navItemsWidth) {
+      if (navItemsWidth > navContainer.offsetWidth) {
+        nav?.classList.add('scrollable');
+      } else {
+        nav?.classList.remove('scrollable');
+        this.navSlideIndex = 0;
+        navList.style.marginLeft = '0px';
+      }
+    }
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => {
+      this.onWindowResize();
+    }, 100);
+  }
+
+  ngAfterViewChecked() {
+    this.onWindowResize();
+  }
+
+  activatePanel(panel: Panel) {
+    const nav = document.querySelector('.panel-navigation');
+    if (nav) {
+      window.scrollTo(0, this.helperService.getOffset(nav).top);
+    }
+
+    this.panelChange.emit(panel);
+  }
+
+  getPanelCount() {
+    return this.panels().filter((p: Panel) => !p.disabled).length;
+  }
+
+  onNavigationItemClick(panel: Panel) {
+    this.activatePanel(panel);
+  }
+
+  slideNavigation(direction: number) {
+    this.navSlideIndex += direction;
+
+    if (this.navSlideIndex < 0) {
+      this.navSlideIndex = 0;
+    } else if (this.navSlideIndex > this.getPanelCount() - 1) {
+      this.navSlideIndex = this.panels().length - 1;
+    }
+
+    const nav = document.querySelector<HTMLElement>('.panel-navigation');
+    const navList = nav?.querySelector<HTMLElement>('.panel-navigation-container > ul');
+    const navItems = nav?.querySelectorAll<HTMLElement>('.panel-navigation-container > ul > li');
+
+    if (navList && navItems) {
+      let navItemsWidth = 0;
+
+      for (let i = 0; i < this.navSlideIndex; ++i) {
+        navItemsWidth += navItems[i].offsetWidth;
+      }
+
+      if (this.navSlideIndex > 0) {
+        navItemsWidth += 20;
+      }
+
+      navList.style.marginLeft = navItemsWidth * -1 + 'px';
+    }
+  }
+
+  isPanelActive(panel: Panel): boolean {
+    return this.activePanel() === panel.name || this.activeParent() === panel.name;
+  }
+}

--- a/libs/model-ad/model-details/src/lib/model-details.component.html
+++ b/libs/model-ad/model-details/src/lib/model-details.component.html
@@ -1,4 +1,4 @@
-<div class="model-details">
+<div [class]="{ 'model-details': true, loading: isLoading }">
   @if (isLoading) {
     <div id="loading">
       <explorers-loading-icon />

--- a/libs/model-ad/model-details/src/lib/model-details.component.html
+++ b/libs/model-ad/model-details/src/lib/model-details.component.html
@@ -1,1 +1,31 @@
-<h1>Model-AD Model Details</h1>
+<div class="model-details">
+  @if (isLoading) {
+    <div id="loading">
+      <explorers-loading-icon />
+    </div>
+  } @else {
+    <h1>{{ model?.model }}</h1>
+    <explorers-panel-navigation
+      [panels]="panels"
+      (panelChange)="onPanelChange($event)"
+      [activePanel]="activePanel"
+      [activeParent]="activeParent"
+    />
+    <div class="panel-content">
+      @switch (activePanel) {
+        @case ('omics') {
+          <h2>Available Data</h2>
+        }
+        @case ('biomarkers') {
+          <h2>Biomarkers</h2>
+        }
+        @case ('pathology') {
+          <h2>Pathology</h2>
+        }
+        @case ('resources') {
+          <h2>Model-Specific Resources</h2>
+        }
+      }
+    </div>
+  }
+</div>

--- a/libs/model-ad/model-details/src/lib/model-details.component.scss
+++ b/libs/model-ad/model-details/src/lib/model-details.component.scss
@@ -3,6 +3,10 @@
 .model-details {
   min-height: calc(100vh - var(--header-height) - var(--footer-height));
 
+  &.loading {
+    display: flex;
+  }
+
   #loading {
     flex: 1 1 auto;
     display: flex;

--- a/libs/model-ad/model-details/src/lib/model-details.component.scss
+++ b/libs/model-ad/model-details/src/lib/model-details.component.scss
@@ -1,1 +1,12 @@
 @use 'styles/src/lib/variables';
+
+.model-details {
+  min-height: calc(100vh - var(--header-height) - var(--footer-height));
+
+  #loading {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
@@ -40,7 +40,7 @@ async function setup(model = modelMock, tab = 'omics', subtab = null, config = c
 describe('ModelDetailsComponent', () => {
   afterAll(() => jest.restoreAllMocks());
 
-  it('should display all model name', async () => {
+  it('should display the model name', async () => {
     await setup();
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(modelMock.model);
   });

--- a/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
@@ -1,20 +1,56 @@
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ModelsService } from '@sagebionetworks/model-ad/api-client-angular';
+import { modelMock } from '@sagebionetworks/model-ad/testing';
 import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { of } from 'rxjs';
 import { ModelDetailsComponent } from './model-details.component';
 
-async function setup() {
-  const result = await render(ModelDetailsComponent, {
+async function setup(model = modelMock, tab = 'omics', subtab = null) {
+  const user = userEvent.setup();
+
+  const mockActivatedRoute = {
+    paramMap: of(convertToParamMap({ model: model.model, tab: tab, subtab: subtab })),
+  };
+
+  const mockModelsService = {
+    getModelByName: jest.fn(() => of(model)),
+  };
+
+  const component = await render(ModelDetailsComponent, {
     imports: [],
-    providers: [],
+    providers: [
+      { provide: ModelsService, useValue: mockModelsService },
+      {
+        provide: ActivatedRoute,
+        useValue: mockActivatedRoute,
+      },
+    ],
   });
 
-  const fixture = result.fixture;
-  const component = fixture.componentInstance;
-  return { fixture, component };
+  return { user, component };
 }
 
 describe('ModelDetailsComponent', () => {
-  it('should create', async () => {
-    const { component } = await setup();
-    expect(component).toBeTruthy();
+  it('should display all model name', async () => {
+    await setup();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(modelMock.model);
+  });
+
+  it('should display all tabs for which the model has data', async () => {
+    await setup();
+    const tabs = ['Omics', 'Biomarkers', 'Pathology', 'Resources'];
+    for (const tab of tabs) {
+      expect(screen.getByText(tab)).toBeInTheDocument();
+    }
+  });
+
+  it('should hide tabs for which the model does not have data', async () => {
+    const modelWithoutOmics = { ...modelMock, biomarkers: [], pathology: [] };
+    await setup(modelWithoutOmics);
+    expect(screen.getByText('Omics')).toBeInTheDocument();
+    expect(screen.queryByText('Biomarkers')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pathology')).not.toBeInTheDocument();
+    expect(screen.getByText('Resources')).toBeInTheDocument();
   });
 });

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -70,9 +70,9 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
           .subscribe({
             next: (model: Model) => {
               this.panels.forEach((p: Panel) => {
-                if (p.name == 'biomarkers' && model.biomarkers.length == 0) {
+                if (p.name === 'biomarkers' && model.biomarkers.length === 0) {
                   p.disabled = true;
-                } else if (p.name == 'pathology' && model.pathology.length == 0) {
+                } else if (p.name === 'pathology' && model.pathology.length === 0) {
                   p.disabled = true;
                 } else {
                   p.disabled = false;

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -57,54 +57,63 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   ngOnInit() {
     this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params: ParamMap) => {
       this.isLoading = true;
-      if (this.configService.config.isPlatformServer) {
-        return;
-      }
 
-      const modelName = params.get('model');
-
-      if (modelName) {
-        this.modelsService
-          .getModelByName(modelName)
-          .pipe(takeUntilDestroyed(this.destroyRef))
-          .subscribe({
-            next: (model: Model) => {
-              this.panels.forEach((p: Panel) => {
-                if (p.name === 'biomarkers' && model.biomarkers.length === 0) {
-                  p.disabled = true;
-                } else if (p.name === 'pathology' && model.pathology.length === 0) {
-                  p.disabled = true;
-                } else {
-                  p.disabled = false;
-                }
-              });
-
-              this.model = model;
-              this.isLoading = false;
-            },
-            error: (error) => {
-              console.error('Error retrieving model: ', error);
-              this.isLoading = false;
-              this.router.navigateByUrl('/not-found', { skipLocationChange: true });
-            },
-          });
-      }
-
-      if (params.get('subtab')) {
-        this.activePanel = params.get('subtab') as string;
-        this.activeParent = params.get('tab') as string;
-      } else if (params.get('tab')) {
-        const panel = this.panels.find((p: Panel) => p.name === params.get('tab'));
-        if (panel) {
-          const { activePanel, activeParent } = this.helperService.getActivePanelAndParent(
-            this.panels,
-            panel,
-          );
-          this.activePanel = activePanel;
-          this.activeParent = activeParent;
-        }
+      // only fetch data during client hydration
+      if (!this.configService.config.isPlatformServer) {
+        this.loadPanelData(params);
+        this.setActivePanelAndParentFromUrl(params);
       }
     });
+  }
+
+  private loadPanelData(params: ParamMap) {
+    const modelName = params.get('model');
+    if (modelName) {
+      this.modelsService
+        .getModelByName(modelName)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (model: Model) => {
+            this.model = model;
+            this.updatePanelDisabledState();
+            this.isLoading = false;
+          },
+          error: (error) => {
+            console.error('Error retrieving model: ', error);
+            this.isLoading = false;
+            this.router.navigateByUrl('/not-found', { skipLocationChange: true });
+          },
+        });
+    }
+  }
+
+  private updatePanelDisabledState() {
+    this.panels.forEach((p: Panel) => {
+      if (p.name === 'biomarkers' && this.model?.biomarkers.length === 0) {
+        p.disabled = true;
+      } else if (p.name === 'pathology' && this.model?.pathology.length === 0) {
+        p.disabled = true;
+      } else {
+        p.disabled = false;
+      }
+    });
+  }
+
+  private setActivePanelAndParentFromUrl(params: ParamMap) {
+    if (params.get('subtab')) {
+      this.activePanel = params.get('subtab') as string;
+      this.activeParent = params.get('tab') as string;
+    } else if (params.get('tab')) {
+      const panel = this.panels.find((p: Panel) => p.name === params.get('tab'));
+      if (panel) {
+        const { activePanel, activeParent } = this.helperService.getActivePanelAndParent(
+          this.panels,
+          panel,
+        );
+        this.activePanel = activePanel;
+        this.activeParent = activeParent;
+      }
+    }
   }
 
   ngAfterViewInit() {

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -7,6 +7,7 @@ import { HelperService } from '@sagebionetworks/explorers/services';
 import { PanelNavigationComponent } from '@sagebionetworks/explorers/ui';
 import { LoadingIconComponent } from '@sagebionetworks/explorers/util';
 import { Model, ModelsService } from '@sagebionetworks/model-ad/api-client-angular';
+import { ConfigService } from '@sagebionetworks/model-ad/config';
 
 @Component({
   selector: 'model-ad-model-details',
@@ -21,6 +22,7 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   helperService = inject(HelperService);
   modelsService = inject(ModelsService);
   destroyRef = inject(DestroyRef);
+  configService = inject(ConfigService);
 
   isLoading = true;
 
@@ -55,6 +57,9 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   ngOnInit() {
     this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params: ParamMap) => {
       this.isLoading = true;
+      if (this.configService.config.isPlatformServer) {
+        return;
+      }
 
       const modelName = params.get('model');
 

--- a/libs/model-ad/testing/src/lib/mocks/config-mocks.ts
+++ b/libs/model-ad/testing/src/lib/mocks/config-mocks.ts
@@ -1,0 +1,14 @@
+import { AppConfig, Environment } from '@sagebionetworks/model-ad/config';
+
+export const configMock: AppConfig = {
+  apiDocsUrl: 'http://localhost:8000/api-docs',
+  appVersion: '1.0.0-beta',
+  csrApiUrl: 'http://localhost:4200/v1',
+  dataUpdatedOn: 'yyyy-mm-dd',
+  environment: Environment.Development,
+  googleTagManagerId: '',
+  ssrApiUrl: 'http://model-ad-api:3333/v1',
+  isPlatformServer: false,
+  privacyPolicyUrl: 'http://localhost:4200/privacy-policy',
+  termsOfUseUrl: 'http://localhost:4200/terms-of-use',
+};

--- a/libs/model-ad/testing/src/lib/mocks/index.ts
+++ b/libs/model-ad/testing/src/lib/mocks/index.ts
@@ -1,2 +1,3 @@
+export * from './config-mocks';
 export * from './dataversion-mocks';
 export * from './models-mocks';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -70,6 +70,7 @@
       "@sagebionetworks/model-ad/model-details": ["libs/model-ad/model-details/src/index.ts"],
       "@sagebionetworks/model-ad/not-found": ["libs/model-ad/not-found/src/index.ts"],
       "@sagebionetworks/model-ad/services": ["libs/model-ad/services/src/index.ts"],
+      "@sagebionetworks/model-ad/testing": ["libs/model-ad/testing/src/index.ts"],
       "@sagebionetworks/model-ad/util": ["libs/model-ad/util/src/index.ts"],
       "@sagebionetworks/openchallenges/about": ["libs/openchallenges/about/src/index.ts"],
       "@sagebionetworks/openchallenges/api-client-angular": [


### PR DESCRIPTION
## Description

Updates model details to include panel navigation tabs.

## Related Issue

- [MG-244](https://sagebionetworks.jira.com/browse/MG-244)

## Changelog

- Updates model details to include panel navigation tabs
- Adds shared panel navigation component, based on Agora's [gene-details component](https://github.com/Sage-Bionetworks/sage-monorepo/tree/main/libs/agora/genes/src/lib/components/gene-details)
- Adds shared helper service to support panel navigation component, based on Agora's [helper service](https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/libs/agora/services/src/lib/helper.service.ts)
- Updates model-details routes to allow URLs with `:tab` and `:subtab` parameters
- Adds model details e2e tests
- Updates `model-ad-data`'s `.env.example` to use a newer data version
- Adds missing path for `model-ad-testing` to `tsconfig.base.json`

## Validation

```
model-ad-build-images && model-ad-docker-start
```

Navigate to a model with all tabs: http://localhost:8000/models/3xTg-AD

https://github.com/user-attachments/assets/b54470da-6b7a-4902-b04e-0054b54800e2

Navigate to a model with some tabs disabled: http://localhost:8000/models/APOE4

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/d4467fd9-0d0f-43d7-8e91-1f9dbdcf90ef" />

Navigate to a model that doesn't exist: http://localhost:8000/models/DOES-NOT-EXIST

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/d22804d6-0efd-4702-b095-6ea87dad3430" />




[MG-244]: https://sagebionetworks.jira.com/browse/MG-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ