### PR TITLE
fix(sage-monorepo): update base Docker images to pull them from Google Cloud's cached Docker Hub images (SMR-234)

### DIFF
--- a/apps/agora/apex/Dockerfile
+++ b/apps/agora/apex/Dockerfile
@@ -1,3 +1,3 @@
-FROM caddy:2.8.4
+FROM mirror.gcr.io/caddy:2.8.4
 
 COPY Caddyfile /etc/caddy/

--- a/apps/agora/api-docs/Dockerfile
+++ b/apps/agora/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.1.5
+FROM mirror.gcr.io/redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8010" || exit 1

--- a/apps/agora/api/Dockerfile
+++ b/apps/agora/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.2-alpine
+FROM mirror.gcr.io/node:18.20.2-alpine
 
 ENV APP_DIR=/app
 

--- a/apps/agora/app/Dockerfile
+++ b/apps/agora/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.7.0-alpine
+FROM mirror.gcr.io/node:20.7.0-alpine
 
 ENV APP_DIR=/app
 

--- a/apps/agora/data/Dockerfile
+++ b/apps/agora/data/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
 # First, bundle the dependencies into the task root.
-FROM python:3.11.9-slim AS builder
+FROM mirror.gcr.io/python:3.11.9-slim AS builder
 
 # Enable bytecode compilation, to improve cold-start performance.
 ENV UV_COMPILE_BYTECODE=1
@@ -23,7 +23,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
     uv pip install -r requirements.txt --target "/app"
 
-FROM python:3.11.9-slim
+FROM mirror.gcr.io/python:3.11.9-slim
 
 ARG USERNAME=app
 ARG USER_UID=1000

--- a/apps/agora/mongo/Dockerfile
+++ b/apps/agora/mongo/Dockerfile
@@ -1,1 +1,1 @@
-FROM mongo:6.0.3
+FROM mirror.gcr.io/mongo:6.0.3

--- a/apps/amp-als/apex/Dockerfile
+++ b/apps/amp-als/apex/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:2.9.1
+FROM mirror.gcr.io/caddy:2.9.1
 
 RUN apk add --no-cache curl jq
 

--- a/apps/amp-als/api-docs/Dockerfile
+++ b/apps/amp-als/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.1.5
+FROM mirror.gcr.io/redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8403" || exit 1

--- a/apps/amp-als/opensearch/Dockerfile
+++ b/apps/amp-als/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.19.1
+FROM mirror.gcr.io/opensearchproject/opensearch:2.19.1
 
 COPY docker-healthcheck /usr/local/bin/
 

--- a/apps/amp-als/postgres/Dockerfile
+++ b/apps/amp-als/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.9-bullseye
+FROM mirror.gcr.io/postgres:16.9-bullseye
 
 COPY docker-healthcheck /usr/local/bin/
 

--- a/apps/iatlas/api/Dockerfile
+++ b/apps/iatlas/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
 # First, bundle the dependencies into the task root.
-FROM python:3.8.20-slim AS builder
+FROM mirror.gcr.io/python:3.8.20-slim AS builder
 
 # Enable bytecode compilation, to improve cold-start performance.
 ENV UV_COMPILE_BYTECODE=1
@@ -28,7 +28,7 @@ RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
 RUN uv export --frozen --no-emit-workspace --no-dev --group prod --no-editable -o requirements.txt \
   && uv pip install -r requirements.txt --target "/app"
 
-FROM python:3.8.20-slim
+FROM mirror.gcr.io/python:3.8.20-slim
 
 ENV APP_DIR=/app
 ENV PYTHONPATH="${APP_DIR}"

--- a/apps/iatlas/data/Dockerfile
+++ b/apps/iatlas/data/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
 # First, bundle the dependencies into the task root.
-FROM python:3.11.10-slim AS builder
+FROM mirror.gcr.io/python:3.11.10-slim AS builder
 
 # Enable bytecode compilation, to improve cold-start performance.
 ENV UV_COMPILE_BYTECODE=1
@@ -23,7 +23,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
     uv pip install -r requirements.txt --target "/app"
 
-FROM python:3.11.10-slim
+FROM mirror.gcr.io/python:3.11.10-slim
 
 ARG USERNAME=app
 ARG USER_UID=1000

--- a/apps/iatlas/postgres/Dockerfile
+++ b/apps/iatlas/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15.3-alpine
+FROM mirror.gcr.io/postgres:15.3-alpine
 
 COPY docker-healthcheck /usr/local/bin/
 

--- a/apps/model-ad/apex/Dockerfile
+++ b/apps/model-ad/apex/Dockerfile
@@ -1,3 +1,3 @@
-FROM caddy:2.8.4
+FROM mirror.gcr.io/caddy:2.8.4
 
 COPY Caddyfile /etc/caddy/

--- a/apps/model-ad/api-docs/Dockerfile
+++ b/apps/model-ad/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.1.5
+FROM mirror.gcr.io/redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8010" || exit 1

--- a/apps/model-ad/api/Dockerfile
+++ b/apps/model-ad/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.2-alpine
+FROM mirror.gcr.io/node:18.20.2-alpine
 
 ENV APP_DIR=/app
 

--- a/apps/model-ad/app/Dockerfile
+++ b/apps/model-ad/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.17.0-alpine3.21
+FROM mirror.gcr.io/node:22.17.0-alpine3.21
 
 ENV APP_DIR=/app
 

--- a/apps/model-ad/data/Dockerfile
+++ b/apps/model-ad/data/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
 # First, bundle the dependencies into the task root.
-FROM python:3.11.9-slim AS builder
+FROM mirror.gcr.io/python:3.11.9-slim AS builder
 
 # Enable bytecode compilation, to improve cold-start performance.
 ENV UV_COMPILE_BYTECODE=1
@@ -23,7 +23,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
     uv pip install -r requirements.txt --target "/app"
 
-FROM python:3.11.9-slim
+FROM mirror.gcr.io/python:3.11.9-slim
 
 ARG USERNAME=app
 ARG USER_UID=1000

--- a/apps/model-ad/mongo/Dockerfile
+++ b/apps/model-ad/mongo/Dockerfile
@@ -1,1 +1,1 @@
-FROM mongo:6.0.3
+FROM mirror.gcr.io/mongo:6.0.3

--- a/apps/observability/apex/Dockerfile
+++ b/apps/observability/apex/Dockerfile
@@ -1,3 +1,3 @@
-FROM caddy:2.8.4
+FROM mirror.gcr.io/caddy:2.8.4
 
 COPY Caddyfile /etc/caddy/

--- a/apps/observability/grafana/Dockerfile
+++ b/apps/observability/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:12.0.0
+FROM mirror.gcr.io/grafana/grafana:12.0.0
 
 # Copy datasources
 COPY provisioning/datasources/ /etc/grafana/provisioning/datasources/

--- a/apps/observability/loki/Dockerfile
+++ b/apps/observability/loki/Dockerfile
@@ -1,1 +1,1 @@
-FROM grafana/loki:3.5.0
+FROM mirror.gcr.io/grafana/loki:3.5.0

--- a/apps/observability/otel-collector/Dockerfile
+++ b/apps/observability/otel-collector/Dockerfile
@@ -1,1 +1,1 @@
-FROM otel/opentelemetry-collector-contrib:0.126.0
+FROM mirror.gcr.io/otel/opentelemetry-collector-contrib:0.126.0

--- a/apps/observability/prometheus/Dockerfile
+++ b/apps/observability/prometheus/Dockerfile
@@ -1,1 +1,1 @@
-FROM prom/prometheus:v3.3.1
+FROM mirror.gcr.io/prom/prometheus:v3.3.1

--- a/apps/observability/pyroscope/Dockerfile
+++ b/apps/observability/pyroscope/Dockerfile
@@ -1,1 +1,1 @@
-FROM grafana/pyroscope:1.13.4
+FROM mirror.gcr.io/grafana/pyroscope:1.13.4

--- a/apps/observability/tempo/Dockerfile
+++ b/apps/observability/tempo/Dockerfile
@@ -1,1 +1,1 @@
-FROM grafana/tempo:2.3.1
+FROM mirror.gcr.io/grafana/tempo:2.3.1

--- a/apps/openchallenges/apex/Dockerfile
+++ b/apps/openchallenges/apex/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy:2.8.4
+FROM mirror.gcr.io/caddy:2.8.4
 
 RUN apk add --no-cache curl jq
 

--- a/apps/openchallenges/api-docs/Dockerfile
+++ b/apps/openchallenges/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.1.5
+FROM mirror.gcr.io/redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8010" || exit 1

--- a/apps/openchallenges/app/Dockerfile
+++ b/apps/openchallenges/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.17.0-alpine3.21
+FROM mirror.gcr.io/node:22.17.0-alpine3.21
 
 ENV APP_DIR=/opt/app
 

--- a/apps/openchallenges/data-lambda/Dockerfile
+++ b/apps/openchallenges/data-lambda/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
 # First, bundle the dependencies into the task root.
-FROM public.ecr.aws/lambda/python:3.13 AS builder
+FROM public.ecr.aws/lambda/mirror.gcr.io/python:3.13 AS builder
 
 # Enable bytecode compilation, to improve cold-start performance.
 ENV UV_COMPILE_BYTECODE=1
@@ -23,7 +23,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
     uv pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
-FROM public.ecr.aws/lambda/python:3.13
+FROM public.ecr.aws/lambda/mirror.gcr.io/python:3.13
 
 # Copy the runtime dependencies from the builder stage.
 COPY --from=builder ${LAMBDA_TASK_ROOT} ${LAMBDA_TASK_ROOT}

--- a/apps/openchallenges/mcp-server/Dockerfile
+++ b/apps/openchallenges/mcp-server/Dockerfile
@@ -2,7 +2,7 @@
 FROM ghcr.io/sage-bionetworks/openchallenges-mcp-server-base:local
 
 # Alternative: Build a statically linked native binary of the app using GraalVM.
-# FROM busybox:1.36.1 AS busybox
+# FROM mirror.gcr.io/busybox:1.36.1 AS busybox
 
 # FROM scratch
 # COPY --from=busybox /tmp /tmp

--- a/apps/openchallenges/opensearch/Dockerfile
+++ b/apps/openchallenges/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.19.1
+FROM mirror.gcr.io/opensearchproject/opensearch:2.19.1
 
 COPY docker-healthcheck /usr/local/bin/
 

--- a/apps/openchallenges/postgres/Dockerfile
+++ b/apps/openchallenges/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.9-bullseye
+FROM mirror.gcr.io/postgres:16.9-bullseye
 
 COPY docker-healthcheck /usr/local/bin/
 

--- a/apps/sandbox/observability-python/Dockerfile
+++ b/apps/sandbox/observability-python/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
 # First, bundle the dependencies into the task root.
-FROM python:3.13.3-slim AS builder
+FROM mirror.gcr.io/python:3.13.3-slim AS builder
 
 # Enable bytecode compilation, to improve cold-start performance.
 ENV UV_COMPILE_BYTECODE=1
@@ -23,7 +23,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt && \
     uv pip install -r requirements.txt --target "/app"
 
-FROM python:3.13.3-slim
+FROM mirror.gcr.io/python:3.13.3-slim
 
 ARG USERNAME=app
 ARG USER_UID=1000

--- a/apps/synapse/api-docs/Dockerfile
+++ b/apps/synapse/api-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM redocly/redoc:v2.1.5
+FROM mirror.gcr.io/redocly/redoc:v2.1.5
 
 HEALTHCHECK --interval=2s --timeout=3s --retries=5 --start-period=2s \
   CMD curl --fail --silent "localhost:8010" || exit 1


### PR DESCRIPTION
## Description

Update base Docker images to pull them from Google Cloud's cached Docker Hub images. A parametrized solution should ideally be found later to avoid hard coding the mirror but we need this fix deployed ASAP.

## Related Issue

- [SMR-234](https://sagebionetworks.jira.com/browse/SMR-234)

## Changelog

- Update base Docker images to pull them from Google Cloud's cached Docker Hub images.

## References

- https://docs.docker.com/docker-hub/usage/
- https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images
