### PR TITLE
chore(sage-monorepo): upgrade explorer apps to es2024 (SMR-282)

### DIFF
--- a/apps/agora/app/tsconfig.json
+++ b/apps/agora/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "useDefineForClassFields": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/apps/agora/app/tsconfig.server.json
+++ b/apps/agora/app/tsconfig.server.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/server",
-    "target": "ES2022",
+    "target": "es2024",
     "types": ["node"],
     "esModuleInterop": false,
     "moduleResolution": "bundler"

--- a/apps/model-ad/app/tsconfig.json
+++ b/apps/model-ad/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "useDefineForClassFields": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/apps/model-ad/app/tsconfig.server.json
+++ b/apps/model-ad/app/tsconfig.server.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/server",
-    "target": "ES2022",
+    "target": "es2024",
     "types": ["node"],
     "esModuleInterop": false,
     "moduleResolution": "bundler"

--- a/apps/model-ad/app/tsconfig.spec.json
+++ b/apps/model-ad/app/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/about/tsconfig.json
+++ b/libs/agora/about/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/api-client-angular/tsconfig.json
+++ b/libs/agora/api-client-angular/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/agora/api-client-angular/tsconfig.spec.json
+++ b/libs/agora/api-client-angular/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/charts/tsconfig.json
+++ b/libs/agora/charts/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/charts/tsconfig.spec.json
+++ b/libs/agora/charts/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/config/tsconfig.json
+++ b/libs/agora/config/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/agora/gene-comparison-tool/tsconfig.json
+++ b/libs/agora/gene-comparison-tool/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/gene-comparison-tool/tsconfig.spec.json
+++ b/libs/agora/gene-comparison-tool/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/genes/tsconfig.json
+++ b/libs/agora/genes/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/home/tsconfig.json
+++ b/libs/agora/home/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/home/tsconfig.spec.json
+++ b/libs/agora/home/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/news/tsconfig.json
+++ b/libs/agora/news/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/news/tsconfig.spec.json
+++ b/libs/agora/news/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/nominated-targets/tsconfig.json
+++ b/libs/agora/nominated-targets/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/nominated-targets/tsconfig.spec.json
+++ b/libs/agora/nominated-targets/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/not-found/tsconfig.json
+++ b/libs/agora/not-found/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/services/tsconfig.json
+++ b/libs/agora/services/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/shared/tsconfig.json
+++ b/libs/agora/shared/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/storybook/tsconfig.json
+++ b/libs/agora/storybook/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/agora/teams/tsconfig.json
+++ b/libs/agora/teams/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/agora/teams/tsconfig.spec.json
+++ b/libs/agora/teams/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/agora/testing/tsconfig.json
+++ b/libs/agora/testing/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/agora/ui/tsconfig.json
+++ b/libs/agora/ui/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/comparison-tools/tsconfig.json
+++ b/libs/explorers/comparison-tools/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/constants/tsconfig.json
+++ b/libs/explorers/constants/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/models/tsconfig.json
+++ b/libs/explorers/models/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/services/tsconfig.json
+++ b/libs/explorers/services/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/shared/tsconfig.json
+++ b/libs/explorers/shared/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/storybook/tsconfig.json
+++ b/libs/explorers/storybook/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/explorers/testing/tsconfig.json
+++ b/libs/explorers/testing/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/explorers/themes/tsconfig.json
+++ b/libs/explorers/themes/tsconfig.json
@@ -14,7 +14,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/ui/tsconfig.json
+++ b/libs/explorers/ui/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/explorers/util/tsconfig.json
+++ b/libs/explorers/util/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/model-ad/api-client-angular/tsconfig.json
+++ b/libs/model-ad/api-client-angular/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/model-ad/api-client-angular/tsconfig.spec.json
+++ b/libs/model-ad/api-client-angular/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/model-ad/config/tsconfig.json
+++ b/libs/model-ad/config/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/model-ad/disease-correlation-comparison-tool/tsconfig.json
+++ b/libs/model-ad/disease-correlation-comparison-tool/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/model-ad/gene-expression-comparison-tool/tsconfig.json
+++ b/libs/model-ad/gene-expression-comparison-tool/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/model-ad/home/tsconfig.json
+++ b/libs/model-ad/home/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/model-ad/home/tsconfig.spec.json
+++ b/libs/model-ad/home/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/model-ad/model-details/tsconfig.json
+++ b/libs/model-ad/model-details/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/model-ad/model-details/tsconfig.spec.json
+++ b/libs/model-ad/model-details/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/model-ad/model-overview-comparison-tool/tsconfig.json
+++ b/libs/model-ad/model-overview-comparison-tool/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/model-ad/services/tsconfig.json
+++ b/libs/model-ad/services/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020",
+    "target": "es2024",
     "esModuleInterop": true
   },
   "angularCompilerOptions": {

--- a/libs/model-ad/testing/tsconfig.json
+++ b/libs/model-ad/testing/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,


### PR DESCRIPTION
## Description
This updates Model-AD and Agora web applications to use ECMAScript 2024 (es2024).

## Related Issue

[SMR-283](https://sagebionetworks.jira.com/browse/SMR-283)

## Changelog

- Update to es2024 in tsconfig.*.json files.
- Update the folders apps/agora, app/model-ad, libs/agora, libs/explorers, and libs/model-ad.

[SMR-283]: https://sagebionetworks.jira.com/browse/SMR-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ