### PR TITLE
fix(model-ad): hide alzforum resource card when id is missing (MG-259)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.spec.ts
@@ -3,11 +3,11 @@ import { modelMock } from '@sagebionetworks/model-ad/testing';
 import { render, screen } from '@testing-library/angular';
 import { ModelDetailsResourcesComponent } from './model-details-resources.component';
 
-async function setup() {
+async function setup(model = modelMock) {
   return render(ModelDetailsResourcesComponent, {
     imports: [ResourceCardsComponent],
     componentInputs: {
-      model: modelMock,
+      model: model,
     },
   });
 }
@@ -34,5 +34,10 @@ describe('ModelDetailsResourcesComponent', () => {
     expect(screen.getByText(/model-ad program/i)).toBeInTheDocument();
     expect(screen.getByText(/mouse genome informatics/i)).toBeInTheDocument();
     expect(screen.getByText(/model-ad preclinical testing core/i)).toBeInTheDocument();
+  });
+
+  it('should not display alzforum card when alzforum_id is missing', async () => {
+    await setup({ ...modelMock, alzforum_id: '' });
+    expect(screen.queryByText(/alzforum/i)).not.toBeInTheDocument();
   });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
@@ -32,7 +32,8 @@ export class ModelDetailsResourcesComponent {
     ];
 
     return cards.filter((card) => {
-      if (card.imagePath.includes('alzforum-logo')) {
+      // hide alzforum resource card when alzforum_id is empty
+      if (card.link.includes('www.alzforum.org')) {
         return this.model().alzforum_id !== '';
       }
       return true;

--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, computed, input } from '@angular/core';
 import { ResourceCardsComponent } from '@sagebionetworks/explorers/ui';
 import { Model } from '@sagebionetworks/model-ad/api-client-angular';
@@ -12,24 +11,33 @@ import { Model } from '@sagebionetworks/model-ad/api-client-angular';
 export class ModelDetailsResourcesComponent {
   model = input.required<Model>();
 
-  modelSpecificResourceCards = computed(() => [
-    {
-      imagePath: '/model-ad-assets/images/ad-knowledge-portal-logo.svg',
-      description:
-        "Explore all of the data and metadata that's available for this model in the AD Knowledge Portal.",
-      link: `https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=${this.model().study_synid}`,
-    },
-    {
-      imagePath: '/model-ad-assets/images/alzforum-logo.svg',
-      description: 'Visit Alzforum to find more information about this model.',
-      link: `https://www.alzforum.org/research-models/${this.model().alzforum_id}`,
-    },
-    {
-      imagePath: '/model-ad-assets/images/jax-logo.svg',
-      description: 'View detailed information about this AD model on JAX.',
-      link: `https://www.jax.org/strain/${this.model().jax_id}`,
-    },
-  ]);
+  modelSpecificResourceCards = computed(() => {
+    const cards = [
+      {
+        imagePath: '/model-ad-assets/images/ad-knowledge-portal-logo.svg',
+        description:
+          "Explore all of the data and metadata that's available for this model in the AD Knowledge Portal.",
+        link: `https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=${this.model().study_synid}`,
+      },
+      {
+        imagePath: '/model-ad-assets/images/alzforum-logo.svg',
+        description: 'Visit Alzforum to find more information about this model.',
+        link: `https://www.alzforum.org/research-models/${this.model().alzforum_id}`,
+      },
+      {
+        imagePath: '/model-ad-assets/images/jax-logo.svg',
+        description: 'View detailed information about this AD model on JAX.',
+        link: `https://www.jax.org/strain/${this.model().jax_id}`,
+      },
+    ];
+
+    return cards.filter((card) => {
+      if (card.imagePath.includes('alzforum-logo')) {
+        return this.model().alzforum_id !== '';
+      }
+      return true;
+    });
+  });
 
   additionalResourceCards = [
     {


### PR DESCRIPTION
## Description

Some models do not have an `alzforum_id`. We should hide the corresponding resource card in this case.

## Related Issue

- [MG-259](https://sagebionetworks.jira.com/browse/MG-259)

## Changelog

- Hides ALZFORUM resource card when id is missing

## Preview

Run `model-ad-build-images && model-ad-docker-start`
Navigate to `http://localhost:8000/models/Abca7*V1599M/resources`
Alzforum card should not be shown: 

<img width="1506" alt="MG-259" src="https://github.com/user-attachments/assets/647a4bc2-9ade-4fd7-8f1e-68e71951a23c" />

[MG-259]: https://sagebionetworks.jira.com/browse/MG-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ