### PR TITLE
refactor(openchallenges): remove `CommonModule` from OC Angular components (SMR-242)

### DIFF
--- a/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge-overview/challenge-overview.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { Challenge } from '@sagebionetworks/openchallenges/api-client-angular';
 import { MOCK_ORGANIZATION_CARDS, OrganizationCard } from '@sagebionetworks/openchallenges/ui';
@@ -15,7 +15,7 @@ import {
     ChallengeIncentiveLabelPipe,
     ChallengeStatusLabelPipe,
     ChallengeSubmissionTypeLabelPipe,
-    CommonModule,
+    NgClass,
     MatIconModule,
   ],
   templateUrl: './challenge-overview.component.html',

--- a/libs/openchallenges/challenge/src/lib/challenge-stargazers/challenge-stargazers.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge-stargazers/challenge-stargazers.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { Challenge } from '@sagebionetworks/openchallenges/api-client-angular';
 import {
@@ -9,7 +8,7 @@ import {
 
 @Component({
   selector: 'openchallenges-challenge-stargazers',
-  imports: [CommonModule, PersonCardComponent],
+  imports: [PersonCardComponent],
   templateUrl: './challenge-stargazers.component.html',
   styleUrls: ['./challenge-stargazers.component.scss'],
 })

--- a/libs/openchallenges/challenge/src/lib/challenge.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.ts
@@ -27,7 +27,7 @@ import { ChallengeOrganizersComponent } from './challenge-organizers/challenge-o
 import { ChallengeOverviewComponent } from './challenge-overview/challenge-overview.component';
 // import { ChallengeStargazersComponent } from './challenge-stargazers/challenge-stargazers.component';
 import { ChallengeStatsComponent } from './challenge-stats/challenge-stats.component';
-import { NgClass, AsyncPipe, Location } from '@angular/common';
+import { NgClass, AsyncPipe, Location, TitleCasePipe } from '@angular/common';
 import { SeoService } from '@sagebionetworks/shared/util';
 import { getSeoData } from './challenge-seo-data';
 import { HttpParams } from '@angular/common/http';
@@ -47,6 +47,7 @@ import { HttpParams } from '@angular/common/http';
     ChallengeStatsComponent,
     AvatarComponent,
     FooterComponent,
+    TitleCasePipe,
   ],
   templateUrl: './challenge.component.html',
   styleUrls: ['./challenge.component.scss'],

--- a/libs/openchallenges/challenge/src/lib/challenge.component.ts
+++ b/libs/openchallenges/challenge/src/lib/challenge.component.ts
@@ -27,7 +27,7 @@ import { ChallengeOrganizersComponent } from './challenge-organizers/challenge-o
 import { ChallengeOverviewComponent } from './challenge-overview/challenge-overview.component';
 // import { ChallengeStargazersComponent } from './challenge-stargazers/challenge-stargazers.component';
 import { ChallengeStatsComponent } from './challenge-stats/challenge-stats.component';
-import { CommonModule, Location } from '@angular/common';
+import { NgClass, AsyncPipe, Location } from '@angular/common';
 import { SeoService } from '@sagebionetworks/shared/util';
 import { getSeoData } from './challenge-seo-data';
 import { HttpParams } from '@angular/common/http';
@@ -35,7 +35,8 @@ import { HttpParams } from '@angular/common/http';
 @Component({
   selector: 'openchallenges-challenge',
   imports: [
-    CommonModule,
+    NgClass,
+    AsyncPipe,
     RouterModule,
     MatTabsModule,
     MatIconModule,

--- a/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
+++ b/libs/openchallenges/home/src/lib/challenge-host-list/challenge-host-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { RouterModule } from '@angular/router';
@@ -21,7 +21,7 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'openchallenges-challenge-host-list',
-  imports: [CommonModule, MatButtonModule, OrganizationCardComponent, RouterModule],
+  imports: [AsyncPipe, MatButtonModule, OrganizationCardComponent, RouterModule],
   templateUrl: './challenge-host-list.component.html',
   styleUrls: ['./challenge-host-list.component.scss'],
 })

--- a/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.ts
+++ b/libs/openchallenges/home/src/lib/challenge-search/challenge-search.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@sagebionetworks/openchallenges/api-client-angular';
 import { Observable, map } from 'rxjs';
 import { Router, RouterModule } from '@angular/router';
-import { CommonModule, isPlatformServer } from '@angular/common';
+import { AsyncPipe, isPlatformServer } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgxTypedJsModule } from 'ngx-typed-js';
 import { InputTextModule } from 'primeng/inputtext';
@@ -17,14 +17,7 @@ import { CountUpModule } from 'ngx-countup';
 
 @Component({
   selector: 'openchallenges-challenge-search',
-  imports: [
-    CommonModule,
-    FormsModule,
-    NgxTypedJsModule,
-    InputTextModule,
-    CountUpModule,
-    RouterModule,
-  ],
+  imports: [AsyncPipe, FormsModule, NgxTypedJsModule, InputTextModule, CountUpModule, RouterModule],
   templateUrl: './challenge-search.component.html',
   styleUrls: ['./challenge-search.component.scss'],
 })

--- a/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.ts
+++ b/libs/openchallenges/home/src/lib/featured-challenge-list/featured-challenge-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import {
   Challenge,
@@ -12,7 +12,7 @@ import { Observable, catchError, map, of, switchMap, throwError } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-featured-challenge-list',
-  imports: [CommonModule, ChallengeCardComponent],
+  imports: [AsyncPipe, ChallengeCardComponent],
   templateUrl: './featured-challenge-list.component.html',
   styleUrls: ['./featured-challenge-list.component.scss'],
 })

--- a/libs/openchallenges/home/src/lib/platforms/platforms.component.ts
+++ b/libs/openchallenges/home/src/lib/platforms/platforms.component.ts
@@ -1,11 +1,11 @@
 import { Component, inject, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Image, ImageService } from '@sagebionetworks/openchallenges/api-client-angular';
 import { Observable } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-platforms',
-  imports: [CommonModule],
+  imports: [AsyncPipe],
   templateUrl: './platforms.component.html',
   styleUrls: ['./platforms.component.scss'],
 })

--- a/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.ts
+++ b/libs/openchallenges/home/src/lib/random-challenge-list/random-challenge-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { Observable, catchError, map, throwError } from 'rxjs';
@@ -13,7 +13,7 @@ import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'openchallenges-random-challenge-list',
-  imports: [CommonModule, MatButtonModule, ChallengeCardComponent, RouterModule],
+  imports: [AsyncPipe, MatButtonModule, ChallengeCardComponent, RouterModule],
   templateUrl: './random-challenge-list.component.html',
   styleUrls: ['./random-challenge-list.component.scss'],
 })

--- a/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.ts
+++ b/libs/openchallenges/home/src/lib/sponsor-list/sponsor-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
 import {
   Image,
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-sponsor-list',
-  imports: [CommonModule],
+  imports: [AsyncPipe],
   templateUrl: './sponsor-list.component.html',
   styleUrls: ['./sponsor-list.component.scss'],
 })

--- a/libs/openchallenges/home/src/lib/topics-viewer/topics-viewer.component.ts
+++ b/libs/openchallenges/home/src/lib/topics-viewer/topics-viewer.component.ts
@@ -1,9 +1,8 @@
-import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 
 @Component({
   selector: 'openchallenges-topics-viewer',
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './topics-viewer.component.html',
   styleUrls: ['./topics-viewer.component.scss'],
 })

--- a/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-overview/org-profile-overview.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { Organization } from '@sagebionetworks/openchallenges/api-client-angular';
 import { MOCK_ORGANIZATION_CARDS, OrganizationCard } from '@sagebionetworks/openchallenges/ui';
@@ -6,7 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'openchallenges-org-profile-overview',
-  imports: [CommonModule, MatIconModule],
+  imports: [NgClass, MatIconModule],
   templateUrl: './org-profile-overview.component.html',
   styleUrls: ['./org-profile-overview.component.scss'],
 })

--- a/libs/openchallenges/org-profile/src/lib/org-profile-stats/org-profile-stats.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile-stats/org-profile-stats.component.ts
@@ -6,12 +6,12 @@ import {
 } from '@sagebionetworks/openchallenges/api-client-angular';
 import { catchError, Observable, switchMap, throwError } from 'rxjs';
 import { HttpStatusRedirect, handleHttpError } from '@sagebionetworks/openchallenges/util';
-import { CommonModule } from '@angular/common';
+import { NgPlural, NgPluralCase, AsyncPipe } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'openchallenges-org-profile-stats',
-  imports: [CommonModule, MatIconModule],
+  imports: [NgPlural, NgPluralCase, AsyncPipe, MatIconModule],
   templateUrl: './org-profile-stats.component.html',
   styleUrls: ['./org-profile-stats.component.scss'],
 })

--- a/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
+++ b/libs/openchallenges/org-profile/src/lib/org-profile.component.ts
@@ -27,7 +27,7 @@ import {
   Image,
 } from '@sagebionetworks/openchallenges/api-client-angular';
 import { HttpStatusRedirect, handleHttpError } from '@sagebionetworks/openchallenges/util';
-import { CommonModule, Location } from '@angular/common';
+import { AsyncPipe, Location, NgClass } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { OrgProfileChallengesComponent } from './org-profile-challenges/org-profile-challenges.component';
 import { OrgProfileMembersComponent } from './org-profile-members/org-profile-members.component';
@@ -40,7 +40,8 @@ import { HttpParams } from '@angular/common/http';
 @Component({
   selector: 'openchallenges-org-profile',
   imports: [
-    CommonModule,
+    AsyncPipe,
+    NgClass,
     RouterModule,
     MatIconModule,
     OrgProfileOverviewComponent,

--- a/libs/openchallenges/team/src/lib/team.component.ts
+++ b/libs/openchallenges/team/src/lib/team.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, inject, OnInit, Renderer2 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import {
@@ -15,7 +15,7 @@ import { getSeoData } from './team-seo-data';
 
 @Component({
   selector: 'openchallenges-team',
-  imports: [CommonModule, RouterModule, FooterComponent],
+  imports: [AsyncPipe, RouterModule, FooterComponent],
   templateUrl: './team.component.html',
   styleUrls: ['./team.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/button-github/button-github.component.ts
+++ b/libs/openchallenges/ui/src/lib/button-github/button-github.component.ts
@@ -1,11 +1,10 @@
-import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'openchallenges-button-github',
   standalone: true,
-  imports: [CommonModule, MatButtonModule],
+  imports: [MatButtonModule],
   templateUrl: './button-github.component.html',
   styleUrls: ['./button-github.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgClass } from '@angular/common';
+import { AsyncPipe, NgClass, TitleCasePipe } from '@angular/common';
 import { Component, inject, Input, OnInit } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-challenge-card',
-  imports: [ChallengeIncentiveLabelPipe, NgClass, AsyncPipe, MatIconModule, RouterModule],
+  imports: [ChallengeIncentiveLabelPipe, NgClass, MatIconModule, RouterModule, TitleCasePipe],
   templateUrl: './challenge-card.component.html',
   styleUrls: ['./challenge-card.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/challenge-card/challenge-card.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { AsyncPipe, NgClass } from '@angular/common';
 import { Component, inject, Input, OnInit } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 
 @Component({
   selector: 'openchallenges-challenge-card',
-  imports: [ChallengeIncentiveLabelPipe, CommonModule, MatIconModule, RouterModule],
+  imports: [ChallengeIncentiveLabelPipe, NgClass, AsyncPipe, MatIconModule, RouterModule],
   templateUrl: './challenge-card.component.html',
   styleUrls: ['./challenge-card.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/footer/footer.component.ts
+++ b/libs/openchallenges/ui/src/lib/footer/footer.component.ts
@@ -1,12 +1,12 @@
 import { Component, inject, Input, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Image, ImageService } from '@sagebionetworks/openchallenges/api-client-angular';
 import { Observable } from 'rxjs';
 import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'openchallenges-footer',
-  imports: [CommonModule, RouterModule],
+  imports: [AsyncPipe, RouterModule],
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.ts
@@ -2,14 +2,13 @@ import { Component, Input, OnInit } from '@angular/core';
 import { OrganizationCard } from './organization-card';
 import { Avatar } from '../avatar/avatar';
 import { MOCK_MEMBERS, OrganizationMember } from './mock-members';
-import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
 import { AvatarComponent } from '../avatar/avatar.component';
 
 @Component({
   selector: 'openchallenges-organization-card',
-  imports: [CommonModule, AvatarComponent, MatIconModule, RouterModule],
+  imports: [AvatarComponent, MatIconModule, RouterModule],
   templateUrl: './organization-card.component.html',
   styleUrls: ['./organization-card.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.ts
+++ b/libs/openchallenges/ui/src/lib/organization-card/organization-card.component.ts
@@ -5,10 +5,11 @@ import { MOCK_MEMBERS, OrganizationMember } from './mock-members';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
 import { AvatarComponent } from '../avatar/avatar.component';
+import { SlicePipe } from '@angular/common';
 
 @Component({
   selector: 'openchallenges-organization-card',
-  imports: [AvatarComponent, MatIconModule, RouterModule],
+  imports: [AvatarComponent, MatIconModule, RouterModule, SlicePipe],
   templateUrl: './organization-card.component.html',
   styleUrls: ['./organization-card.component.scss'],
 })

--- a/libs/openchallenges/ui/src/lib/user-button/user-button.component.ts
+++ b/libs/openchallenges/ui/src/lib/user-button/user-button.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Avatar } from '../avatar/avatar';
 import { EMPTY_AVATAR } from '../avatar/mock-avatars';
 import { MenuItem } from './menu-item';
-import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
@@ -13,7 +12,6 @@ import { AvatarComponent } from '../avatar/avatar.component';
 @Component({
   selector: 'openchallenges-user-button',
   imports: [
-    CommonModule,
     RouterModule,
     MatButtonModule,
     MatDividerModule,


### PR DESCRIPTION
## Related Issue

- [SMR-242](https://sagebionetworks.jira.com/browse/SMR-242)

Fixes #(issue)

## Changelog

- Remove `CommonModule` from OC Angular components.

[SMR-242]: https://sagebionetworks.jira.com/browse/SMR-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ