### PR TITLE
feat(model-ad): adding comparison tool header component and buttons (MG-245)

### DIFF
--- a/apps/agora/app/src/app/app.component.html
+++ b/apps/agora/app/src/app/app.component.html
@@ -8,4 +8,4 @@
   </div>
   <agora-footer></agora-footer>
 </div>
-<p-toast key="global-toast" position="bottom-center"></p-toast>
+<p-toast class="global-toast" position="bottom-center"></p-toast>

--- a/apps/agora/app/src/app/app.component.html
+++ b/apps/agora/app/src/app/app.component.html
@@ -8,4 +8,4 @@
   </div>
   <agora-footer></agora-footer>
 </div>
-<p-toast class="global-toast" position="bottom-center"></p-toast>
+<p-toast key="global-toast" position="bottom-center"></p-toast>

--- a/apps/model-ad/app/src/app/app.component.html
+++ b/apps/model-ad/app/src/app/app.component.html
@@ -17,3 +17,4 @@
     [dataVersion]="dataVersion"
   ></explorers-footer>
 </div>
+<p-toast class="global-toast" position="bottom-center"></p-toast>

--- a/apps/model-ad/app/src/app/app.component.ts
+++ b/apps/model-ad/app/src/app/app.component.ts
@@ -12,8 +12,10 @@ import {
   createGoogleTagManagerIdProvider,
   isGoogleTagManagerIdSet,
 } from '@sagebionetworks/shared/google-tag-manager';
+import { ToastModule } from 'primeng/toast';
+
 @Component({
-  imports: [RouterModule, FooterComponent, HeaderComponent, GoogleTagManagerComponent],
+  imports: [RouterModule, FooterComponent, HeaderComponent, ToastModule, GoogleTagManagerComponent],
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',

--- a/apps/model-ad/app/src/app/app.config.ts
+++ b/apps/model-ad/app/src/app/app.config.ts
@@ -14,6 +14,7 @@ import { configFactory, ConfigService } from '@sagebionetworks/model-ad/config';
 import { routes } from './app.routes';
 import { ModelAdPreset } from './primeNGPreset';
 import { provideMarkdown } from 'ngx-markdown';
+import { MessageService } from 'primeng/api';
 
 // This index is used to remove the corresponding provider in app.config.server.ts.
 // TODO: This index could be out of sync if we are not careful. Find a more elegant way.
@@ -59,5 +60,6 @@ export const appConfig: ApplicationConfig = {
         scrollPositionRestoration: 'enabled',
       }),
     ),
+    MessageService,
   ],
 };

--- a/libs/explorers/comparison-tools/src/index.ts
+++ b/libs/explorers/comparison-tools/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/base-comparison-tool/base-comparison-tool.component';
 export * from './lib/help-links/help-links.component';
 export * from './lib/legend-panel/legend-panel.component';
+export * from './lib/comparison-tool-header/comparison-tool-header.component';

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-filter-results-button/comparison-tool-filter-results-button.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-filter-results-button/comparison-tool-filter-results-button.component.html
@@ -1,0 +1,10 @@
+<p-button
+  label="Filter Results"
+  (click)="toggle()"
+  [rounded]="true"
+  icon="pi pi-filter-fill"
+  size="small"
+  [pTooltip]="tooltip()"
+  tooltipPosition="right"
+  tooltipStyleClass="tooltip"
+></p-button>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-filter-results-button/comparison-tool-filter-results-button.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-filter-results-button/comparison-tool-filter-results-button.component.html
@@ -6,5 +6,4 @@
   size="small"
   [pTooltip]="tooltip()"
   tooltipPosition="right"
-  tooltipStyleClass="tooltip"
 ></p-button>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-filter-results-button/comparison-tool-filter-results-button.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-filter-results-button/comparison-tool-filter-results-button.component.ts
@@ -1,0 +1,20 @@
+import { Component, input, output, signal } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
+
+@Component({
+  selector: 'explorers-comparison-tool-filter-results-button',
+  imports: [ButtonModule, TooltipModule],
+  templateUrl: './comparison-tool-filter-results-button.component.html',
+  styleUrls: ['./comparison-tool-filter-results-button.component.scss'],
+})
+export class ComparisonToolFilterResultsButtonComponent {
+  tooltip = input('');
+  filterToggle = output<boolean>();
+  private filterState = signal(false);
+
+  toggle() {
+    this.filterState.update((state) => !state);
+    this.filterToggle.emit(this.filterState());
+  }
+}

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.html
@@ -1,8 +1,10 @@
-<div class="header">
-  <explorers-comparison-tool-filter-results-button
-    (filterToggle)="toggleFilterPanel()"
-    [tooltip]="filterResultsButtonTooltip()"
-  />
-  <h1>{{ headerTitle() }}</h1>
-  <explorers-comparison-tool-share-url-button [tooltip]="shareUrlButtonTooltip()" />
+<div class="comparison-tool-header">
+  <div class="comparison-tool-header-inner">
+    <explorers-comparison-tool-filter-results-button
+      (filterToggle)="toggleFilterPanel()"
+      [tooltip]="filterResultsButtonTooltip()"
+    />
+    <h1>{{ headerTitle() }}</h1>
+    <explorers-comparison-tool-share-url-button [tooltip]="shareUrlButtonTooltip()" />
+  </div>
 </div>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.html
@@ -1,0 +1,8 @@
+<div class="header">
+  <explorers-comparison-tool-filter-results-button
+    (filterToggle)="toggleFilterPanel()"
+    [tooltip]="filterResultsButtonTooltip()"
+  />
+  <h1>{{ headerTitle() }}</h1>
+  <explorers-comparison-tool-share-url-button [tooltip]="shareUrlButtonTooltip()" />
+</div>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.scss
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.scss
@@ -1,0 +1,5 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.scss
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.scss
@@ -1,5 +1,20 @@
-.header {
+.comparison-tool-header {
+  padding: 10px 80px;
   display: flex;
+  justify-content: center;
   align-items: center;
-  justify-content: space-between;
+  height: 75px;
+  border: 1px solid var(--color-gray-300);
+
+  .comparison-tool-header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+
+    h1 {
+      font-size: 24px;
+      font-weight: 600;
+    }
+  }
 }

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.ts
@@ -1,0 +1,19 @@
+import { Component, input } from '@angular/core';
+import { ComparisonToolFilterResultsButtonComponent } from './comparison-tool-filter-results-button/comparison-tool-filter-results-button.component';
+import { ComparisonToolShareURLButtonComponent } from './comparison-tool-share-url-button/comparison-tool-share-url-button.component';
+
+@Component({
+  selector: 'explorers-comparison-tool-header',
+  imports: [ComparisonToolFilterResultsButtonComponent, ComparisonToolShareURLButtonComponent],
+  templateUrl: './comparison-tool-header.component.html',
+  styleUrls: ['./comparison-tool-header.component.scss'],
+})
+export class ComparisonToolHeaderComponent {
+  filterResultsButtonTooltip = input.required<string>();
+  headerTitle = input.required<string>();
+  shareUrlButtonTooltip = input.required<string>();
+
+  toggleFilterPanel() {
+    alert('Filter panel toggled');
+  }
+}

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.ts
@@ -14,6 +14,7 @@ export class ComparisonToolHeaderComponent {
   shareUrlButtonTooltip = input.required<string>();
 
   toggleFilterPanel() {
+    // TODO: Replace this alert with proper filter panel toggle behavior in a future update (MG-246)
     alert('Filter panel toggled');
   }
 }

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.html
@@ -6,5 +6,5 @@
   size="small"
   [pTooltip]="tooltip()"
   tooltipPosition="left"
-  tooltipStyleClass="tooltip"
 ></p-button>
+<p-toast key="share-url-button-toast" [life]="toastDuration"></p-toast>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.html
@@ -1,0 +1,10 @@
+<p-button
+  label="Share URL"
+  (click)="copyUrl()"
+  [rounded]="true"
+  variant="outlined"
+  size="small"
+  [pTooltip]="tooltip()"
+  tooltipPosition="left"
+  tooltipStyleClass="tooltip"
+></p-button>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
@@ -1,0 +1,31 @@
+import { Component, inject, input } from '@angular/core';
+import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
+
+@Component({
+  selector: 'explorers-comparison-tool-share-url-button',
+  imports: [ButtonModule, TooltipModule],
+  templateUrl: './comparison-tool-share-url-button.component.html',
+  styleUrls: ['./comparison-tool-share-url-button.component.scss'],
+})
+export class ComparisonToolShareURLButtonComponent {
+  messageService = inject(MessageService);
+
+  tooltip = input('');
+
+  copyUrl() {
+    navigator.clipboard.writeText(window.location.href);
+    this.messageService.clear();
+    this.messageService.add({
+      severity: 'info',
+      sticky: true,
+      summary: '',
+      detail:
+        'URL copied to clipboard! Use this URL to share or bookmark the current table configuration.',
+    });
+    setTimeout(() => {
+      this.messageService.clear();
+    }, 5000);
+  }
+}

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
@@ -2,10 +2,11 @@ import { Component, inject, input } from '@angular/core';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';
+import { ToastModule } from 'primeng/toast';
 
 @Component({
   selector: 'explorers-comparison-tool-share-url-button',
-  imports: [ButtonModule, TooltipModule],
+  imports: [ButtonModule, TooltipModule, ToastModule],
   templateUrl: './comparison-tool-share-url-button.component.html',
   styleUrls: ['./comparison-tool-share-url-button.component.scss'],
 })
@@ -14,18 +15,17 @@ export class ComparisonToolShareURLButtonComponent {
 
   tooltip = input('');
 
+  toastDuration = 1000;
+
   copyUrl() {
     navigator.clipboard.writeText(window.location.href);
     this.messageService.clear();
     this.messageService.add({
+      key: 'share-url-button-toast',
       severity: 'info',
-      sticky: true,
       summary: '',
       detail:
         'URL copied to clipboard! Use this URL to share or bookmark the current table configuration.',
     });
-    setTimeout(() => {
-      this.messageService.clear();
-    }, 5000);
   }
 }

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
@@ -15,7 +15,7 @@ export class ComparisonToolShareURLButtonComponent {
 
   tooltip = input('');
 
-  toastDuration = 1000;
+  toastDuration = 5000;
 
   copyUrl() {
     navigator.clipboard.writeText(window.location.href);
@@ -23,7 +23,7 @@ export class ComparisonToolShareURLButtonComponent {
     this.messageService.add({
       key: 'share-url-button-toast',
       severity: 'info',
-      summary: '',
+      summary: 'URL Copied',
       detail:
         'URL copied to clipboard! Use this URL to share or bookmark the current table configuration.',
     });

--- a/libs/explorers/comparison-tools/src/lib/help-links/help-links.component.scss
+++ b/libs/explorers/comparison-tools/src/lib/help-links/help-links.component.scss
@@ -1,4 +1,11 @@
 .help-links {
+  padding: 10px 80px;
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  height: 75px;
+  border: 1px solid var(--color-gray-300);
+
   .help-links-inner {
     display: flex;
 

--- a/libs/explorers/shared/src/lib/components/not-found/not-found.component.scss
+++ b/libs/explorers/shared/src/lib/components/not-found/not-found.component.scss
@@ -1,7 +1,7 @@
 @use 'libs/explorers/styles/src/lib/mixins';
 
 .page-not-found {
-  min-height: calc(100vh - var(--header-height) - var(--footer-height) + 1px);
+  min-height: calc(100vh - var(--header-height) - var(--footer-height));
   color: white;
   background-size: cover !important;
 

--- a/libs/explorers/shared/src/lib/components/wiki-hero/wiki-hero.component.scss
+++ b/libs/explorers/shared/src/lib/components/wiki-hero/wiki-hero.component.scss
@@ -4,7 +4,7 @@
 #wiki-hero-container {
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - var(--header-height) - var(--footer-height) + 1px);
+  min-height: calc(100vh - var(--header-height) - var(--footer-height));
 
   .wiki-hero {
     flex: 1 1 auto;

--- a/libs/explorers/styles/src/index.scss
+++ b/libs/explorers/styles/src/index.scss
@@ -3,3 +3,4 @@
 @forward './lib/mixins';
 @forward './lib/section';
 @forward './lib/components/fonts';
+@forward './lib/components/tooltip';

--- a/libs/explorers/styles/src/lib/components/_tooltip.scss
+++ b/libs/explorers/styles/src/lib/components/_tooltip.scss
@@ -1,0 +1,10 @@
+.p-tooltip {
+  opacity: 0.8 !important;
+  font-family: 'DM Sans Variable', sans-serif;
+  font-size: 14px;
+  text-align: center;
+
+  .p-tooltip-arrow {
+    display: none !important;
+  }
+}

--- a/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.html
+++ b/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.html
@@ -7,7 +7,7 @@
     <explorers-comparison-tool-header
       headerTitle="Disease Correlation"
       filterResultsButtonTooltip="Filter the results based on the selected criteria"
-      shareUrlButtonTooltip="Share the URL of the current results"
+      shareUrlButtonTooltip="Copy the URL to capture the table’s current filtering, sorting, and pinned results"
     />
     <model-ad-disease-correlation-help-links />
   </div>

--- a/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.html
+++ b/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.html
@@ -4,9 +4,11 @@
   [resultsCount]="resultsCount()"
 >
   <div class="disease-correlation-comparison-tool">
-    <div class="header">
-      <h1>Disease Correlation</h1>
-    </div>
+    <explorers-comparison-tool-header
+      headerTitle="Disease Correlation"
+      filterResultsButtonTooltip="Filter the results based on the selected criteria"
+      shareUrlButtonTooltip="Share the URL of the current results"
+    />
     <model-ad-disease-correlation-help-links />
   </div>
 </explorers-base-comparison-tool>

--- a/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.scss
+++ b/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.scss
@@ -1,11 +1,4 @@
 .disease-correlation-comparison-tool {
   width: 100%;
   height: 100%;
-
-  // TODO move these styles to the base CT header
-  .header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 }

--- a/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.spec.ts
+++ b/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.spec.ts
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/angular';
 import { DiseaseCorrelationComparisonToolComponent } from './disease-correlation-comparison-tool.component';
 import { BaseComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tools';
+import { MessageService } from 'primeng/api';
 
 async function setup() {
   const { fixture } = await render(DiseaseCorrelationComparisonToolComponent, {
     imports: [BaseComparisonToolComponent],
+    providers: [MessageService],
   });
 
   const component = fixture.componentInstance;

--- a/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.ts
+++ b/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.ts
@@ -1,11 +1,18 @@
 import { Component, OnInit, signal } from '@angular/core';
-import { BaseComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tools';
+import {
+  BaseComparisonToolComponent,
+  ComparisonToolHeaderComponent,
+} from '@sagebionetworks/explorers/comparison-tools';
 import { ComparisonToolService } from '@sagebionetworks/model-ad/services';
 import { DiseaseCorrelationHelpLinksComponent } from './components/disease-correlation-help-links/disease-correlation-help-links.component';
 import { LOADING_ICON_COLORS } from '@sagebionetworks/model-ad/util';
 @Component({
   selector: 'model-ad-disease-correlation-comparison-tool',
-  imports: [BaseComparisonToolComponent, DiseaseCorrelationHelpLinksComponent],
+  imports: [
+    BaseComparisonToolComponent,
+    ComparisonToolHeaderComponent,
+    DiseaseCorrelationHelpLinksComponent,
+  ],
   templateUrl: './disease-correlation-comparison-tool.component.html',
   styleUrls: ['./disease-correlation-comparison-tool.component.scss'],
   providers: [ComparisonToolService],

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.html
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.html
@@ -7,7 +7,7 @@
     <explorers-comparison-tool-header
       headerTitle="Gene Expression"
       filterResultsButtonTooltip="Filter the results based on the selected criteria"
-      shareUrlButtonTooltip="Share the URL of the current results"
+      shareUrlButtonTooltip="Copy the URL to capture the table’s current filtering, sorting, and pinned results"
     />
     <model-ad-gene-expression-help-links />
   </div>

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.html
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.html
@@ -4,9 +4,11 @@
   [resultsCount]="resultsCount()"
 >
   <div class="gene-expression-comparison-tool">
-    <div class="header">
-      <h1>Gene Expression</h1>
-    </div>
+    <explorers-comparison-tool-header
+      headerTitle="Gene Expression"
+      filterResultsButtonTooltip="Filter the results based on the selected criteria"
+      shareUrlButtonTooltip="Share the URL of the current results"
+    />
     <model-ad-gene-expression-help-links />
   </div>
 </explorers-base-comparison-tool>

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.scss
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.scss
@@ -1,11 +1,4 @@
 .gene-expression-comparison-tool {
   width: 100%;
   height: 100%;
-
-  // TODO move these styles to the base CT header
-  .header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 }

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.spec.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.spec.ts
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/angular';
 import { GeneExpressionComparisonToolComponent } from './gene-expression-comparison-tool.component';
 import { BaseComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tools';
+import { MessageService } from 'primeng/api';
 
 async function setup() {
   const { fixture } = await render(GeneExpressionComparisonToolComponent, {
     imports: [BaseComparisonToolComponent],
+    providers: [MessageService],
   });
 
   const component = fixture.componentInstance;

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.ts
@@ -1,11 +1,18 @@
 import { Component, OnInit, signal } from '@angular/core';
-import { BaseComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tools';
+import {
+  BaseComparisonToolComponent,
+  ComparisonToolHeaderComponent,
+} from '@sagebionetworks/explorers/comparison-tools';
 import { ComparisonToolService } from '@sagebionetworks/model-ad/services';
 import { GeneExpressionHelpLinksComponent } from './components/gene-expression-help-links/gene-expression-help-links.component';
 import { LOADING_ICON_COLORS } from '@sagebionetworks/model-ad/util';
 @Component({
   selector: 'model-ad-gene-expression-comparison-tool',
-  imports: [BaseComparisonToolComponent, GeneExpressionHelpLinksComponent],
+  imports: [
+    BaseComparisonToolComponent,
+    ComparisonToolHeaderComponent,
+    GeneExpressionHelpLinksComponent,
+  ],
   templateUrl: './gene-expression-comparison-tool.component.html',
   styleUrls: ['./gene-expression-comparison-tool.component.scss'],
   providers: [ComparisonToolService],

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.html
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.html
@@ -4,9 +4,11 @@
   [resultsCount]="resultsCount()"
 >
   <div class="model-overview-comparison-tool">
-    <div class="header">
-      <h1>Model Overview</h1>
-    </div>
+    <explorers-comparison-tool-header
+      headerTitle="Model Overview"
+      filterResultsButtonTooltip="Filter the results based on the selected criteria"
+      shareUrlButtonTooltip="Share the URL of the current results"
+    />
     <model-ad-model-overview-help-links />
   </div>
 </explorers-base-comparison-tool>

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.html
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.html
@@ -7,7 +7,7 @@
     <explorers-comparison-tool-header
       headerTitle="Model Overview"
       filterResultsButtonTooltip="Filter the results based on the selected criteria"
-      shareUrlButtonTooltip="Share the URL of the current results"
+      shareUrlButtonTooltip="Copy the URL to capture the table’s current filtering, sorting, and pinned results"
     />
     <model-ad-model-overview-help-links />
   </div>

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.scss
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.scss
@@ -1,11 +1,4 @@
 .model-overview-comparison-tool {
   width: 100%;
   height: 100%;
-
-  // TODO move these styles to the base CT header
-  .header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 }

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.spec.ts
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.spec.ts
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/angular';
 import { ModelOverviewComparisonToolComponent } from './model-overview-comparison-tool.component';
 import { BaseComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tools';
+import { MessageService } from 'primeng/api';
 
 async function setup() {
   const { fixture } = await render(ModelOverviewComparisonToolComponent, {
     imports: [BaseComparisonToolComponent],
+    providers: [MessageService],
   });
 
   const component = fixture.componentInstance;

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.ts
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.ts
@@ -1,11 +1,18 @@
 import { Component, OnInit, signal } from '@angular/core';
-import { BaseComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tools';
+import {
+  BaseComparisonToolComponent,
+  ComparisonToolHeaderComponent,
+} from '@sagebionetworks/explorers/comparison-tools';
 import { ComparisonToolService } from '@sagebionetworks/model-ad/services';
 import { ModelOverviewHelpLinksComponent } from './components/model-overview-help-links/model-overview-help-links.component';
 import { LOADING_ICON_COLORS } from '@sagebionetworks/model-ad/util';
 @Component({
   selector: 'model-ad-model-overview-comparison-tool',
-  imports: [BaseComparisonToolComponent, ModelOverviewHelpLinksComponent],
+  imports: [
+    BaseComparisonToolComponent,
+    ComparisonToolHeaderComponent,
+    ModelOverviewHelpLinksComponent,
+  ],
   templateUrl: './model-overview-comparison-tool.component.html',
   styleUrls: ['./model-overview-comparison-tool.component.scss'],
   providers: [ComparisonToolService],

--- a/libs/model-ad/util/src/lib/navigation-links.ts
+++ b/libs/model-ad/util/src/lib/navigation-links.ts
@@ -9,15 +9,15 @@ export const headerLinks: NavigationLink[] = [
   },
   {
     label: 'Model Overview',
-    routerLink: ['model-overview'],
+    routerLink: ['comparison/model'],
   },
   {
     label: 'Gene Expression',
-    routerLink: ['gene-expression'],
+    routerLink: ['comparison/expression'],
   },
   {
     label: 'Disease Correlation',
-    routerLink: ['disease-correlation'],
+    routerLink: ['comparison/correlation'],
   },
 ];
 


### PR DESCRIPTION
## Description

This adds a CT header component with a "Filter Results" button, header title and "Share URL" button.

## Related Issue

[MG-245](https://sagebionetworks.jira.com/jira/software/c/projects/MG/boards/243?assignee=633b138697148a8301fe2c72&selectedIssue=MG-245)

## Changelog

- Filter Results button: (partial implementation) This button will be fully functional with [MG-246](https://sagebionetworks.jira.com/browse/MG-246).  This button will only show an alert at this time but otherwise should follow the design in Figma.
- Header Title is now part of the ComparisonToolHeaderComponent
- Share URL button: A button that creates a toast and copies the URL into the clipboard.
- Tooltips will show placeholder text but will be refined in a future update (pending).
- Fixed styling in not-found component (404) and wiki-hero component (about/news pages) that caused a vertical scrollbar to show

## Preview
Showing all 3 CTs with tooltips and functioning buttons.
https://www.loom.com/share/d3e5e86a41b4419db3c12064738d030f


[MG-245]: https://sagebionetworks.jira.com/browse/MG-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MG-246]: https://sagebionetworks.jira.com/browse/MG-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ