### PR TITLE
chore(agora): update dockerfile to node.js 22 (SMR-201)

### DIFF
--- a/apps/agora/app/Dockerfile
+++ b/apps/agora/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/node:20.7.0-alpine
+FROM mirror.gcr.io/node:22.17.0-alpine3.21
 
 ENV APP_DIR=/app
 


### PR DESCRIPTION
## Description

Align the major version number of Node.js used as the base Docker image of the Model-AD web app to the version installed inside the dev environment. The update also fixes a [critical CVE.](https://hub.docker.com/layers/library/node/20.7.0-alpine/images/sha256-ad38de8de343e0fed46efcb5b8df47f4996da2a3fb359eef3f53243b1670b50e)

## Related Issue

- [SMR-201](https://sagebionetworks.jira.com/browse/SMR-201)

## Changelog

- Update `model-ad-app` base Docker image to Node.js 22.

## Preview

```
$ docker exec agora-app node --version
v22.17.0
```

[SMR-202]: https://sagebionetworks.jira.com/browse/SMR-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




[SMR-201]: https://sagebionetworks.jira.com/browse/SMR-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ