### PR TITLE
feat(openchallenges): base changes for api-description

### DIFF
--- a/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
@@ -162,6 +162,11 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
   schemas:
     ChallengeSort:
       description: What to sort results by.

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -1396,3 +1396,8 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/AccountId'
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key

--- a/libs/openchallenges/api-description/openapi/organization.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/organization.openapi.yaml
@@ -57,6 +57,11 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
   schemas:
     OrganizationCategory:
       description: The category of the organization.

--- a/libs/openchallenges/api-description/src/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/src/challenge.openapi.yaml
@@ -36,3 +36,7 @@ paths:
     $ref: paths/challengePlatforms/@{challengePlatformName}.yaml
   /edamConcepts:
     $ref: paths/edamConcepts.yaml
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      $ref: components/securitySchemes/ApiKeyAuth.yaml

--- a/libs/openchallenges/api-description/src/components/responses/Forbidden.yaml
+++ b/libs/openchallenges/api-description/src/components/responses/Forbidden.yaml
@@ -1,0 +1,5 @@
+description: Forbidden - user does not have the permission to perform this action
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/openchallenges/api-description/src/organization.openapi.yaml
+++ b/libs/openchallenges/api-description/src/organization.openapi.yaml
@@ -20,3 +20,7 @@ paths:
     $ref: paths/organizations.yaml
   /organizations/{org}:
     $ref: paths/organizations/@{org}.yaml
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      $ref: components/securitySchemes/ApiKeyAuth.yaml


### PR DESCRIPTION
This PR lays the groundwork for adding "write" endpoints to the OC REST APIs

## Changelog

* add new schema for Forbidden response object for `403` status
* add `securitySchema` to the `challenge` and `organization` OpenAPI specs
