### PR TITLE
chore(model-ad): update dockerfile to node.js 22 (SMR-202)

### DIFF
--- a/apps/model-ad/app/Dockerfile
+++ b/apps/model-ad/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.7.0-alpine
+FROM node:22.17.0-alpine3.21
 
 ENV APP_DIR=/app
 


### PR DESCRIPTION
## Description

Align the major version number of Node.js used as the base Docker image of the Model-AD web app to the version installed inside the dev environment. The update also fixes a [critical CVE.](https://hub.docker.com/layers/library/node/20.7.0-alpine/images/sha256-ad38de8de343e0fed46efcb5b8df47f4996da2a3fb359eef3f53243b1670b50e)

## Related Issue

- [SMR-202](https://sagebionetworks.jira.com/browse/SMR-202)

## Changelog

- Update `model-ad-app` base Docker image to Node.js 22.

## Preview

```
$ docker exec model-ad-app node --version
v22.17.0
```