### PR TITLE
feat(sage-monorepo): add Atlassian remote MCP server to `mcp.json` (SMR-267)

### DIFF
--- a/.github/instructions/nx.instructions.md
+++ b/.github/instructions/nx.instructions.md
@@ -9,14 +9,12 @@ You are in an nx workspace using Nx 21.2.1 and pnpm as the package manager.
 You have access to the Nx MCP server and the tools it provides. Use them. Follow these guidelines in order to best help the user:
 
 # General Guidelines
-
 - When answering questions, use the nx_workspace tool first to gain an understanding of the workspace architecture
 - For questions around nx configuration, best practices or if you're unsure, use the nx_docs tool to get relevant, up-to-date docs!! Always use this instead of assuming things about nx configuration
 - If the user needs help with an Nx configuration or project graph error, use the 'nx_workspace' tool to get any errors
 - To help answer questions about the workspace structure or simply help with demonstrating how tasks depend on each other, use the 'nx_visualize_graph' tool
 
 # Generation Guidelines
-
 If the user wants to generate something, use the following flow:
 
 - learn about the nx workspace and any specifics the user needs by using the 'nx_workspace' tool and the 'nx_project_details' tool if applicable
@@ -31,11 +29,19 @@ If the user wants to generate something, use the following flow:
 - use the information provided in the log file to answer the user's question or continue with what they were doing
 
 # Running Tasks Guidelines
-
 If the user wants help with tasks or commands (which include keywords like "test", "build", "lint", or other similar actions), use the following flow:
-
 - Use the 'nx_current_running_tasks_details' tool to get the list of tasks (this can include tasks that were completed, stopped or failed).
 - If there are any tasks, ask the user if they would like help with a specific task then use the 'nx_current_running_task_output' tool to get the terminal output for that task/command
 - Use the terminal output from 'nx_current_running_task_output' to see what's wrong and help the user fix their problem. Use the appropriate tools if necessary
 - If the user would like to rerun the task or command, always use `nx run <taskId>` to rerun in the terminal. This will ensure that the task will run in the nx context and will be run the same way it originally executed
-- If the task was marked as "continuous" do not offer to rerun the task. This task is already running and the user can see the output in the terminal. You can use 'nx_current_running_task_output' to get the output of the task to verify the output.
+- If the task was marked as "continuous" do not offer to rerun the task. This task is already running and the user can see the output in the terminal. You can use 'nx_current_running_task_output' to get the output of the task to verify the output. 
+
+
+# CI Error Guidelines
+If the user wants help with fixing an error in their CI pipeline, use the following flow:
+- Retrieve the list of current CI Pipeline Executions (CIPEs) using the 'nx_cloud_cipe_details' tool
+- If there are any errors, use the 'nx_cloud_fix_cipe_failure' tool to retrieve the logs for a specific task
+- Use the task logs to see what's wrong and help the user fix their problem. Use the appropriate tools if necessary
+- Make sure that the problem is fixed by running the task that you passed into the 'nx_cloud_fix_cipe_failure' tool
+
+

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,11 +1,9 @@
 {
   "servers": {
-    // https://www.atlassian.com/platform/remote-mcp-server
     "atlassian": {
       "type": "http",
       "url": "https://mcp.atlassian.com/v1/sse"
     },
-    // https://github.com/github/github-mcp-server/
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,5 +1,9 @@
 {
   "servers": {
+    "atlassian": {
+      "type": "sse",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    },
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,9 +1,11 @@
 {
   "servers": {
+    // https://www.atlassian.com/platform/remote-mcp-server
     "atlassian": {
-      "type": "sse",
+      "type": "http",
       "url": "https://mcp.atlassian.com/v1/sse"
     },
+    // https://github.com/github/github-mcp-server/
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"


### PR DESCRIPTION
## Description

Add Atlassian remote MCP server to `mcp.json` to extract information and manage resources in Jira and Confluence.

## Related Issue

- [SMR-267](https://sagebionetworks.jira.com/browse/SMR-267)

## How to install an MCP server

There are two ways to install a (remote) MCP server:

1. By adding its configuration directly to `.vscode/mcp.json`.
2. Using the Extension menu of VS Code
    - Open the Extension menu
    - Open the section "MCP Servers - Installed"
    - Place the cursor on this menu section to reveal the "globe" button named "Browse MCP Servers"
      - You are redirected to a web page that list MCP server.
    - Click on the "Install" button of the MCP server you want to install, e.g. GitHub or Atlassian
    - Back to VS Code, the MCP server will be listed as shown below

<img width="2357" height="1257" alt="image" src="https://github.com/user-attachments/assets/71c569b0-0cd9-453c-9cd9-6ca808f02245" />

The preferred method is to define the MCP server in `mcp.json` so that developers don't have to install them themselves and for audit reasons.

> [!INFO]
> MCP servers that are configured directly in `mcp.json` will all have the MCP icon with just a name. The MCP servers added via the Extension menu will appears with a custom icon, a name, description and publishing organization.

<img width="468" height="394" alt="image" src="https://github.com/user-attachments/assets/bdb439d7-def1-42d1-b6a7-6852cc74627f" />

## Preview

<img width="516" height="283" alt="image" src="https://github.com/user-attachments/assets/aea408f5-a68a-4089-8744-4f8b36c4a27f" />

> [!TIP]
> The MCP server may not need to be manually started. In at least one occurrence, Copilot was able to start the server on its own when asked a question that triggered it to use the Atlassian MCP server. This was done after the server had been manually started and stopped once.

<img width="504" height="705" alt="image" src="https://github.com/user-attachments/assets/691ce3c7-1361-46c6-98d5-6450e16c16ac" />

> [!WARNING]
> The two methods described above to install an MCP server (edit `mcp.json` and via the Extension menu) lead to the instantiation of different MCP server, even if their configuration is the same. For example, I first added GitHub via the Extension menu before using its metadata to add a corresponding configuration to `mcp.json`. This led to the creation of two MCP server instances for GitHub (74 tool each) triggered the error message reported below about Copilot's context being limited to 128 tools. 

## Copilot limits the number of MCP tools

<img width="489" height="296" alt="image" src="https://github.com/user-attachments/assets/ad784c59-7952-4563-9181-fbc7af132e26" />


[SMR-267]: https://sagebionetworks.jira.com/browse/SMR-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ