### PR TITLE
feat(openchallenges): make challenge.platform.slug and challenge.platform.name aggregatable (SMR-274)

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/SimpleChallengePlatformEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/SimpleChallengePlatformEntity.java
@@ -10,8 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.engine.backend.types.Aggregable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
 
 @Entity
 @Table(name = "challenge_platform")
@@ -27,11 +27,11 @@ public class SimpleChallengePlatformEntity {
   private Long id;
 
   @Column(nullable = false)
-  @GenericField
+  @KeywordField(aggregable = Aggregable.YES)
   private String slug;
 
   @Column(nullable = false)
-  @FullTextField
+  @KeywordField(aggregable = Aggregable.YES)
   private String name;
 
   @Column(name = "avatar_key", nullable = false)


### PR DESCRIPTION
## Description

Make challenge.platform.slug and challenge.platform.name aggregatable.

## Related Issue

- [SMR-274](https://sagebionetworks.jira.com/browse/SMR-274)

## Changelog

- Make challenge.platform.slug and challenge.platform.name aggregatable.

## Preview

<img width="1304" height="832" alt="image" src="https://github.com/user-attachments/assets/784a30e9-50c5-429a-8da7-6e73c9872bce" />

We can now generate a pie chart directly in OpenSearch Dashboards, where categories are created automatically. This is a significant improvement over the [previous diagram](https://github.com/Sage-Bionetworks/sage-monorepo/pull/3283#pullrequestreview-3007220395), which required manual category creation by the user.

<img width="1496" height="1186" alt="image" src="https://github.com/user-attachments/assets/4b6eb49c-b8ce-4b54-9683-8fa1934ac998" />


[SMR-274]: https://sagebionetworks.jira.com/browse/SMR-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ