### PR TITLE
refactor(openchallenges): compute the home page plot data dynamically to prevent data drift (SMR-233)

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/projection/YearlyChallengeCount.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/projection/YearlyChallengeCount.java
@@ -1,0 +1,6 @@
+package org.sagebionetworks.openchallenges.challenge.service.model.projection;
+
+public interface YearlyChallengeCount {
+  Integer getYear();
+  Integer getCount();
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/ChallengeRepository.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/repository/ChallengeRepository.java
@@ -1,7 +1,22 @@
 package org.sagebionetworks.openchallenges.challenge.service.model.repository;
 
+import java.util.List;
 import org.sagebionetworks.openchallenges.challenge.service.model.entity.ChallengeEntity;
+import org.sagebionetworks.openchallenges.challenge.service.model.projection.YearlyChallengeCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChallengeRepository
-  extends JpaRepository<ChallengeEntity, Long>, CustomChallengeRepository {}
+  extends JpaRepository<ChallengeEntity, Long>, CustomChallengeRepository {
+  @Query(
+    value = "SELECT EXTRACT(YEAR FROM start_date) AS year, COUNT(*) AS count " +
+    "FROM challenge " +
+    "WHERE start_date IS NOT NULL " +
+    "GROUP BY year ORDER BY year",
+    nativeQuery = true
+  )
+  List<YearlyChallengeCount> findChallengeCountsByYear();
+
+  @Query(value = "SELECT COUNT(*) FROM challenge WHERE start_date IS NULL", nativeQuery = true)
+  int countUndatedChallenges();
+}

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeAnalyticsService.java
@@ -1,45 +1,35 @@
 package org.sagebionetworks.openchallenges.challenge.service.service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.sagebionetworks.openchallenges.challenge.service.model.dto.ChallengesPerYearDto;
+import org.sagebionetworks.openchallenges.challenge.service.model.projection.YearlyChallengeCount;
+import org.sagebionetworks.openchallenges.challenge.service.model.repository.ChallengeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ChallengeAnalyticsService {
 
+  private final ChallengeRepository challengeRepository;
+
+  public ChallengeAnalyticsService(ChallengeRepository challengeRepository) {
+    this.challengeRepository = challengeRepository;
+  }
+
   @Transactional(readOnly = true)
   public ChallengesPerYearDto getChallengesPerYear() {
-    List<String> years = Arrays.asList(
-      "2007",
-      "2008",
-      "2009",
-      "2010",
-      "2011",
-      "2012",
-      "2013",
-      "2014",
-      "2015",
-      "2016",
-      "2017",
-      "2018",
-      "2019",
-      "2020",
-      "2021",
-      "2022",
-      "2023",
-      "2024",
-      "2025"
-    );
+    List<YearlyChallengeCount> results = challengeRepository.findChallengeCountsByYear();
+    int undatedChallengeCount = challengeRepository.countUndatedChallenges();
 
-    // The following line will be auto-updated by a script and should NOT be modified manually.
-    List<Integer> challengeCounts = /* AUTO-UPDATE MARKER */Arrays.asList(11, 17, 25, 34, 45, 53, 61, 73, 85, 100, 138, 155, 178, 203, 254, 316, 387, 452, 484);
-    Integer undatedChallengeCount = 171;
+    List<String> years = new ArrayList<>();
+    List<Integer> challengeCounts = new ArrayList<>();
 
-    // int currentYear = Year.now().getValue();
-    // years.removeIf(year -> Integer.parseInt(year) > currentYear);
-    // challengeCounts = challengeCounts.subList(0, years.size());
+    for (YearlyChallengeCount row : results) {
+      years.add(String.valueOf(row.getYear()));
+      challengeCounts.add(row.getCount());
+    }
 
     return ChallengesPerYearDto.builder()
       .years(years)

--- a/docker/openchallenges/services/challenge-service.yml
+++ b/docker/openchallenges/services/challenge-service.yml
@@ -23,6 +23,8 @@ services:
         condition: service_healthy
       openchallenges-elasticsearch:
         condition: service_healthy
+      openchallenges-postgres:
+        condition: service_healthy
       openchallenges-service-registry:
         condition: service_healthy
     deploy:

--- a/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
+++ b/libs/openchallenges/home/src/lib/statistics-viewer/statistics-viewer.component.html
@@ -1,11 +1,10 @@
 <section id="statistics" class="mat-typography">
-  <h3 class="section-title">Total Challenges Tracked</h3>
+  <h3 class="section-title">Challenge Activity Through the Years</h3>
   <div class="col container">
     <div id="timeline-plot" echarts [options]="chartOptions"></div>
     <!-- <div id="timeline-plot" echarts [options]="flippedChartOptions"></div> -->
     <span class="caption">
-      *The plot does not include challenges that are planned beyond this year, or those with
-      unspecified start dates.
+      The plot does not include challenges with unspecified start dates.
     </span>
   </div>
 </section>


### PR DESCRIPTION
## Related Issue

- [SMR-233](https://sagebionetworks.jira.com/browse/SMR-233)

## Changelog

- Compute the home page plot data with an SQL query in the challenge service.
- Update the plot title.

## Preview

### Before

```java
  public ChallengesPerYearDto getChallengesPerYear() {
    List<String> years = Arrays.asList(
      "2007",
      "2008",
      "2009",
      "2010",
      "2011",
      "2012",
      "2013",
      "2014",
      "2015",
      "2016",
      "2017",
      "2018",
      "2019",
      "2020",
      "2021",
      "2022",
      "2023",
      "2024",
      "2025"
    );

    // The following line will be auto-updated by a script and should NOT be modified manually.
    List<Integer> challengeCounts = /* AUTO-UPDATE MARKER */Arrays.asList(11, 17, 25, 34, 45, 53, 61, 73, 85, 100, 138, 155, 178, 203, 254, 316, 387, 452, 484);
    Integer undatedChallengeCount = 171;
```

### After

```json
{
  "years": [
    "1999",
    "2000",
    "2002",
    "2003",
    "2004",
    "2005",
    "2006",
    "2007",
    "2008",
    "2009",
    "2010",
    "2011",
    "2012",
    "2013",
    "2014",
    "2015",
    "2016",
    "2017",
    "2018",
    "2019",
    "2020",
    "2021",
    "2022",
    "2023",
    "2024",
    "2025"
  ],
  "challengeCounts": [
    3,
    1,
    1,
    1,
    2,
    5,
    4,
    11,
    6,
    8,
    9,
    11,
    8,
    8,
    12,
    12,
    15,
    38,
    17,
    23,
    25,
    51,
    62,
    71,
    65,
    32
  ],
  "undatedChallengeCount": 178
}
```


[SMR-233]: https://sagebionetworks.jira.com/browse/SMR-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ