### PR TITLE
fix(sage-monorepo): fix `NX_BRANCH` value in the main CI workflow when merging to `main` (SMR-280)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - 'renovate/**'
   pull_request:
   merge_group:
 
@@ -75,17 +74,11 @@ jobs:
 
   pr:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
-    # Runs this job if triggered by a PR and if at least one of these conditions are true:
-    # - the PR originate from a fork
-    # - the branch name does not start with `renovate/` since we know that the workflow would have
-    #   been already triggered by the `push` event.
+    # Runs this job if triggered by a PR and if the PR originates from a fork
     if: |
       github.event_name == 'pull_request'
-        && (
-          github.event.pull_request.head.repo.full_name !=
+        && github.event.pull_request.head.repo.full_name !=
             github.event.pull_request.base.repo.full_name
-          || !startsWith(github.head_ref, 'renovate/')
-        )
     steps:
       - uses: actions/checkout@v4
         name: Checkout merge commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
   HEAD_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-  NX_BRANCH: ${{ github.event.number }}
+  NX_BRANCH: ${{ github.event_name == 'pull_request' && github.event.number || github.ref_name }}
   NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
 
 jobs:
@@ -20,8 +20,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN_READ_WRITE }}
-    # env:
-    #   NX_BRANCH: main
     steps:
       - uses: actions/checkout@v4
         name: Checkout ${{ env.HEAD_REPOSITORY }}:${{ env.HEAD_REF }}


### PR DESCRIPTION
## Description

Fix `NX_BRANCH` value in the CI workflow when merging to `main`.

## Related Issue

- [SMR-280](https://sagebionetworks.jira.com/browse/SMR-280)

## Changelog

- Fix `NX_BRANCH` value in the CI workflow when merging to `main`.
- Remove references to Renovate from the CI workflow.

## Preview

The job steps are properly annotated with the PR number when the jobs are triggered by pushing a commit to a PR.

<img width="1254" height="380" alt="image" src="https://github.com/user-attachments/assets/3e56467a-0dac-4e38-84ad-0f6355808784" />

However, there are no results when searching for the `main` branch. The jobs that ran when pushing to the `main` branch exist, but they are annotated with "no branch".

<img width="1254" height="476" alt="image" src="https://github.com/user-attachments/assets/9c37ab4f-84a7-4e47-a4f3-5193a13ffc4b" />

<img width="1242" height="239" alt="image" src="https://github.com/user-attachments/assets/2bc772ff-bd95-48ea-9b1e-cf4936cb0e44" />

[SMR-280]: https://sagebionetworks.jira.com/browse/SMR-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ