### PR TITLE
chore(openchallenges): migrate to ngx-echarts standalone import (SMR-204)

### DIFF
--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.ts
@@ -1,23 +1,23 @@
-
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { HomeDataService } from '../home-data-service';
-import { NgxEchartsModule, NGX_ECHARTS_CONFIG } from 'ngx-echarts';
+import { NgxEchartsDirective, provideEchartsCore } from 'ngx-echarts';
+import * as echarts from 'echarts/core';
 import { EChartsOption } from 'echarts';
 import { CountUpModule } from 'ngx-countup';
 import { Subscription } from 'rxjs';
 import { RouterModule } from '@angular/router';
+import { BarChart } from 'echarts/charts';
+import { GridComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([BarChart, GridComponent, CanvasRenderer]);
 
 @Component({
   selector: 'openchallenges-statistics-viewer',
-  imports: [RouterModule, CountUpModule, NgxEchartsModule],
-  providers: [
-    {
-      provide: NGX_ECHARTS_CONFIG,
-      useFactory: () => ({ echarts: () => import('echarts') }),
-    },
-  ],
+  imports: [RouterModule, CountUpModule, NgxEchartsDirective],
   templateUrl: './statistics-viewer.component.html',
   styleUrls: ['./statistics-viewer.component.scss'],
+  providers: [provideEchartsCore({ echarts })],
 })
 export class StatisticsViewerComponent implements OnInit, OnDestroy {
   constructor(private homeDataService: HomeDataService) {}


### PR DESCRIPTION
## Description

Remove `NgxEchartsModule` and import `ngx-echarts` as [standalone components](https://www.npmjs.com/package/ngx-echarts#standalone).

## Related Issue

- [SMR-204](https://sagebionetworks.jira.com/browse/SMR-204)

## Changelog

<!-- Itemize the changes made in this PR. -->

- Add ...
- Remove ...

## Bundle Size

There is currently a concern regarding the increase of the bundle size.

### Before

### After

```console
Browser bundles      
Initial chunk files   | Names               |  Raw size | Estimated transfer size
chunk-RG6BFECQ.js     | -                   | 526.48 kB |               134.22 kB
chunk-Y27WWOMN.js     | -                   | 498.88 kB |               140.71 kB
chunk-SXCWY3UK.js     | -                   | 414.22 kB |                80.53 kB
main-LFHY552X.js      | main                | 256.51 kB |                49.51 kB
styles-BUXTSV2U.css   | styles              |  42.10 kB |                 6.78 kB
polyfills-2AIA7NCG.js | polyfills           |  34.52 kB |                11.29 kB

                      | Initial total       |   1.77 MB |               423.04 kB

Lazy chunk files      | Names               |  Raw size | Estimated transfer size
chunk-HI65NFLR.js     | -                   | 156.87 kB |                30.27 kB
chunk-EAY4DFQT.js     | index               | 121.05 kB |                24.39 kB
chunk-QMXXQGSM.js     | index               |  72.00 kB |                13.11 kB
chunk-IMPL6SZ7.js     | index               |  16.57 kB |                 4.78 kB
chunk-Q4SAIPRT.js     | 2mindex               |  12.59 kB |                 3.97 kB
chunk-GLFOQSRC.js     | index               |   9.81 kB |                 3.26 kB
chunk-HPTH5JFS.js     | -                   |   8.79 kB |                 2.41 kB
chunk-MTNCHDZ4.js     | index               |   6.61 kB |                 2.04 kB
chunk-OUQPHY3I.js     | index               |   6.51 kB |                 2.02 kB
chunk-AE62OVYN.js     | index               |   2.16 kB |               902 bytes
chunk-6B4OG3SP.js     | -                   |   1.35 kB |               553 bytes
chunk-AOUOK2OI.js     | -                   | 217 bytes |               217 bytes
chunk-TUVMBXET.js     | index               | 153 bytes |               153 bytes


Server bundles       
Initial chunk files   | Names               |  Raw size
server.mjs            | server              | 822.24 kB |                        
chunk-KJDY2ZHR.mjs    | -                   | 732.29 kB |                        
chunk-HGGV4C2P.mjs    | -                   | 543.96 kB |                        
chunk-OQ7UJRH4.mjs    | -                   | 516.51 kB |                        
chunk-MNRWSXZP.mjs    | -                   | 414.28 kB |                        
polyfills.server.mjs  | polyfills.server    | 265.87 kB |                        
chunk-7G6LO3ZF.mjs    | -                   |  21.63 kB |                        
chunk-H4UZCO6D.mjs    | -                   |   2.92 kB |                        
main.server.mjs       | main.server         | 481 bytes |                        

Lazy chunk files      | Names               |  Raw size
chunk-BI5MKLS2.mjs    | -                   | 156.94 kB |                        
chunk-LZWIWZUT.mjs    | index               | 121.11 kB |                        
chunk-VU5GGPIS.mjs    | index               |  72.06 kB |                        
chunk-DZ2SJLEF.mjs    | index               |  16.63 kB |                        
chunk-PSWPOXEZ.mjs    | index               |  12.66 kB |                        
chunk-GU5K3B5R.mjs    | xhr2                |  12.08 kB |                        
chunk-DNRCV3NI.mjs    | index               |   9.88 kB |                        
chunk-LADPS5FK.mjs    | -                   |   8.83 kB |                        
chunk-WC6AJPEZ.mjs    | index               |   6.67 kB |                        
chunk-A5F3PLAC.mjs    | index               |   6.57 kB |                        
chunk-4OCMLMCM.mjs    | index               |   2.23 kB |                        
chunk-DIFMHJN4.mjs    | -                   |   1.38 kB |                        
chunk-S6MWLPPM.mjs    | getMachineId-win    | 616 bytes |                        
chunk-2AOMLZR3.mjs    | getMachineId-bsd    | 506 bytes |                        
chunk-SYDNMT3S.mjs    | getMachineId-darwin | 486 bytes |                        
...and 5 more lazy chunks files. Use "--verbose" to show all the files.
```