### PR TITLE
feat(sage): create github.copilot.chat.agent.terminal.allowList and denyList (SMR-264)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -119,11 +119,6 @@
     "ls": true,
     "cat": true,
     "pwd": true,
-    "Write-Host": true,
-    "Set-Location": true,
-    "Get-ChildItem": true,
-    "Get-Content": true,
-    "Get-Location": true,
     "git status": true,
     "git log": true,
     "git diff": true,
@@ -132,13 +127,11 @@
   "github.copilot.chat.agent.terminal.denyList": {
     "rm": true,
     "rmdir": true,
-    "del": true,
     "kill": true,
     "curl": true,
     "wget": true,
     "eval": true,
     "chmod": true,
-    "chown": true,
-    "Remove-Item": true
+    "chown": true
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -123,7 +123,11 @@
     "Set-Location": true,
     "Get-ChildItem": true,
     "Get-Content": true,
-    "Get-Location": true
+    "Get-Location": true,
+    "git status": true,
+    "git log": true,
+    "git diff": true,
+    "git show": true
   },
   "github.copilot.chat.agent.terminal.denyList": {
     "rm": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -112,5 +112,29 @@
   "terminal.integrated.showExitAlert": false,
   "rewrap.wrappingColumn": 100,
   "jest.runMode": "on-demand",
-  "nxConsole.generateAiAgentRules": true
+  "nxConsole.generateAiAgentRules": true,
+  "github.copilot.chat.agent.terminal.allowList": {
+    "echo": true,
+    "cd": true,
+    "ls": true,
+    "cat": true,
+    "pwd": true,
+    "Write-Host": true,
+    "Set-Location": true,
+    "Get-ChildItem": true,
+    "Get-Content": true,
+    "Get-Location": true
+  },
+  "github.copilot.chat.agent.terminal.denyList": {
+    "rm": true,
+    "rmdir": true,
+    "del": true,
+    "kill": true,
+    "curl": true,
+    "wget": true,
+    "eval": true,
+    "chmod": true,
+    "chown": true,
+    "Remove-Item": true
+  }
 }


### PR DESCRIPTION
## Description

Create `github.copilot.chat.agent.terminal` `allowList` and `denyList`.

## Related Issue

- [SMR-264](https://sagebionetworks.jira.com/browse/SMR-264)

## Changelog

- Adds terminal commands that the Copilot Agent can run without approval (`allowList`) or must always ask for approval before running (`denyList`)

## Preview

> [!NOTE] 
> Feature became available in the June 2025 release of VS Code. Ensure that your VS Code is on version 1.102.0 before attempting to test.

The video below demonstrates the feature -- `git log` runs without approval (`allowList`), whereas `eval` requires approval (`denyList`).

https://github.com/user-attachments/assets/3f75854f-da04-4b03-8a8d-18873595f0f9


[SMR-264]: https://sagebionetworks.jira.com/browse/SMR-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ