### PR TITLE
fix(model-ad): fix style lint warnings in header (MG-294)

### DIFF
--- a/libs/explorers/ui/src/lib/components/header/header.component.scss
+++ b/libs/explorers/ui/src/lib/components/header/header.component.scss
@@ -4,11 +4,6 @@
 #header {
   padding: 10px 80px;
   min-height: var(--header-height);
-
-  @media (width <= 965px) {
-    padding: 10px 30px 10px 10px;
-  }
-
   display: flex;
   justify-content: center;
   align-items: center;
@@ -17,6 +12,10 @@
   // for hamburger menu styling
   position: relative;
   z-index: 999;
+
+  @media (width <= 965px) {
+    padding: 10px 30px 10px 10px;
+  }
 
   .header-inner {
     display: flex;


### PR DESCRIPTION
## Description
This fixes few style lint warnings in the console when running the Model-AD web app.

## Related Issue
[MG-294](https://sagebionetworks.jira.com/browse/MG-294)

## Changelog
Style lint warnings were triggered by the placement of @media queries.  Reordering the media queries fixes the error.


[MG-294]: https://sagebionetworks.jira.com/browse/MG-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ