### PR TITLE
feat(model-ad): add model-ad boxplot and update boxplot styling options (MG-274, MG-299)

### DIFF
--- a/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.ts
+++ b/libs/agora/charts/src/lib/box-plot-chart/box-plot-chart.component.ts
@@ -10,6 +10,7 @@ import { HelperService } from '@sagebionetworks/agora/services';
 import { BoxPlotChartItem } from '@sagebionetworks/agora/models';
 import { CategoryBoxplotSummary, CategoryPoint } from '@sagebionetworks/shared/charts';
 import { BoxplotDirective } from '@sagebionetworks/shared/charts-angular';
+import { CallbackDataParams } from 'echarts/types/dist/shared';
 
 // -------------------------------------------------------------------------- //
 // Component
@@ -28,7 +29,7 @@ export class BoxPlotComponent {
   summaries: CategoryBoxplotSummary[] = [];
   xAxisCategoryToTooltipText: Record<string, string> | undefined = {};
   isInitialized = false;
-  pointTooltipFormatter: ((pt: CategoryPoint) => string) | undefined;
+  pointTooltipFormatter: ((pt: CategoryPoint, params: CallbackDataParams) => string) | undefined;
 
   get data(): BoxPlotChartItem[] {
     return this._data;
@@ -94,7 +95,7 @@ export class BoxPlotComponent {
         }
       }
 
-      this.pointTooltipFormatter = (pt: CategoryPoint) => {
+      this.pointTooltipFormatter = (pt: CategoryPoint, params: CallbackDataParams) => {
         return pt.text ?? pt.value.toString();
       };
     });

--- a/libs/explorers/util/src/lib/pipes/decode-greek-entity.pipe.spec.ts
+++ b/libs/explorers/util/src/lib/pipes/decode-greek-entity.pipe.spec.ts
@@ -1,0 +1,37 @@
+import { DecodeGreekEntityPipe } from './decode-greek-entity.pipe';
+
+describe('DecodeGreekEntityPipe', () => {
+  let pipe: DecodeGreekEntityPipe;
+
+  beforeEach(() => {
+    pipe = new DecodeGreekEntityPipe();
+  });
+
+  it('should return empty string when input is null or undefined', () => {
+    expect(pipe.transform(null)).toBe('');
+    expect(pipe.transform(undefined)).toBe('');
+  });
+
+  it('should return the same string when no Greek entities are present', () => {
+    expect(pipe.transform('Hello, World!')).toBe('Hello, World!');
+  });
+
+  it('should decode a single Greek entity', () => {
+    expect(pipe.transform('&alpha;')).toBe('\u03B1');
+    expect(pipe.transform('&beta;')).toBe('\u03B2');
+    expect(pipe.transform('&gamma;')).toBe('\u03B3');
+  });
+
+  it('should decode multiple Greek entities in a string', () => {
+    expect(pipe.transform('&alpha;&beta;&gamma;')).toBe('\u03B1\u03B2\u03B3');
+    expect(pipe.transform('&alpha;&beta;&alpha;')).toBe('\u03B1\u03B2\u03B1');
+    expect(pipe.transform('&Alpha;&alpha;&Beta;&beta;&Gamma;&gamma;&Delta;&delta;&Tau;&tau;')).toBe(
+      '\u0391\u03B1\u0392\u03B2\u0393\u03B3\u0394\u03B4\u03A4\u03C4',
+    );
+  });
+
+  it('should decode Greek entities mixed with regular text', () => {
+    expect(pipe.transform('&Alpha; and &beta;')).toBe('\u0391 and \u03B2');
+    expect(pipe.transform('The &delta; value is 0.05')).toBe('The \u03B4 value is 0.05');
+  });
+});

--- a/libs/explorers/util/src/lib/pipes/decode-greek-entity.pipe.ts
+++ b/libs/explorers/util/src/lib/pipes/decode-greek-entity.pipe.ts
@@ -1,0 +1,33 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'decodeGreekEntity',
+  standalone: true,
+})
+export class DecodeGreekEntityPipe implements PipeTransform {
+  private readonly greekToUnicodeMap: { [key: string]: string } = {
+    '&Alpha;': '\u0391',
+    '&alpha;': '\u03B1',
+    '&Beta;': '\u0392',
+    '&beta;': '\u03B2',
+    '&Gamma;': '\u0393',
+    '&gamma;': '\u03B3',
+    '&Delta;': '\u0394',
+    '&delta;': '\u03B4',
+    '&Tau;': '\u03A4',
+    '&tau;': '\u03C4',
+  };
+
+  transform(value: string | null | undefined): string {
+    if (!value) {
+      return '';
+    }
+
+    let clean = value;
+    for (const [entity, unicode] of Object.entries(this.greekToUnicodeMap)) {
+      clean = clean.replace(new RegExp(entity, 'g'), unicode);
+    }
+
+    return clean;
+  }
+}

--- a/libs/explorers/util/src/lib/pipes/index.ts
+++ b/libs/explorers/util/src/lib/pipes/index.ts
@@ -1,2 +1,3 @@
 export * from './capitalize-boolean.pipe';
+export * from './decode-greek-entity.pipe';
 export * from './sanitize-html.pipe';

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -7,4 +7,5 @@
   [pointTooltipFormatter]="pointTooltipFormatter"
   [pointCategoryColors]="pointCategoryColors"
   [pointCategoryShapes]="pointCategoryShapes"
+  [showLegend]="showLegend()"
 ></div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -1,0 +1,10 @@
+<h3>{{ modelData().age }}</h3>
+<div
+  sageBoxplot
+  [style.height]="450"
+  [points]="points()"
+  [yAxisTitle]="formatYAxisTitle()"
+  [pointTooltipFormatter]="pointTooltipFormatter"
+  [pointCategoryColors]="pointCategoryColors"
+  [pointCategoryShapes]="pointCategoryShapes"
+></div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -8,4 +8,5 @@
   [pointCategoryColors]="pointCategoryColors"
   [pointCategoryShapes]="pointCategoryShapes"
   [showLegend]="showLegend()"
+  [pointOpacity]="0.5"
 ></div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.scss
@@ -1,0 +1,3 @@
+h3 {
+  padding-bottom: 20px;
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
@@ -1,0 +1,80 @@
+import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
+import { render, screen } from '@testing-library/angular';
+import { ModelDetailsBoxplotComponent } from './model-details-boxplot.component';
+
+const mockModelData: ModelData = {
+  model: '3xTg-AD',
+  evidence_type: 'A&beta;42',
+  tissue: 'Cerebral Cortex',
+  age: '6 months',
+  units: 'ng/ml',
+  data: [
+    { genotype: '3xTg-AD', sex: 'Male', individual_id: '1001', value: 5.5 },
+    { genotype: '3xTg-AD', sex: 'Male', individual_id: '1002', value: 6.2 },
+    { genotype: '3xTg-AD', sex: 'Female', individual_id: '1003', value: 7.2 },
+    { genotype: '3xTg-AD', sex: 'Female', individual_id: '1004', value: 4.4 },
+  ],
+};
+
+async function setup(
+  modelData = mockModelData,
+  sexes: IndividualData.SexEnum[] = ['Male', 'Female'],
+) {
+  const { fixture } = await render(ModelDetailsBoxplotComponent, {
+    imports: [],
+    componentInputs: {
+      modelData,
+      sexes,
+    },
+  });
+  const component = fixture.componentInstance;
+  return { component, fixture };
+}
+
+describe('ModelDetailsBoxplotComponent', () => {
+  it('should render chart title with age', async () => {
+    await setup();
+    expect(screen.getByRole('heading', { level: 3, name: '6 months' })).toBeVisible();
+  });
+
+  it('should filter data by selected sexes', async () => {
+    const { component } = await setup(mockModelData, ['Male']);
+    const points = component.points();
+    expect(points).toHaveLength(2);
+    expect(points.every((point) => point.pointCategory === 'Male')).toBe(true);
+  });
+
+  it('should include both sexes when both are selected', async () => {
+    const { component } = await setup(mockModelData, ['Male', 'Female']);
+
+    const points = component.points();
+    expect(points).toHaveLength(4);
+
+    const malePoints = points.filter((point) => point.pointCategory === 'Male');
+    const femalePoints = points.filter((point) => point.pointCategory === 'Female');
+    expect(malePoints).toHaveLength(2);
+    expect(femalePoints).toHaveLength(2);
+  });
+
+  it('should handle empty sexes filter', async () => {
+    const { component } = await setup(mockModelData, []);
+    const points = component.points();
+    expect(points).toHaveLength(0);
+  });
+
+  it('should format Y-axis title with decoded Greek entities and title case', async () => {
+    const { component } = await setup(mockModelData);
+    const yAxisTitle = component.formatYAxisTitle();
+    expect(yAxisTitle).toBe('Aβ42 (ng/ml)');
+  });
+
+  it('should format Y-axis title without Greek entities', async () => {
+    const { component } = await setup({
+      ...mockModelData,
+      evidence_type: 'Beta amyloid',
+      units: 'pg/mg',
+    });
+    const yAxisTitle = component.formatYAxisTitle();
+    expect(yAxisTitle).toBe('Beta Amyloid (pg/mg)');
+  });
+});

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -29,6 +29,7 @@ export class ModelDetailsBoxplotComponent {
 
   modelData = input.required<ModelData>();
   sexes = input.required<IndividualData.SexEnum[]>();
+  showLegend = input<boolean>(false);
 
   points = computed<CategoryPoint[]>(() => {
     return this.modelData()

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -1,0 +1,61 @@
+import { TitleCasePipe } from '@angular/common';
+import { Component, computed, inject, input } from '@angular/core';
+import { DecodeGreekEntityPipe } from '@sagebionetworks/explorers/util';
+import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
+import { CategoryPoint } from '@sagebionetworks/shared/charts';
+import { BoxplotDirective } from '@sagebionetworks/shared/charts-angular';
+import { CallbackDataParams } from 'echarts/types/dist/shared';
+
+@Component({
+  selector: 'model-ad-model-details-boxplot',
+  imports: [BoxplotDirective],
+  providers: [DecodeGreekEntityPipe, TitleCasePipe],
+  templateUrl: './model-details-boxplot.component.html',
+  styleUrls: ['./model-details-boxplot.component.scss'],
+})
+export class ModelDetailsBoxplotComponent {
+  titleCasePipe = inject(TitleCasePipe);
+  decodeGreekEntityPipe = inject(DecodeGreekEntityPipe);
+
+  pointCategoryColors = {
+    Male: '#1B00B3',
+    Female: '#DB00FF',
+  };
+
+  pointCategoryShapes = {
+    Male: 'circle',
+    Female: 'triangle',
+  };
+
+  modelData = input.required<ModelData>();
+  sexes = input.required<IndividualData.SexEnum[]>();
+
+  points = computed<CategoryPoint[]>(() => {
+    return this.modelData()
+      .data.filter((individual) => this.sexes().includes(individual.sex))
+      .map((individual) => ({
+        xAxisCategory: individual.genotype,
+        value: individual.value,
+        gridCategory: individual.genotype,
+        pointCategory: individual.sex,
+        text: this.createTooltipText(individual, this.modelData().units),
+      }))
+      .sort((a, b) => a.pointCategory.localeCompare(b.pointCategory));
+  });
+
+  createTooltipText(individual: IndividualData, units: string): string {
+    return `${individual.sex}\n${individual.value} ${units}\nIndividual ID: ${individual.individual_id}`;
+  }
+
+  pointTooltipFormatter = (pt: CategoryPoint, params: CallbackDataParams) => {
+    return `${params.marker} ${pt.text ?? pt.value.toString()}`;
+  };
+
+  formatYAxisTitle = () => {
+    const evidenceType = this.decodeGreekEntityPipe.transform(
+      this.titleCasePipe.transform(this.modelData().evidence_type),
+    );
+    const units = this.modelData().units;
+    return `${evidenceType} (${units})`;
+  };
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
@@ -5,8 +5,12 @@
   </div>
 
   <div class="boxplots-grid">
-    @for (modelData of modelDataList(); track modelData) {
-      <model-ad-model-details-boxplot [modelData]="modelData" [sexes]="sexes()" />
+    @for (modelData of modelDataList(); track modelData; let last = $last) {
+      <model-ad-model-details-boxplot
+        [modelData]="modelData"
+        [sexes]="sexes()"
+        [showLegend]="$last"
+      />
     }
   </div>
 </div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
@@ -1,0 +1,12 @@
+<div class="boxplots-grid-container">
+  <div class="boxplots-grid-title">
+    <h2>{{ title() | decodeGreekEntity }}</h2>
+    <!-- <explorers-download-dom-image /> -->
+  </div>
+
+  <div class="boxplots-grid">
+    @for (modelData of modelDataList(); track modelData) {
+      <model-ad-model-details-boxplot [modelData]="modelData" [sexes]="sexes()" />
+    }
+  </div>
+</div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
@@ -1,0 +1,21 @@
+@use 'styles/src/lib/variables';
+@use 'styles/src/lib/mixins';
+
+.boxplots-grid-container {
+  overflow-x: hidden;
+
+  .boxplots-grid {
+    display: grid;
+    gap: 30px 50px;
+    grid-template-columns: minmax(0, 1fr);
+
+    @include mixins.respond-to('large') {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    shared-typescript-charts-angular {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
@@ -1,6 +1,10 @@
 @use 'styles/src/lib/variables';
 @use 'styles/src/lib/mixins';
 
+h2 {
+  padding-bottom: 30px;
+}
+
 .boxplots-grid-container {
   overflow-x: hidden;
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.spec.ts
@@ -1,0 +1,30 @@
+import { modelMock } from '@sagebionetworks/model-ad/testing';
+import { render, screen } from '@testing-library/angular';
+import { ModelDetailsBoxplotsGridComponent } from './model-details-boxplots-grid.component';
+
+const mockTitle = 'My Title';
+const mockModelDataList = modelMock.biomarkers.slice(1, 4);
+
+async function setup(modelDataList = mockModelDataList) {
+  return render(ModelDetailsBoxplotsGridComponent, {
+    imports: [],
+    componentInputs: {
+      modelDataList: modelDataList,
+      sexes: ['Male', 'Female'],
+      title: mockTitle,
+    },
+  });
+}
+
+describe('ModelDetailsBoxplotsGridComponent', () => {
+  it('should render title', async () => {
+    await setup();
+    expect(screen.getByRole('heading', { level: 2, name: mockTitle })).toBeVisible();
+  });
+
+  it('should render the correct number of boxplot components', async () => {
+    const { container } = await setup();
+    const boxplotComponents = container.querySelectorAll('model-ad-model-details-boxplot');
+    expect(boxplotComponents).toHaveLength(mockModelDataList.length);
+  });
+});

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
@@ -1,0 +1,16 @@
+import { Component, input } from '@angular/core';
+import { DecodeGreekEntityPipe } from '@sagebionetworks/explorers/util';
+import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
+import { ModelDetailsBoxplotComponent } from '../model-details-boxplot/model-details-boxplot.component';
+
+@Component({
+  selector: 'model-ad-model-details-boxplots-grid',
+  imports: [ModelDetailsBoxplotComponent, DecodeGreekEntityPipe],
+  templateUrl: './model-details-boxplots-grid.component.html',
+  styleUrls: ['./model-details-boxplots-grid.component.scss'],
+})
+export class ModelDetailsBoxplotsGridComponent {
+  modelDataList = input.required<ModelData[]>();
+  sexes = input.required<IndividualData.SexEnum[]>();
+  title = input.required<string>();
+}

--- a/libs/model-ad/model-details/src/lib/model-details.component.html
+++ b/libs/model-ad/model-details/src/lib/model-details.component.html
@@ -18,6 +18,11 @@
         }
         @case ('biomarkers') {
           <h2>Biomarkers</h2>
+          <model-ad-model-details-boxplots-grid
+            [title]="model.biomarkers[0].evidence_type"
+            [modelDataList]="model.biomarkers.slice(0, 3)"
+            [sexes]="['Male', 'Female']"
+          />
         }
         @case ('pathology') {
           <h2>Pathology</h2>

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -8,6 +8,7 @@ import { PanelNavigationComponent } from '@sagebionetworks/explorers/ui';
 import { LoadingIconComponent } from '@sagebionetworks/explorers/util';
 import { Model, ModelsService } from '@sagebionetworks/model-ad/api-client-angular';
 import { ConfigService, ROUTE_PATHS } from '@sagebionetworks/model-ad/config';
+import { ModelDetailsBoxplotsGridComponent } from './components/model-details-boxplots-grid/model-details-boxplots-grid.component';
 import { ModelDetailsHeroComponent } from './components/model-details-hero/model-details-hero.component';
 import { ModelDetailsOmicsComponent } from './components/model-details-omics/model-details-omics.component';
 import { ModelDetailsResourcesComponent } from './components/model-details-resources/model-details-resources.component';
@@ -20,6 +21,7 @@ import { ModelDetailsResourcesComponent } from './components/model-details-resou
     ModelDetailsOmicsComponent,
     ModelDetailsResourcesComponent,
     ModelDetailsHeroComponent,
+    ModelDetailsBoxplotsGridComponent,
   ],
   templateUrl: './model-details.component.html',
   styleUrls: ['./model-details.component.scss'],

--- a/libs/model-ad/model-details/src/test-setup.ts
+++ b/libs/model-ad/model-details/src/test-setup.ts
@@ -1,3 +1,78 @@
 import '@testing-library/jest-dom';
 import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
 setupZoneTestEnv();
+
+const originalClientHeightDescriptor = Object.getOwnPropertyDescriptor(
+  window.HTMLElement.prototype,
+  'clientHeight',
+);
+const originalClientWidthDescriptor = Object.getOwnPropertyDescriptor(
+  window.HTMLElement.prototype,
+  'clientWidth',
+);
+
+const observeMock = jest.fn();
+const unobserveMock = jest.fn();
+const disconnectMock = jest.fn();
+const originalResizeObserver = global.ResizeObserver;
+
+const originalGetBBoxDescriptor = Object.getOwnPropertyDescriptor(
+  global.SVGElement.prototype,
+  'getBBox',
+);
+
+beforeEach(() => {
+  /**
+   * Mock clientHeight and clientWidth -- Apache Echarts expects a non-zero value to be returned, but
+   * jsdom will always return 0. See https://github.com/jsdom/jsdom/issues/2342 and
+   * https://github.com/jsdom/jsdom/issues/2310. */
+  Object.defineProperty(window.HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: jest.fn().mockReturnValue(500),
+  });
+  Object.defineProperty(window.HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: jest.fn().mockReturnValue(100),
+  });
+
+  global.ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: observeMock,
+    unobserve: unobserveMock,
+    disconnect: disconnectMock,
+  }));
+
+  Object.defineProperty(global.SVGElement.prototype, 'getBBox', {
+    writable: true,
+    value: jest.fn().mockReturnValue({
+      x: 0,
+      y: 0,
+    }),
+  });
+});
+
+afterEach(() => {
+  if (originalClientHeightDescriptor) {
+    Object.defineProperty(
+      window.HTMLElement.prototype,
+      'clientHeight',
+      originalClientHeightDescriptor,
+    );
+  }
+
+  if (originalClientWidthDescriptor) {
+    Object.defineProperty(
+      window.HTMLElement.prototype,
+      'clientWidth',
+      originalClientWidthDescriptor,
+    );
+  }
+
+  global.ResizeObserver = originalResizeObserver;
+  observeMock.mockClear();
+  unobserveMock.mockClear();
+  disconnectMock.mockClear();
+
+  if (originalGetBBoxDescriptor) {
+    Object.defineProperty(global.SVGElement.prototype, 'getBBox', originalGetBBoxDescriptor);
+  }
+});

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -25,6 +25,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [pointCategoryColors]="pointCategoryColors"
       [pointCategoryShapes]="pointCategoryShapes"
       [showLegend]="showLegend"
+      [pointOpacity]="pointOpacity"
     ></div>`,
   })
   class TestComponent {
@@ -40,6 +41,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
     pointCategoryColors = props.pointCategoryColors;
     pointCategoryShapes = props.pointCategoryShapes;
     showLegend = props.showLegend;
+    pointOpacity = props.pointOpacity;
   }
 
   return await render(TestComponent, {

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -22,6 +22,8 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [yAxisMax]="yAxisMax"
       [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText"
       [pointTooltipFormatter]="pointTooltipFormatter"
+      [pointCategoryColors]="pointCategoryColors"
+      [pointCategoryShapes]="pointCategoryShapes"
     ></div>`,
   })
   class TestComponent {
@@ -34,6 +36,8 @@ const renderTestComponent = async (props: BoxplotProps) => {
     yAxisMax = props.yAxisMax;
     xAxisCategoryToTooltipText = props.xAxisCategoryToTooltipText;
     pointTooltipFormatter = props.pointTooltipFormatter;
+    pointCategoryColors = props.pointCategoryColors;
+    pointCategoryShapes = props.pointCategoryShapes;
   }
 
   return await render(TestComponent, {

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -24,6 +24,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [pointTooltipFormatter]="pointTooltipFormatter"
       [pointCategoryColors]="pointCategoryColors"
       [pointCategoryShapes]="pointCategoryShapes"
+      [showLegend]="showLegend"
     ></div>`,
   })
   class TestComponent {
@@ -38,6 +39,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
     pointTooltipFormatter = props.pointTooltipFormatter;
     pointCategoryColors = props.pointCategoryColors;
     pointCategoryShapes = props.pointCategoryShapes;
+    showLegend = props.showLegend;
   }
 
   return await render(TestComponent, {

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -17,7 +17,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity"></div>`,
   }),
 };
 export default meta;
@@ -60,5 +60,6 @@ export const DynamicSummary: Story = {
     pointCategoryColors: { Male: 'yellow', Female: 'green' },
     pointCategoryShapes: { Male: 'circle', Female: 'triangle' },
     showLegend: true,
+    pointOpacity: 0.5,
   },
 };

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -17,7 +17,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend"></div>`,
   }),
 };
 export default meta;
@@ -59,5 +59,6 @@ export const DynamicSummary: Story = {
       `${pt.pointCategory}: ${pt.value}`,
     pointCategoryColors: { Male: 'yellow', Female: 'green' },
     pointCategoryShapes: { Male: 'circle', Female: 'triangle' },
+    showLegend: true,
   },
 };

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -6,19 +6,18 @@ import {
   staticBoxplotSummaries,
 } from '@sagebionetworks/shared/charts';
 import { Meta, StoryObj } from '@storybook/angular';
+import { CallbackDataParams } from 'echarts/types/dist/shared';
 import { BoxplotDirective } from './boxplot.directive';
 
 const meta: Meta<BoxplotDirective> = {
   component: BoxplotDirective,
   title: 'directives/sageBoxplot',
   argTypes: {
-    // pointTooltipFormatter: {
-    //   control: { type: 'function' },
-    // },
+    pointTooltipFormatter: { control: false },
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes"></div>`,
   }),
 };
 export default meta;
@@ -45,7 +44,7 @@ export const StaticSummary: Story = {
     yAxisMax: 100,
     yAxisMin: -100,
     title: 'AD Diagnosis (males and females)',
-    pointTooltipFormatter: (pt: CategoryPoint) => {
+    pointTooltipFormatter: (pt: CategoryPoint, params: CallbackDataParams) => {
       return `Value: ${pt.value}`;
     },
   },
@@ -55,7 +54,10 @@ export const DynamicSummary: Story = {
   args: {
     points: dynamicBoxplotPoints,
     xAxisTitle: 'MODEL',
-    yAxisTitle: '#objects/sqmm',
-    pointTooltipFormatter: (pt: CategoryPoint) => `${pt.pointCategory}: ${pt.value}`,
+    yAxisTitle: 'Insoluble A&beta;40 #objects/sqmm',
+    pointTooltipFormatter: (pt: CategoryPoint, params: CallbackDataParams) =>
+      `${pt.pointCategory}: ${pt.value}`,
+    pointCategoryColors: { Male: 'yellow', Female: 'green' },
+    pointCategoryShapes: { Male: 'circle', Female: 'triangle' },
   },
 };

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -29,6 +29,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
     | ((pt: CategoryPoint, params: CallbackDataParams) => string);
   @Input() pointCategoryColors: undefined | Record<string, string>;
   @Input() pointCategoryShapes: undefined | Record<string, string>;
+  @Input() showLegend: undefined | boolean;
 
   ngOnInit() {
     this.boxplot = new BoxplotChart(this.el.nativeElement, this.getBoxplotProps());
@@ -55,6 +56,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       pointTooltipFormatter: this.pointTooltipFormatter,
       pointCategoryColors: this.pointCategoryColors,
       pointCategoryShapes: this.pointCategoryShapes,
+      showLegend: this.showLegend,
     };
   }
 }

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -5,6 +5,7 @@ import {
   CategoryBoxplotSummary,
   CategoryPoint,
 } from '@sagebionetworks/shared/charts';
+import { CallbackDataParams } from 'echarts/types/dist/shared';
 
 @Directive({
   selector: '[sageBoxplot]',
@@ -18,12 +19,16 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input({ required: true }) points: CategoryPoint[] = [];
   @Input() summaries: CategoryBoxplotSummary[] | undefined;
   @Input() title = '';
-  @Input() xAxisTitle = '';
+  @Input() xAxisTitle: string | undefined;
   @Input() yAxisTitle = '';
   @Input() yAxisMin: number | undefined;
   @Input() yAxisMax: number | undefined;
   @Input() xAxisCategoryToTooltipText: Record<string, string> | undefined;
-  @Input() pointTooltipFormatter: undefined | ((pt: CategoryPoint) => string);
+  @Input() pointTooltipFormatter:
+    | undefined
+    | ((pt: CategoryPoint, params: CallbackDataParams) => string);
+  @Input() pointCategoryColors: undefined | Record<string, string>;
+  @Input() pointCategoryShapes: undefined | Record<string, string>;
 
   ngOnInit() {
     this.boxplot = new BoxplotChart(this.el.nativeElement, this.getBoxplotProps());
@@ -48,6 +53,8 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       yAxisMax: this.yAxisMax,
       xAxisCategoryToTooltipText: this.xAxisCategoryToTooltipText,
       pointTooltipFormatter: this.pointTooltipFormatter,
+      pointCategoryColors: this.pointCategoryColors,
+      pointCategoryShapes: this.pointCategoryShapes,
     };
   }
 }

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -30,6 +30,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() pointCategoryColors: undefined | Record<string, string>;
   @Input() pointCategoryShapes: undefined | Record<string, string>;
   @Input() showLegend: undefined | boolean;
+  @Input() pointOpacity: undefined | number;
 
   ngOnInit() {
     this.boxplot = new BoxplotChart(this.el.nativeElement, this.getBoxplotProps());
@@ -57,6 +58,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       pointCategoryColors: this.pointCategoryColors,
       pointCategoryShapes: this.pointCategoryShapes,
       showLegend: this.showLegend,
+      pointOpacity: this.pointOpacity,
     };
   }
 }

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -28,6 +28,7 @@ const yAxisPadding = 0.2;
 const defaultPointShape = 'circle';
 const defaultPointSize = 18;
 const defaultPointColor = '#8b8ad1';
+const defaultPointOpacity = 0.8;
 
 const Y_AXIS_TICK_LABELS_MAX_WIDTH = 80;
 const SPACE_FOR_Y_AXIS_NAME = 40;
@@ -68,6 +69,7 @@ export class BoxplotChart {
       pointTooltipFormatter,
       pointCategoryColors,
       pointCategoryShapes,
+      pointOpacity,
     } = boxplotProps;
 
     const showLegend = boxplotProps.showLegend || false;
@@ -213,6 +215,7 @@ export class BoxplotChart {
                   pointCategories,
                   defaultPointColor,
                 ),
+          opacity: pointOpacity || defaultPointOpacity,
         },
         tooltip: {
           formatter: (params) => {

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -70,6 +70,8 @@ export class BoxplotChart {
       pointCategoryShapes,
     } = boxplotProps;
 
+    const showLegend = boxplotProps.showLegend || false;
+
     const noPoints = points.length === 0;
     const noSummaries = summaries == null || summaries.length === 0;
 
@@ -181,6 +183,7 @@ export class BoxplotChart {
       seriesOpts.push({
         type: 'scatter',
         datasetId: id,
+        name: id,
         xAxisId: 'value-x-axis',
         encode: {
           x: 'xAxisValue',
@@ -247,6 +250,16 @@ export class BoxplotChart {
     }
 
     const option: EChartsOption = {
+      legend: {
+        show: showLegend,
+        data: pointDatasetIds,
+        orient: 'horizontal',
+        left: 'left',
+        top: 'bottom',
+        itemHeight: defaultPointSize,
+        itemWidth: defaultPointSize,
+        selectedMode: false,
+      },
       grid: {
         top: title ? 60 : 20,
         left: Y_AXIS_TICK_LABELS_MAX_WIDTH + SPACE_FOR_Y_AXIS_NAME,

--- a/libs/shared/typescript/charts/src/lib/models/boxplot.ts
+++ b/libs/shared/typescript/charts/src/lib/models/boxplot.ts
@@ -63,4 +63,5 @@ export interface BoxplotProps {
   where key is the pointCategory and value is the shape. */
   pointCategoryShapes?: Record<string, string>;
   showLegend?: boolean;
+  pointOpacity?: number;
 }

--- a/libs/shared/typescript/charts/src/lib/models/boxplot.ts
+++ b/libs/shared/typescript/charts/src/lib/models/boxplot.ts
@@ -1,3 +1,5 @@
+import type { CallbackDataParams } from 'echarts/types/dist/shared';
+
 export type CategoryPoint = {
   // x-axis category for this point
   xAxisCategory: string;
@@ -53,5 +55,11 @@ export interface BoxplotProps {
   is the tooltipText. otherwise, tooltips will not be displayed. */
   xAxisCategoryToTooltipText?: Record<string, string>;
   /* if defined, will be used to format tooltip for each point. */
-  pointTooltipFormatter?: (pt: CategoryPoint) => string;
+  pointTooltipFormatter?: (pt: CategoryPoint, params: CallbackDataParams) => string;
+  /* if defined, will be used to set color for each point based on its pointCategory, 
+  where key is the pointCategory and value is the color. */
+  pointCategoryColors?: Record<string, string>;
+  /* if defined, will be used to set shape for each point based on its pointCategory, 
+  where key is the pointCategory and value is the shape. */
+  pointCategoryShapes?: Record<string, string>;
 }

--- a/libs/shared/typescript/charts/src/lib/models/boxplot.ts
+++ b/libs/shared/typescript/charts/src/lib/models/boxplot.ts
@@ -62,4 +62,5 @@ export interface BoxplotProps {
   /* if defined, will be used to set shape for each point based on its pointCategory, 
   where key is the pointCategory and value is the shape. */
   pointCategoryShapes?: Record<string, string>;
+  showLegend?: boolean;
 }

--- a/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.spec.ts
+++ b/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.spec.ts
@@ -50,62 +50,37 @@ describe('boxplot-utils', () => {
 
   describe('getPointStyleFromArray', () => {
     const pointCategories = ['a', 'b', 'c'];
-    const pt = { xAxisCategory: 'first', value: 1, pointCategory: 'a' };
     const shapes = ['circle', 'triangle'];
     const styleType = 'shape';
     const notFoundValue = 'none';
 
     it('should handle valid point categories', () => {
-      expect(getPointStyleFromArray(pt, pointCategories, shapes, styleType, notFoundValue)).toEqual(
-        'circle',
-      );
       expect(
-        getPointStyleFromArray(
-          { ...pt, pointCategory: 'b' },
-          pointCategories,
-          shapes,
-          styleType,
-          notFoundValue,
-        ),
+        getPointStyleFromArray('a', pointCategories, shapes, styleType, notFoundValue),
+      ).toEqual('circle');
+      expect(
+        getPointStyleFromArray('b', pointCategories, shapes, styleType, notFoundValue),
       ).toEqual('triangle');
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should reuse values if there are more categories than values', () => {
-      expect(
-        getPointStyleFromArray(
-          { ...pt, pointCategory: 'c' },
-          pointCategories,
-          shapes,
-          'shape',
-          'none',
-        ),
-      ).toEqual('circle');
+      expect(getPointStyleFromArray('c', pointCategories, shapes, 'shape', 'none')).toEqual(
+        'circle',
+      );
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should return notFoundValue if category is not found', () => {
       expect(
-        getPointStyleFromArray(
-          { ...pt, pointCategory: 'd' },
-          pointCategories,
-          shapes,
-          styleType,
-          notFoundValue,
-        ),
+        getPointStyleFromArray('d', pointCategories, shapes, styleType, notFoundValue),
       ).toEqual(notFoundValue);
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should return notFoundValue if category is undefined', () => {
       expect(
-        getPointStyleFromArray(
-          { ...pt, pointCategory: undefined },
-          pointCategories,
-          shapes,
-          styleType,
-          notFoundValue,
-        ),
+        getPointStyleFromArray(undefined, pointCategories, shapes, styleType, notFoundValue),
       ).toEqual(notFoundValue);
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     });
@@ -113,81 +88,46 @@ describe('boxplot-utils', () => {
 
   describe('getCategoryPointShape', () => {
     it('should return first shape for the first point category', () => {
-      expect(
-        getCategoryPointShape({ xAxisCategory: 'b', pointCategory: 'X', value: 1 }, [
-          'X',
-          'Y',
-          'Z',
-        ]),
-      ).toEqual('circle');
+      expect(getCategoryPointShape('X', ['X', 'Y', 'Z'])).toEqual('circle');
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should return second shape for the second point category', () => {
-      expect(
-        getCategoryPointShape({ xAxisCategory: 'b', pointCategory: 'Y', value: 1 }, [
-          'X',
-          'Y',
-          'Z',
-        ]),
-      ).toEqual('triangle');
+      expect(getCategoryPointShape('Y', ['X', 'Y', 'Z'])).toEqual('triangle');
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should return default when point category is not found', () => {
-      expect(
-        getCategoryPointShape({ xAxisCategory: 'b', pointCategory: 'WW', value: 1 }, [
-          'X',
-          'Y',
-          'Z',
-        ]),
-      ).toEqual('none');
+      expect(getCategoryPointShape('WW', ['X', 'Y', 'Z'])).toEqual('none');
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('getCategoryPointColor', () => {
     it('should return first color for the first point category', () => {
-      expect(
-        getCategoryPointColor(
-          { xAxisCategory: 'b', pointCategory: 'X', value: 1 },
-          ['X', 'Y', 'Z'],
-          ['blue', 'red', 'yellow'],
-        ),
-      ).toEqual('blue');
+      expect(getCategoryPointColor('X', ['X', 'Y', 'Z'], ['blue', 'red', 'yellow'])).toEqual(
+        'blue',
+      );
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should return second color for the second point category', () => {
-      expect(
-        getCategoryPointColor(
-          { xAxisCategory: 'b', pointCategory: 'Y', value: 1 },
-          ['X', 'Y', 'Z'],
-          ['blue', 'red', 'yellow'],
-        ),
-      ).toEqual('red');
+      expect(getCategoryPointColor('Y', ['X', 'Y', 'Z'], ['blue', 'red', 'yellow'])).toEqual('red');
       expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should return default when point category is not found', () => {
-      expect(
-        getCategoryPointColor({ xAxisCategory: 'b', pointCategory: 'WW', value: 1 }, [
-          'X',
-          'Y',
-          'Z',
-        ]),
-      ).toEqual('transparent');
+      expect(getCategoryPointColor('WW', ['X', 'Y', 'Z'])).toEqual('transparent');
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('getCategoryPointStyle', () => {
-    const point = { xAxisCategory: 'b', pointCategory: 'X', value: 1 };
     const pointCategories = ['X', 'Y', 'Z'];
 
     it('should return default value when hasPointCategories is false', () => {
       const result = getCategoryPointStyle(
-        point,
+        'X',
         false,
         { X: 'triangle' },
         getCategoryPointShape,
@@ -200,7 +140,7 @@ describe('boxplot-utils', () => {
     it('should return custom style when point category in custom mapping', () => {
       const customShapes = { X: 'triangle', Y: 'rect' };
       const result = getCategoryPointStyle(
-        point,
+        'X',
         true,
         customShapes,
         getCategoryPointShape,
@@ -211,10 +151,9 @@ describe('boxplot-utils', () => {
     });
 
     it('should return default when point category not in custom mapping', () => {
-      const pointWithUnknownCategory = { xAxisCategory: 'b', pointCategory: 'Z', value: 1 };
       const customShapes = { X: 'triangle', Y: 'rect' };
       const result = getCategoryPointStyle(
-        pointWithUnknownCategory,
+        'Z',
         true,
         customShapes,
         getCategoryPointShape,
@@ -226,7 +165,7 @@ describe('boxplot-utils', () => {
 
     it('should use default style fucntion when no custom mapping is provided', () => {
       const result = getCategoryPointStyle(
-        point,
+        'X',
         true,
         undefined,
         getCategoryPointShape,

--- a/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.spec.ts
+++ b/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.spec.ts
@@ -10,6 +10,7 @@ import {
   formatCategoryPointsForBoxplotTransform,
   getCategoryPointColor,
   getCategoryPointShape,
+  getCategoryPointStyle,
   getOffsetAndJitteredXValue,
   getPointStyleFromArray,
   getRandomNumber,
@@ -177,6 +178,62 @@ describe('boxplot-utils', () => {
         ]),
       ).toEqual('transparent');
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getCategoryPointStyle', () => {
+    const point = { xAxisCategory: 'b', pointCategory: 'X', value: 1 };
+    const pointCategories = ['X', 'Y', 'Z'];
+
+    it('should return default value when hasPointCategories is false', () => {
+      const result = getCategoryPointStyle(
+        point,
+        false,
+        { X: 'triangle' },
+        getCategoryPointShape,
+        pointCategories,
+        'circle',
+      );
+      expect(result).toEqual('circle');
+    });
+
+    it('should return custom style when point category in custom mapping', () => {
+      const customShapes = { X: 'triangle', Y: 'rect' };
+      const result = getCategoryPointStyle(
+        point,
+        true,
+        customShapes,
+        getCategoryPointShape,
+        pointCategories,
+        'circle',
+      );
+      expect(result).toEqual('triangle');
+    });
+
+    it('should return default when point category not in custom mapping', () => {
+      const pointWithUnknownCategory = { xAxisCategory: 'b', pointCategory: 'Z', value: 1 };
+      const customShapes = { X: 'triangle', Y: 'rect' };
+      const result = getCategoryPointStyle(
+        pointWithUnknownCategory,
+        true,
+        customShapes,
+        getCategoryPointShape,
+        pointCategories,
+        'circle',
+      );
+      expect(result).toEqual('circle');
+    });
+
+    it('should use default style fucntion when no custom mapping is provided', () => {
+      const result = getCategoryPointStyle(
+        point,
+        true,
+        undefined,
+        getCategoryPointShape,
+        pointCategories,
+        'triangle',
+      );
+      expect(result).toEqual('circle');
     });
   });
 

--- a/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.ts
+++ b/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.ts
@@ -47,6 +47,27 @@ export const getCategoryPointColor = (
   return getPointStyleFromArray(pt, pointCategories, colors, 'color', 'transparent');
 };
 
+export const getCategoryPointStyle = <T>(
+  point: CategoryPoint,
+  hasPointCategories: boolean,
+  customMapping: Record<string, T> | undefined,
+  defaultStyleFunction: (pt: CategoryPoint, categories: string[]) => T,
+  pointCategories: string[],
+  defaultValue: T,
+): T => {
+  if (!hasPointCategories) {
+    return defaultValue;
+  }
+
+  if (customMapping) {
+    const ptCategory = point.pointCategory;
+    const customStyle = ptCategory && customMapping[ptCategory];
+    return customStyle || defaultValue;
+  } else {
+    return defaultStyleFunction(point, pointCategories);
+  }
+};
+
 export function getUniqueValues(
   values: Record<string, unknown>[],
   key: string,

--- a/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.ts
+++ b/libs/shared/typescript/charts/src/lib/utils/boxplot-utils.ts
@@ -2,15 +2,15 @@ import { CategoryAsValuePoint, CategoryBoxplotSummary, CategoryPoint } from '../
 import { CategoryAsValueBoxplotSummary } from '../models/boxplot';
 
 export const getPointStyleFromArray = (
-  pt: CategoryPoint,
+  pointCategory: string | undefined,
   pointCategories: string[],
   styleValues: string[],
   styleType: string,
   notFoundValue: string,
 ) => {
-  const pointIndex = pointCategories.indexOf(pt.pointCategory || '');
+  const pointIndex = pointCategories.indexOf(pointCategory || '');
   if (pointIndex < 0) {
-    console.warn(`Point category ${pt.pointCategory} not found.`);
+    console.warn(`Point category ${pointCategory} not found.`);
     return notFoundValue;
   }
   if (pointIndex >= styleValues.length) {
@@ -23,15 +23,15 @@ export const getPointStyleFromArray = (
 };
 
 export const getCategoryPointShape = (
-  pt: CategoryPoint,
+  pointCategory: string | undefined,
   pointCategories: string[],
   shapes: string[] = ['circle', 'triangle', 'rect', 'roundRect', 'diamond', 'pin', 'arrow'],
 ) => {
-  return getPointStyleFromArray(pt, pointCategories, shapes, 'shape', 'none');
+  return getPointStyleFromArray(pointCategory, pointCategories, shapes, 'shape', 'none');
 };
 
 export const getCategoryPointColor = (
-  pt: CategoryPoint,
+  pointCategory: string | undefined,
   pointCategories: string[],
   colors: string[] = [
     '#000000',
@@ -44,14 +44,14 @@ export const getCategoryPointColor = (
     '#CC79A7',
   ],
 ) => {
-  return getPointStyleFromArray(pt, pointCategories, colors, 'color', 'transparent');
+  return getPointStyleFromArray(pointCategory, pointCategories, colors, 'color', 'transparent');
 };
 
 export const getCategoryPointStyle = <T>(
-  point: CategoryPoint,
+  pointCategory: string | undefined,
   hasPointCategories: boolean,
   customMapping: Record<string, T> | undefined,
-  defaultStyleFunction: (pt: CategoryPoint, categories: string[]) => T,
+  defaultStyleFunction: (pointCategory: string | undefined, categories: string[]) => T,
   pointCategories: string[],
   defaultValue: T,
 ): T => {
@@ -60,11 +60,10 @@ export const getCategoryPointStyle = <T>(
   }
 
   if (customMapping) {
-    const ptCategory = point.pointCategory;
-    const customStyle = ptCategory && customMapping[ptCategory];
+    const customStyle = pointCategory && customMapping[pointCategory];
     return customStyle || defaultValue;
   } else {
-    return defaultStyleFunction(point, pointCategories);
+    return defaultStyleFunction(pointCategory, pointCategories);
   }
 };
 


### PR DESCRIPTION
## Description

This PR adds the Model-AD boxplot and grid for displaying related boxplots. Also updates shared boxplot styling options, including allowing configuration of point opacity and ensuring that points maintain their expected color/shape when filtering.

> [!NOTE] 
> 1. The boxplots are rendered in the model details page for demonstration purposes only, so may not be appropriately grouped (e.g. multiple tissues included in the same grid). Filters and grids grouped by tissue will be added in a future PR. 
> 2. The boxplot style will be addressed in [MG-298](https://sagebionetworks.jira.com/browse/MG-298).

## Related Issues

- [MG-274](https://sagebionetworks.jira.com/browse/MG-274)
- [MG-299](https://sagebionetworks.jira.com/browse/MG-299)

## Changelog

- Creates Model-AD boxplot and grid component for displaying multiple boxplots in a grid layout
- Adds `DecodeGreekEntityPipe` to convert a subset of Greek letter HTML entities to unicode for rendering in chart canvas
- Adds controls for point opacity, point category symbol styling, and legend display to shared boxplot chart
- Ensures color and shape consistency when filtering is applied across multiple plots
- Adds ability to display marker color in tooltip
- Fixes spacing of y-axis title when y-axis labels are variable, so that title will not overlap labels
-Ensures that y-axis line will be aligned for plots in different grid rows

## Preview

### Model-AD boxplot grid

`model-ad-build-images && model-ad-docker-start`

> [!NOTE] 
> The following boxplots are rendered for demonstration only (e.g. to show that y-axes are aligned across plot rows), so are not appropriately grouped (e.g. multiple tissues in one grid). Filters and grids grouped by tissue will be added in a future PR. 

`http://localhost:8000/models/Abca7*V1599M/biomarkers`

<img width="1888" height="879" alt="Abca7*V1599M_grid" src="https://github.com/user-attachments/assets/5f55cf2a-4abb-4802-b279-29e504f6b0ba" />

`http://localhost:8000/models/3xTg-AD/biomarkers`

<img width="1890" height="879" alt="3xTg-AD_grid" src="https://github.com/user-attachments/assets/4697796b-5d08-4946-b978-f0bff9910690" />

> [!NOTE]
> The marker color in the tooltip is displayed correctly, but the symbol is always a circle (even when the marker is another shape). This is a [known limitation in echarts](https://redirect.github.com/apache/echarts/issues/19826). We can address in a follow up PR, if this is not acceptable.

https://github.com/user-attachments/assets/a141f440-01f5-42bc-9219-9835b1a1c8cd

### Agora boxplot

Confirm that the Agora boxplot is unchanged by these updates: `agora-build-images && agora-docker-start`.

dev site | feature branch
:---:|:---:
<img width="1886" height="842" alt="agora_current_dev" src="https://github.com/user-attachments/assets/2bcf86f6-3636-496f-a83b-8ac94154b238" /> | <img width="1886" height="846" alt="agora_feature_branch" src="https://github.com/user-attachments/assets/0e8dd56a-4dd6-401d-8007-64bba7caff53" />

### Storybook

Run `nx storybook shared-typescript-charts-angular`. `http://localhost:4400/` will open in your browser. Go to the Dynamic Summary story. 

Change the point data to demonstrate point color/shape consistency when changing the number of categories in the data. For example, in the video below, "Male" is consistently a yellow dot and "Female" is a green triangle:

https://github.com/user-attachments/assets/32a08038-f4de-415d-aa5c-0dd6b8f2ae0a

See other newly added controls below: 
<img width="1343" height="746" alt="image" src="https://github.com/user-attachments/assets/f54348dd-4449-4402-b40a-2bec58166b8d" />


[MG-298]: https://sagebionetworks.jira.com/browse/MG-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-219]: https://sagebionetworks.jira.com/browse/MG-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-299]: https://sagebionetworks.jira.com/browse/MG-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MG-274]: https://sagebionetworks.jira.com/browse/MG-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ