### PR TITLE
feat(openchallenges): index `challenge.website_url` in OpenSearch (SMR-275, SMR-276)

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
+import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
@@ -65,6 +66,7 @@ public class ChallengeEntity {
   private String avatarUrl;
 
   @Column(name = "website_url", nullable = true, length = 500)
+  @GenericField(name = "website_url", searchable = Searchable.NO)
   private String websiteUrl;
 
   @Column(nullable = true, length = 120)


### PR DESCRIPTION
## Description

Index `challenge.website_url` in OpenSearch to make it easier to visit a challenge web page from results displayed in OpenSearch Dashboards. The property is indexed but is set as non-searchable to make searches faster.

## Related Issue

- [SMR-275](https://sagebionetworks.jira.com/browse/SMR-275)
- [SMR-276](https://sagebionetworks.jira.com/browse/SMR-276)

## Changelog

- Index `challenge.website_url` in OpenSearch.

## Validation

Start the OC stack:

```bash
openchallenges-build-images
nx serve-detach openchallenges-apex
```

Start OpenSearch Dashboards, which is not deployed with the main stack:

```bash
nx serve-detach openchallenges-opensearch-dashboards
```

## Visualize Data in OpenSearch Dashboards

1. Navigate to http://localhost:5601.
2. Open the three-bar menu >Management > Select "Dashboards Management".
3. Click on "Index Patterns".
4. Click on "Create index pattern".
5. Index pattern name: `openchallenges-challenge-read`.
6. Click on "Next step".
7. Time field: `created_at`.
8. Click on "Create index pattern".
9. Confirm that "website_url" is listed as a "Field".

<img width="1323" height="853" alt="image" src="https://github.com/user-attachments/assets/8ab48451-5aee-465a-a71b-563d97942d08" />

The field `website_url` is now available when exploring the data.

<img width="1319" height="676" alt="image" src="https://github.com/user-attachments/assets/9c7997e0-439c-4303-a738-6adad1db7434" />




[SMR-275]: https://sagebionetworks.jira.com/browse/SMR-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SMR-276]: https://sagebionetworks.jira.com/browse/SMR-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ