### PR TITLE
feat(sage-monorepo): add GitHub remote MCP server

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,26 +1,8 @@
 {
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "github_token",
-      "description": "GitHub Personal Access Token",
-      "password": true
-    }
-  ],
   "servers": {
     "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
-      }
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
     },
     "openchallenges-mcp-server": {
       "type": "sse",

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,5 +1,27 @@
 {
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "github_token",
+      "description": "GitHub Personal Access Token",
+      "password": true
+    }
+  ],
   "servers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
+      }
+    },
     "openchallenges-mcp-server": {
       "type": "sse",
       "url": "http://localhost:8000/mcp-server/sse"


### PR DESCRIPTION
## Description

Add the [GitHub remote MCP server](https://github.com/github/github-mcp-server) to automate GitHub workflows and processes, and extract and analyze data from GitHub repositories.

## Preview

1. Open the file `.vscode/mcp.json`.
2. Click on the link "Start" displayed above the GitHub MCP server configuration.

<img width="1332" height="394" alt="image" src="https://github.com/user-attachments/assets/95199584-14d0-4379-93fa-6319bb38d1a6" />

3. Accept the prompt to authenticate and you will be redirected to a page in your browser. If this page does not load, head back to VS Code and click on the "Cancel" button of the popup.

<img width="847" height="219" alt="image" src="https://github.com/user-attachments/assets/13838139-1761-41b1-af1e-302fe9f2c3da" />

4. Another popup will propose an alternative way to login. Click "Yes".
5. A new page should open in the browser that should this time includes instructions on the next steps.

<img width="845" height="229" alt="image" src="https://github.com/user-attachments/assets/b34e9da5-7308-4cc3-9264-743597065582" />

6. After following the login steps, head back to the file `mcp.json` to confirm that the server is running and that MCP tools are available.

<img width="902" height="410" alt="image" src="https://github.com/user-attachments/assets/948c3d3a-5ae0-454c-93da-1e98ef40957a" />

7. Open Copilot and ask a question about the Sage-Bionetworks/sage-monorepo.

<img width="698" height="1445" alt="image" src="https://github.com/user-attachments/assets/7ee6a8eb-c01c-4ae6-a016-99f1dc0718c5" />



