### PR TITLE
feat(model-ad): add model details resources panel content (MG-214)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -70,3 +70,51 @@ test.describe('model details - omics', () => {
     await page.waitForURL('/comparison/correlation?model=APOE4');
   });
 });
+
+test.describe('model details - resources', () => {
+  const resourcesUrl = '/models/3xTg-AD/resources';
+
+  test('AD knowledge portal card links to ADKP study page for this model', async ({ page }) => {
+    await page.goto(resourcesUrl);
+    const card = page.getByRole('button', {
+      name: /ad knowledge portal/i,
+    });
+
+    const popupPromise = page.waitForEvent('popup');
+    await card.click();
+    const popup = await popupPromise;
+
+    await popup.waitForURL(
+      'https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=**',
+    );
+    await expect.poll(() => page.getByText(/3xtg-ad/i).count()).toBeGreaterThan(0);
+  });
+
+  test('alzforum card links to alzforum page for this model', async ({ page }) => {
+    await page.goto(resourcesUrl);
+    const card = page.getByRole('button', {
+      name: /alzforum/i,
+    });
+
+    const popupPromise = page.waitForEvent('popup');
+    await card.click();
+    const popup = await popupPromise;
+
+    await popup.waitForURL('https://www.alzforum.org/research-models/**');
+    await expect.poll(() => page.getByText(/3xtg-ad/i).count()).toBeGreaterThan(0);
+  });
+
+  test('JAX card links to JAX page for this model', async ({ page }) => {
+    await page.goto(resourcesUrl);
+    const card = page.getByRole('button', {
+      name: /jax/i,
+    });
+
+    const popupPromise = page.waitForEvent('popup');
+    await card.click();
+    const popup = await popupPromise;
+
+    await popup.waitForURL('https://www.jax.org/strain/**');
+    await expect.poll(() => page.getByText(/3xtg-ad/i).count()).toBeGreaterThan(0);
+  });
+});

--- a/libs/explorers/styles/src/lib/_section.scss
+++ b/libs/explorers/styles/src/lib/_section.scss
@@ -5,4 +5,8 @@ section {
   padding: var(--section-padding);
   margin-left: auto;
   margin-right: auto;
+
+  h2 {
+    margin-bottom: 30px;
+  }
 }

--- a/libs/explorers/styles/src/lib/_variables.scss
+++ b/libs/explorers/styles/src/lib/_variables.scss
@@ -146,7 +146,7 @@ $main-content-total-width: $main-content-desktop-width + ($main-content-margin *
 // -------------------------------------------------------------------------- //
 
 $section-max-width: 1120px;
-$section-padding: 50px;
+$section-padding: 40px;
 
 :root {
   --section-max-width: #{$section-max-width};

--- a/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.scss
+++ b/libs/explorers/ui/src/lib/components/resource-card/resource-card.component.scss
@@ -5,6 +5,7 @@
   box-shadow: 0 4px 4px rgb(0 0 0 / 10%);
   background: #fff;
   padding: 40px;
+  height: 100%;
 
   button {
     @include mixins.reset-button;

--- a/libs/model-ad/model-details/src/lib/components/model-details-omics/model-details-omics.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-omics/model-details-omics.component.scss
@@ -1,3 +1,0 @@
-h2 {
-  margin-bottom: 30px;
-}

--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.html
@@ -1,0 +1,10 @@
+<div class="model-details-resources">
+  <section>
+    <h2>Model-Specific Resources</h2>
+    <explorers-resource-cards [cards]="modelSpecificResourceCards()" />
+  </section>
+  <section>
+    <h2>Additional Resources</h2>
+    <explorers-resource-cards [cards]="additionalResourceCards" />
+  </section>
+</div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.scss
@@ -1,0 +1,4 @@
+.model-details-resources {
+  display: flex;
+  flex-direction: column;
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.spec.ts
@@ -1,0 +1,38 @@
+import { ResourceCardsComponent } from '@sagebionetworks/explorers/ui';
+import { modelMock } from '@sagebionetworks/model-ad/testing';
+import { render, screen } from '@testing-library/angular';
+import { ModelDetailsResourcesComponent } from './model-details-resources.component';
+
+async function setup() {
+  return render(ModelDetailsResourcesComponent, {
+    imports: [ResourceCardsComponent],
+    componentInputs: {
+      model: modelMock,
+    },
+  });
+}
+
+describe('ModelDetailsResourcesComponent', () => {
+  it('should display all model-specific resource cards', async () => {
+    await setup();
+
+    const sectionTitle = screen.getByText('Model-Specific Resources');
+    expect(sectionTitle).toBeInTheDocument();
+
+    expect(screen.getByText(/ad knowledge portal/i)).toBeInTheDocument();
+    expect(screen.getByText(/alzforum/i)).toBeInTheDocument();
+    expect(screen.getByText(/jax/i)).toBeInTheDocument();
+  });
+
+  it('should display all additional resource cards', async () => {
+    await setup();
+
+    const sectionTitle = screen.getByText('Additional Resources');
+    expect(sectionTitle).toBeInTheDocument();
+
+    expect(screen.getByText(/human genes in ad/i)).toBeInTheDocument();
+    expect(screen.getByText(/model-ad program/i)).toBeInTheDocument();
+    expect(screen.getByText(/mouse genome informatics/i)).toBeInTheDocument();
+    expect(screen.getByText(/model-ad preclinical testing core/i)).toBeInTheDocument();
+  });
+});

--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
@@ -1,0 +1,58 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, input } from '@angular/core';
+import { ResourceCardsComponent } from '@sagebionetworks/explorers/ui';
+import { Model } from '@sagebionetworks/model-ad/api-client-angular';
+
+@Component({
+  selector: 'model-ad-model-details-resources',
+  imports: [CommonModule, ResourceCardsComponent],
+  templateUrl: './model-details-resources.component.html',
+  styleUrls: ['./model-details-resources.component.scss'],
+})
+export class ModelDetailsResourcesComponent {
+  model = input.required<Model>();
+
+  modelSpecificResourceCards = computed(() => [
+    {
+      imagePath: '/model-ad-assets/images/ad-knowledge-portal-logo.svg',
+      description:
+        "Explore all of the data and metadata that's available for this model in the AD Knowledge Portal.",
+      link: `https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=${this.model().study_synid}`,
+    },
+    {
+      imagePath: '/model-ad-assets/images/alzforum-logo.svg',
+      description: 'Visit Alzforum to find more information about this model.',
+      link: `https://www.alzforum.org/research-models/${this.model().alzforum_id}`,
+    },
+    {
+      imagePath: '/model-ad-assets/images/jax-logo.svg',
+      description: 'View detailed information about this AD model on JAX.',
+      link: `https://www.jax.org/strain/${this.model().jax_id}`,
+    },
+  ]);
+
+  additionalResourceCards = [
+    {
+      imagePath: '/model-ad-assets/images/agora-logo.svg',
+      description: 'View evidence about the role of human genes in AD.',
+      link: 'https://agora.adknowledgeportal.org/',
+    },
+    {
+      imagePath: '/model-ad-assets/images/model-ad-logo.svg',
+      description: 'Learn about the MODEL-AD program.',
+      link: 'https://www.model-ad.org/',
+    },
+    {
+      imagePath: '/model-ad-assets/images/mgi-logo.svg',
+      description:
+        'Search Mouse Genome Informatics for detailed information about mouse genes, alleles, and more.',
+      link: 'https://www.informatics.jax.org/',
+    },
+    {
+      imagePath: '/model-ad-assets/images/stop-ad-compound-portal-logo.svg',
+      description:
+        'Nominate a test compound for preclinical screening by the MODEL-AD Preclinical Testing Core.',
+      link: 'https://stopadportal.synapse.org/',
+    },
+  ];
+}

--- a/libs/model-ad/model-details/src/lib/model-details.component.html
+++ b/libs/model-ad/model-details/src/lib/model-details.component.html
@@ -27,7 +27,7 @@
           <h2>Pathology</h2>
         }
         @case ('resources') {
-          <h2>Model-Specific Resources</h2>
+          <model-ad-model-details-resources [model]="model" />
         }
       }
     </div>

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -10,6 +10,7 @@ import { Model, ModelsService } from '@sagebionetworks/model-ad/api-client-angul
 import { ConfigService } from '@sagebionetworks/model-ad/config';
 import { LOADING_ICON_COLORS } from '@sagebionetworks/model-ad/util';
 import { ModelDetailsOmicsComponent } from './components/model-details-omics/model-details-omics.component';
+import { ModelDetailsResourcesComponent } from './components/model-details-resources/model-details-resources.component';
 
 @Component({
   selector: 'model-ad-model-details',
@@ -18,6 +19,7 @@ import { ModelDetailsOmicsComponent } from './components/model-details-omics/mod
     PanelNavigationComponent,
     LoadingIconComponent,
     ModelDetailsOmicsComponent,
+    ModelDetailsResourcesComponent,
   ],
   templateUrl: './model-details.component.html',
   styleUrls: ['./model-details.component.scss'],


### PR DESCRIPTION
## Description

Adds the resources panel content to the model details page.

## Related Issue

- [MG-214](https://sagebionetworks.jira.com/browse/MG-214)

## Changelog

- Adds `model-details-resources` component
- Ensures that `resource-card`s in the same row have the same height

## Preview

1. Build and run Model-AD: `model-ad-build-images && model-ad-docker-start`
2. Navigate to a model details page: http://localhost:8000/models/3xTg-AD/resources

![MG-214](https://github.com/user-attachments/assets/de7517d5-34b8-428e-b99d-81b57ec6048f)

[MG-214]: https://sagebionetworks.jira.com/browse/MG-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-214]: https://sagebionetworks.jira.com/browse/MG-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ