### PR TITLE
feat(openchallenges): add OpenSearch Dashboards to OC (SMR-220)

### DIFF
--- a/apps/openchallenges/opensearch-dashboards/Dockerfile
+++ b/apps/openchallenges/opensearch-dashboards/Dockerfile
@@ -1,0 +1,1 @@
+FROM mirror.gcr.io/opensearchproject/opensearch-dashboards:2.19.1

--- a/apps/openchallenges/opensearch-dashboards/project.json
+++ b/apps/openchallenges/opensearch-dashboards/project.json
@@ -1,0 +1,21 @@
+{
+  "name": "openchallenges-opensearch-dashboards",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "targets": {
+    "serve-detach": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker/openchallenges/serve-detach.sh {projectName}"
+      }
+    },
+    "scan-image": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "trivy image ghcr.io/sage-bionetworks/{projectName}:local --quiet",
+        "color": true
+      }
+    }
+  },
+  "tags": ["type:app", "scope:frontend"]
+}

--- a/docker/openchallenges/serve-detach.sh
+++ b/docker/openchallenges/serve-detach.sh
@@ -15,6 +15,7 @@ args=(
   --file docker/"$product_name"/services/image-service.yml
   --file docker/"$product_name"/services/kafka.yml
   --file docker/"$product_name"/services/mcp-server.yml
+  --file docker/"$product_name"/services/opensearch-dashboards.yml
   --file docker/"$product_name"/services/opensearch.yml
   --file docker/"$product_name"/services/organization-service.yml
   --file docker/"$product_name"/services/postgres.yml

--- a/docker/openchallenges/services/opensearch-dashboards.yml
+++ b/docker/openchallenges/services/opensearch-dashboards.yml
@@ -1,0 +1,19 @@
+services:
+  openchallenges-opensearch-dashboards:
+    image: ghcr.io/sage-bionetworks/openchallenges-opensearch-dashboards:${OPENCHALLENGES_VERSION:-local}
+    container_name: openchallenges-opensearch-dashboards
+    restart: always
+    environment:
+      - OPENSEARCH_HOSTS=["http://openchallenges-opensearch:9200"]
+      - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
+    networks:
+      - openchallenges
+    ports:
+      - '5601:5601'
+    depends_on:
+      openchallenges-opensearch:
+        condition: service_started
+    deploy:
+      resources:
+        limits:
+          memory: 512M


### PR DESCRIPTION
## Description

This dashboard will be used to visualize the data current indexed in OpenSearch as well as new data that will be indexed soon from external sites like Kaggle.

## Related Issue

- [SMR-220](https://sagebionetworks.jira.com/browse/SMR-220)

## Changelog

- Add the project `openchallenges-opensearch-dashboards`.
- Add Docker Compose files to start the new app.
- Reuse the existing dev container port `5601`.
- Document how to create an index pattern in OS Dashboads and explore OC data.

## Preview

### Starting the components

```bash
openchallenges-build-images
nx serve-detach openchallenges-{apex,opensearch-dashboards} --parallel 1
```

### Listing the indices in OpenSearch

At startup, the challenge and organization microservices index their data into OpenSearch. The indices can be listed using the command below. For example, we can see that the index `openchallenges-challenge-000001` includes 679 documents (challenges).

```console
$ curl -X GET "http://openchallenges-opensearch:9200/_cat/indices?v"
health status index                                    uuid                   pri rep docs.count docs.deleted store.size pri.store.size
yellow open   openchallenges-challenge-000001          H7kd_cgURSqnE1II4qSUbg   1   1        679            0    674.4kb        674.4kb
green  open   .plugins-ml-config                       NrI_ZGlaS2K7LfTfsoFnXg   1   0          1            0        4kb            4kb
green  open   .opensearch-observability                1uoIJkgXRXq-EJSnxpuv5A   1   0          0            0       208b           208b
yellow open   top_queries-2025.07.09-40803             oAeBLExaRwulVJiAEO1vlQ   1   1          9           18    293.2kb        293.2kb
green  open   .ql-datasources                          47XOH3kMQ-uVBDfCXbLRKQ   1   0          0            0       208b           208b
yellow open   openchallenges-organization-000001       mKm_LmV7S1m3le8ocZkeqg   1   1        509            0    419.2kb        419.2kb
green  open   .kibana_1                                0ECl1mgrQE6J6qjXXBekbA   1   0          1            0      5.3kb          5.3kb
yellow open   openchallenges-edam-concept-000001       6tCNUwpXSQa7oG4-ATid4A   1   1       3473            0    407.7kb        407.7kb
yellow open   openchallenges-challenge-platform-000001 7uhZMpLmSHS-ZMj-B009ng   1   1         15            0     10.9kb         10.9kb
```

### Accessing OS Dashboards

Navigate to http://localhost:5601

![image](https://github.com/user-attachments/assets/7b9c0506-7b9d-4488-ad1d-859a45d3b1ad)

![image](https://github.com/user-attachments/assets/3413f8e1-16da-4f78-a2a6-ad4cae1e938e)

Create the index pattern `openchallenges-challenge-*` in the screen shown below. When asked for a primary time property, select "created_at".

![image](https://github.com/user-attachments/assets/5cea77d2-1b06-4773-a934-142321c03da4)

Click on the 3 bar menu and select "Discover", then set the time window to include the documents created over the past 3 years.

![image](https://github.com/user-attachments/assets/a7b6f07e-6d06-41c0-85ad-5125ff2e564b)

By default, all the properties of the documents are displayed. Select a few properties like `name` and `platform.name` to only show these properties.

![image](https://github.com/user-attachments/assets/2a073673-e237-4414-8c57-ba814efb3d4d)

One or more filters can be applied to show only the documents of interest. Here, create a filter to show the documents that have their `status` set to "active".

![image](https://github.com/user-attachments/assets/40a4a9aa-6b52-47d6-8e8e-b5e2303dafdc)

![image](https://github.com/user-attachments/assets/98cc2c88-dda1-4d45-b52c-be05e0da9d14)

## References

- https://hub.docker.com/r/opensearchproject/opensearch-dashboards
- https://docs.opensearch.org/docs/latest/install-and-configure/install-dashboards/docker/

[SMR-220]: https://sagebionetworks.jira.com/browse/SMR-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ