### PR TITLE
feat(openchallenges): add DELETE endpoint for deleting a single challenge

### DIFF
--- a/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
@@ -72,12 +72,16 @@ paths:
       description: |
         Deletes a challenge using its unique ChallengeID. This action is
         irreversible.
-      operationId: DeleteChallengeById
+      operationId: deleteChallengeById
+      security:
+        - APIKeyAuth: []
       responses:
         '204':
           description: Deletion successful
-        '403':
+        '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -893,6 +897,12 @@ components:
             $ref: '#/components/schemas/BasicError'
     Unauthorized:
       description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Forbidden:
+      description: Forbidden
       content:
         application/problem+json:
           schema:

--- a/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
@@ -183,6 +183,11 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
   schemas:
     ChallengeSort:
       description: What to sort results by.

--- a/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
@@ -65,6 +65,23 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Challenge
+      summary: Delete a challenge
+      description: |
+        Deletes a challenge using its unique ChallengeID. This action is
+        irreversible.
+      operationId: DeleteChallengeById
+      responses:
+        '204':
+          description: Deletion successful
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /challenges/{challengeId}/contributions:
     parameters:
       - $ref: '#/components/parameters/challengeId'
@@ -870,6 +887,12 @@ components:
             $ref: '#/components/schemas/BasicError'
     NotFound:
       description: The specified resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Unauthorized:
+      description: Unauthorized
       content:
         application/problem+json:
           schema:

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -1429,3 +1429,8 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/AccountId'
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -78,12 +78,16 @@ paths:
       description: |
         Deletes a challenge using its unique ChallengeID. This action is
         irreversible.
-      operationId: DeleteChallengeById
+      operationId: deleteChallengeById
+      security:
+        - APIKeyAuth: []
       responses:
         '204':
           description: Deletion successful
-        '403':
+        '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -1323,6 +1327,12 @@ components:
             $ref: '#/components/schemas/BasicError'
     Unauthorized:
       description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Forbidden:
+      description: Forbidden
       content:
         application/problem+json:
           schema:

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -71,6 +71,23 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Challenge
+      summary: Delete a challenge
+      description: |
+        Deletes a challenge using its unique ChallengeID. This action is
+        irreversible.
+      operationId: DeleteChallengeById
+      responses:
+        '204':
+          description: Deletion successful
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   '/challenges/{challengeId}/contributions':
     parameters:
       - $ref: '#/components/parameters/challengeId'
@@ -1300,6 +1317,12 @@ components:
             $ref: '#/components/schemas/BasicError'
     NotFound:
       description: The specified resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Unauthorized:
+      description: Unauthorized
       content:
         application/problem+json:
           schema:

--- a/libs/openchallenges/api-description/src/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/src/challenge.openapi.yaml
@@ -36,3 +36,7 @@ paths:
     $ref: paths/challengePlatforms/@{challengePlatformName}.yaml
   /edamConcepts:
     $ref: paths/edamConcepts.yaml
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      $ref: components/securitySchemes/ApiKeyAuth.yaml

--- a/libs/openchallenges/api-description/src/components/responses/Forbidden.yaml
+++ b/libs/openchallenges/api-description/src/components/responses/Forbidden.yaml
@@ -1,0 +1,5 @@
+description: Forbidden
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
@@ -28,6 +28,8 @@ delete:
     Deletes a challenge using its unique ChallengeID. This action is
     irreversible.
   operationId: deleteChallengeById
+  security:
+    - APIKeyAuth: []
   responses:
     '204':
       description: Deletion successful

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
@@ -27,7 +27,7 @@ delete:
   description: |
     Deletes a challenge using its unique ChallengeID. This action is
     irreversible.
-  operationId: DeleteChallengeById
+  operationId: deleteChallengeById
   responses:
     '204':
       description: Deletion successful

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
@@ -31,9 +31,11 @@ delete:
   responses:
     '204':
       description: Deletion successful
+    '401':
+      $ref: ../../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../../components/responses/Forbidden.yaml
     '404':
       $ref: ../../components/responses/NotFound.yaml
-    '403':
-      $ref: ../../components/responses/Unauthorized.yaml
     '500':
       $ref: ../../components/responses/InternalServerError.yaml

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}.yaml
@@ -20,3 +20,20 @@ get:
       $ref: ../../components/responses/NotFound.yaml
     '500':
       $ref: ../../components/responses/InternalServerError.yaml
+delete:
+  tags:
+    - Challenge
+  summary: Delete a challenge
+  description: |
+    Deletes a challenge using its unique ChallengeID. This action is
+    irreversible.
+  operationId: DeleteChallengeById
+  responses:
+    '204':
+      description: Deletion successful
+    '404':
+      $ref: ../../components/responses/NotFound.yaml
+    '403':
+      $ref: ../../components/responses/Unauthorized.yaml
+    '500':
+      $ref: ../../components/responses/InternalServerError.yaml


### PR DESCRIPTION
## Changelog

- [x] Add API description for DELETE endpoint for a single challenge (@vpchung)
   - New schema for Forbidden response object for `403` status
- [x] Update OpenAPI spec (@vpchung)
- [ ] Implement feature (@tschaffter)

#### Notes
* Response code `204` is used, in order to indicate a successful request without needing to send any content back to the user [[ref](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/204)]

## Preview

_To add_
