### PR TITLE
Feat api desc challenge service delete contributions

### DIFF
--- a/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge.openapi.yaml
@@ -85,6 +85,27 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - ChallengeContribution
+      summary: Delete all contributions for a specific challenge
+      description: |
+        Deletes all associated contributions for a given challenge, identified by its `challengeId`.
+        This action is irreversible.
+      operationId: deleteAllChallengeContributions
+      security:
+        - APIKeyAuth: []
+      responses:
+        '204':
+          description: Deletion successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /challengeAnalytics/challengesPerYear:
     get:
       tags:
@@ -875,6 +896,18 @@ components:
             $ref: '#/components/schemas/BasicError'
     NotFound:
       description: The specified resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Forbidden:
+      description: Forbidden - user does not have the permission to perform this action
       content:
         application/problem+json:
           schema:

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -91,6 +91,29 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - ChallengeContribution
+      summary: Delete all contributions for a specific challenge
+      description: >
+        Deletes all associated contributions for a given challenge, identified
+        by its `challengeId`.
+
+        This action is irreversible.
+      operationId: deleteAllChallengeContributions
+      security:
+        - APIKeyAuth: []
+      responses:
+        '204':
+          description: Deletion successful
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /challengeAnalytics/challengesPerYear:
     get:
       tags:
@@ -1300,6 +1323,18 @@ components:
             $ref: '#/components/schemas/BasicError'
     NotFound:
       description: The specified resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    Forbidden:
+      description: Forbidden - user does not have the permission to perform this action
       content:
         application/problem+json:
           schema:

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions.yaml
@@ -17,3 +17,24 @@ get:
       $ref: ../../../components/responses/BadRequest.yaml
     '500':
       $ref: ../../../components/responses/InternalServerError.yaml
+delete:
+  tags:
+    - ChallengeContribution
+  summary: Delete all contributions for a specific challenge
+  description: |
+    Deletes all associated contributions for a given challenge, identified by its `challengeId`.
+    This action is irreversible.
+  operationId: deleteAllChallengeContributions
+  security:
+    - APIKeyAuth: []
+  responses:
+    '204':
+      description: Deletion successful
+    '401':
+      $ref: ../../../components/responses/Unauthorized.yaml
+    '403':
+      $ref: ../../../components/responses/Forbidden.yaml
+    '404':
+      $ref: ../../../components/responses/NotFound.yaml
+    '500':
+      $ref: ../../../components/responses/InternalServerError.yaml


### PR DESCRIPTION
## Description

This PR adds an endpoint to delete all contributions of a challenge in the challenge service.

## Related Issue

[SMR-236](https://sagebionetworks.jira.com/browse/SMR-236)

## Changelog

- [ ] Add API description for DELETE endpoint (@vpchung)
- [ ] Update OpenAPI spec (@vpchung)
- [ ] Implement feature (@tschaffter)

#### Notes
* Response code `204` is used, in order to indicate a successful request without needing to send any content back to the user [[ref](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/204)]

## Preview

_To add_
