### PR TITLE
fix(explorers): ensure playwright reports are uploaded in CI

### DIFF
--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Run Explorer e2e tests
         env:
-          cmd: 'nx run ${{ inputs.explorer }}-app:e2e'
+          cmd: 'CI=true nx run ${{ inputs.explorer }}-app:e2e'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"

--- a/apps/agora/app/playwright.config.ts
+++ b/apps/agora/app/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   webServer: {
     command: 'nx run agora-apex:serve-detach',
     url: `${baseURL}/health`,
-    reuseExistingServer: !process.env['CI'],
+    reuseExistingServer: true,
     cwd: workspaceRoot,
     timeout: 60000 * 3, // give time for agora-data to populate agora-mongo
   },

--- a/apps/model-ad/app/playwright.config.ts
+++ b/apps/model-ad/app/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   webServer: {
     command: 'nx run model-ad-apex:serve-detach',
     url: `${baseURL}/health`,
-    reuseExistingServer: !process.env['CI'],
+    reuseExistingServer: true,
     cwd: workspaceRoot,
     timeout: 60000 * 3, // give time for model-ad-data to populate model-ad-mongo
   },


### PR DESCRIPTION
## Description

The `CI` environment variable was not set in the devcontainer, so playwright HTML reports were not prevented from opening (fix in #3222 depends on setting `CI` env var). Ensure that `CI` is set, so the correct configuration is used. 

## Related Issue

- N/A

## Changelog

- Set `CI` environment variable in devcontainer when running explorers e2e tests
- Always attempt reuse existing server when running explorers e2e tests; the CI workflow starts the app before running e2e tests

## Preview

Run the app: `model-ad-build-images && model-ad-app-start`
Edit `not-found.spec.ts` so the test will fail, e.g. change expected text content to "This will fail".
Run the e2e tests as if in CI: `CI=true nx e2e model-ad-app`
Tests should fail.
HTML report should not open.