### PR TITLE
feat(model-ad): add model details boxplot selector and model details biomarkers/pathology content (MG-216, MG-217, MG-219)

### DIFF
--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="63"
+DATA_VERSION="66"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="66"
+DATA_VERSION="67"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/libs/explorers/services/src/index.ts
+++ b/libs/explorers/services/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/breakpoint-config.service';
 export * from './lib/comparison-tool.service';
 export * from './lib/helper.service';
 export * from './lib/meta-tag.service';

--- a/libs/explorers/services/src/lib/breakpoint-config.service.spec.ts
+++ b/libs/explorers/services/src/lib/breakpoint-config.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { BreakpointConfigService } from './breakpoint-config.service';
+
+describe('BreakpointConfigService', () => {
+  let service: BreakpointConfigService;
+  let mockGetPropertyValue: jest.Mock;
+  let mockGetComputedStyle: jest.Mock;
+
+  beforeEach(() => {
+    mockGetPropertyValue = jest.fn();
+    mockGetComputedStyle = jest.fn().mockReturnValue({
+      getPropertyValue: mockGetPropertyValue,
+    });
+
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(mockGetComputedStyle);
+
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BreakpointConfigService);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    jest.restoreAllMocks();
+  });
+
+  it('should return default breakpoint when CSS custom property is not defined', () => {
+    mockGetPropertyValue.mockReturnValue('');
+
+    const breakpoint = service.largeBreakpoint;
+
+    expect(breakpoint).toBe('992px');
+    expect(mockGetComputedStyle).toHaveBeenCalledWith(document.documentElement);
+    expect(mockGetPropertyValue).toHaveBeenCalledWith('--lg-breakpoint');
+  });
+
+  it('should return CSS custom property value when defined', () => {
+    mockGetPropertyValue.mockReturnValue('1024px');
+
+    const breakpoint = service.largeBreakpoint;
+
+    expect(breakpoint).toBe('1024px');
+    expect(mockGetComputedStyle).toHaveBeenCalledWith(document.documentElement);
+    expect(mockGetPropertyValue).toHaveBeenCalledWith('--lg-breakpoint');
+  });
+
+  it('should cache the computed value and not call getComputedStyle multiple times', () => {
+    mockGetPropertyValue.mockReturnValue('1024px');
+
+    const firstCall = service.largeBreakpoint;
+    const secondCall = service.largeBreakpoint;
+
+    expect(firstCall).toBe('1024px');
+    expect(secondCall).toBe('1024px');
+    expect(mockGetComputedStyle).toHaveBeenCalledTimes(1);
+    expect(mockGetPropertyValue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/explorers/services/src/lib/breakpoint-config.service.ts
+++ b/libs/explorers/services/src/lib/breakpoint-config.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BreakpointConfigService {
+  private readonly defaultLargeBreakpoint = '992px';
+  private _largeBreakpoint: string | null = null;
+
+  get largeBreakpoint(): string {
+    if (this._largeBreakpoint === null) {
+      this._largeBreakpoint = this.computeLargeBreakpoint();
+    }
+    return this._largeBreakpoint;
+  }
+
+  private computeLargeBreakpoint(): string {
+    if (typeof document !== 'undefined') {
+      const breakpointValue = getComputedStyle(document.documentElement).getPropertyValue(
+        '--lg-breakpoint',
+      );
+      return breakpointValue?.trim() || this.defaultLargeBreakpoint;
+    }
+    return this.defaultLargeBreakpoint;
+  }
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -3,6 +3,7 @@
   sageBoxplot
   [style.height]="450"
   [points]="points()"
+  [xAxisLabelFormatter]="xAxisLabelFormatter"
   [yAxisTitle]="formatYAxisTitle()"
   [pointTooltipFormatter]="pointTooltipFormatter"
   [pointCategoryColors]="pointCategoryColors"

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -4,6 +4,7 @@
   [style.height]="450"
   [points]="points()"
   [xAxisLabelFormatter]="xAxisLabelFormatter"
+  [xAxisCategories]="genotypeOrder()"
   [yAxisTitle]="formatYAxisTitle()"
   [pointTooltipFormatter]="pointTooltipFormatter"
   [pointCategoryColors]="pointCategoryColors"

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
@@ -87,4 +87,22 @@ describe('ModelDetailsBoxplotComponent', () => {
     const yAxisTitle = component.formatYAxisTitle();
     expect(yAxisTitle).toContain('\n');
   });
+
+  it('should format x-axis labels', async () => {
+    const { component } = await setup();
+
+    const labelToExpectedFormattedLabel = {
+      'short-dash': 'short-dash',
+      'short*star': 'short*star',
+      'long-onedash': 'long-\nonedash',
+      'long*onestar': 'long*\nonestar',
+      'long-multi-dash': 'long-\nmulti-dash',
+      'long*multi*star': 'long*\nmulti*star',
+    };
+
+    for (const [label, expectedFormattedLabel] of Object.entries(labelToExpectedFormattedLabel)) {
+      const formattedLabel = component.xAxisLabelFormatter(label);
+      expect(formattedLabel).toBe(expectedFormattedLabel);
+    }
+  });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
@@ -77,4 +77,14 @@ describe('ModelDetailsBoxplotComponent', () => {
     const yAxisTitle = component.formatYAxisTitle();
     expect(yAxisTitle).toBe('Beta Amyloid (pg/mg)');
   });
+
+  it('should include a line break in very long Y-axis titles', async () => {
+    const { component } = await setup({
+      ...mockModelData,
+      evidence_type: 'Some very very very long title',
+      units: 'these units are long too',
+    });
+    const yAxisTitle = component.formatYAxisTitle();
+    expect(yAxisTitle).toContain('\n');
+  });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -17,6 +17,8 @@ export class ModelDetailsBoxplotComponent {
   titleCasePipe = inject(TitleCasePipe);
   decodeGreekEntityPipe = inject(DecodeGreekEntityPipe);
 
+  private readonly Y_AXIS_TITLE_LINE_BREAK_THRESHOLD = 30;
+
   pointCategoryColors = {
     Male: '#1B00B3',
     Female: '#DB00FF',
@@ -57,6 +59,9 @@ export class ModelDetailsBoxplotComponent {
       this.titleCasePipe.transform(this.modelData().evidence_type),
     );
     const units = this.modelData().units;
-    return `${evidenceType} (${units})`;
+
+    const nChars = evidenceType.length + units.length;
+    const sep = nChars > this.Y_AXIS_TITLE_LINE_BREAK_THRESHOLD ? '\n' : ' ';
+    return `${evidenceType}${sep}(${units})`;
   };
 }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -32,6 +32,7 @@ export class ModelDetailsBoxplotComponent {
   modelData = input.required<ModelData>();
   sexes = input.required<IndividualData.SexEnum[]>();
   showLegend = input<boolean>(false);
+  genotypeOrder = input<string[] | undefined>();
 
   points = computed<CategoryPoint[]>(() => {
     return this.modelData()

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -54,6 +54,13 @@ export class ModelDetailsBoxplotComponent {
     return `${params.marker} ${pt.text ?? pt.value.toString()}`;
   };
 
+  xAxisLabelFormatter = (value: string) => {
+    if (value.length > 10) {
+      return value.replace(/[-*]/, (match) => match + '\n');
+    }
+    return value;
+  };
+
   formatYAxisTitle = () => {
     const evidenceType = this.decodeGreekEntityPipe.transform(
       this.titleCasePipe.transform(this.modelData().evidence_type),

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -2,7 +2,7 @@ import { TitleCasePipe } from '@angular/common';
 import { Component, computed, inject, input } from '@angular/core';
 import { DecodeGreekEntityPipe } from '@sagebionetworks/explorers/util';
 import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
-import { CategoryPoint } from '@sagebionetworks/shared/charts';
+import { CategoryPoint, getTextWidth } from '@sagebionetworks/shared/charts';
 import { BoxplotDirective } from '@sagebionetworks/shared/charts-angular';
 import { CallbackDataParams } from 'echarts/types/dist/shared';
 
@@ -18,6 +18,8 @@ export class ModelDetailsBoxplotComponent {
   decodeGreekEntityPipe = inject(DecodeGreekEntityPipe);
 
   private readonly Y_AXIS_TITLE_LINE_BREAK_THRESHOLD = 30;
+  private readonly X_AXIS_LABEL_MAX_WIDTH = 100;
+  private readonly X_AXIS_LABEL_FONT = "bold 14px 'DM Sans Variable', sans-serif";
 
   pointCategoryColors = {
     Male: '#1B00B3',
@@ -56,7 +58,8 @@ export class ModelDetailsBoxplotComponent {
   };
 
   xAxisLabelFormatter = (value: string) => {
-    if (value.length > 10) {
+    const textWidth = getTextWidth(value, this.X_AXIS_LABEL_FONT);
+    if (textWidth > this.X_AXIS_LABEL_MAX_WIDTH) {
       // replace first occurrence of - or * with a newline character
       return value.replace(/[-*]/, (match) => match + '\n');
     }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -57,6 +57,7 @@ export class ModelDetailsBoxplotComponent {
 
   xAxisLabelFormatter = (value: string) => {
     if (value.length > 10) {
+      // replace first occurrence of - or * with a newline character
       return value.replace(/[-*]/, (match) => match + '\n');
     }
     return value;

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
@@ -5,11 +5,11 @@
   </div>
 
   <div class="boxplots-grid">
-    @for (modelData of modelDataList(); track modelData; let last = $last) {
+    @for (modelData of modelDataList(); track modelData; let i = $index) {
       <model-ad-model-details-boxplot
         [modelData]="modelData"
         [sexes]="sexes()"
-        [showLegend]="$last"
+        [showLegend]="i === legendIndex()"
       />
     }
   </div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
@@ -10,6 +10,7 @@
         [modelData]="modelData"
         [sexes]="sexes()"
         [showLegend]="i === legendIndex()"
+        [genotypeOrder]="genotypeOrder()"
       />
     }
   </div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
@@ -1,5 +1,9 @@
-@use 'styles/src/lib/variables';
+@use 'styles/src/lib/variables' as vars;
 @use 'styles/src/lib/mixins';
+
+:host {
+  --lg-breakpoint: vars.$lg-breakpoint;
+}
 
 h2 {
   padding-bottom: 30px;

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
@@ -20,10 +20,5 @@ h2 {
     @include mixins.respond-to('large') {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
-
-    shared-typescript-charts-angular {
-      display: flex;
-      flex-direction: column;
-    }
   }
 }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
@@ -2,6 +2,7 @@ import { BreakpointObserver } from '@angular/cdk/layout';
 import { Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { DecodeGreekEntityPipe } from '@sagebionetworks/explorers/util';
+import { BreakpointConfigService } from '@sagebionetworks/explorers/services';
 import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
 import { ModelDetailsBoxplotComponent } from '../model-details-boxplot/model-details-boxplot.component';
 
@@ -13,26 +14,15 @@ import { ModelDetailsBoxplotComponent } from '../model-details-boxplot/model-det
 })
 export class ModelDetailsBoxplotsGridComponent {
   private readonly breakpointObserver = inject(BreakpointObserver);
+  private readonly breakpointConfigService = inject(BreakpointConfigService);
 
   modelDataList = input.required<ModelData[]>();
   genotypeOrder = input<string[] | undefined>();
   sexes = input.required<IndividualData.SexEnum[]>();
   title = input.required<string>();
 
-  private readonly defaultLargeBreakpoint = '992px';
-
-  private readonly largeBreakpoint = (() => {
-    if (typeof document !== 'undefined') {
-      const breakpointValue = getComputedStyle(document.documentElement).getPropertyValue(
-        '--lg-breakpoint',
-      );
-      return breakpointValue?.trim() || this.defaultLargeBreakpoint;
-    }
-    return this.defaultLargeBreakpoint;
-  })();
-
   private readonly observeLargeScreen = toSignal(
-    this.breakpointObserver.observe(`(min-width: ${this.largeBreakpoint})`),
+    this.breakpointObserver.observe(`(min-width: ${this.breakpointConfigService.largeBreakpoint})`),
     { initialValue: { matches: false, breakpoints: {} } },
   );
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
@@ -15,6 +15,7 @@ export class ModelDetailsBoxplotsGridComponent {
   private readonly breakpointObserver = inject(BreakpointObserver);
 
   modelDataList = input.required<ModelData[]>();
+  genotypeOrder = input<string[] | undefined>();
   sexes = input.required<IndividualData.SexEnum[]>();
   title = input.required<string>();
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
@@ -1,4 +1,6 @@
-import { Component, input } from '@angular/core';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { Component, computed, inject, input } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { DecodeGreekEntityPipe } from '@sagebionetworks/explorers/util';
 import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
 import { ModelDetailsBoxplotComponent } from '../model-details-boxplot/model-details-boxplot.component';
@@ -10,7 +12,39 @@ import { ModelDetailsBoxplotComponent } from '../model-details-boxplot/model-det
   styleUrls: ['./model-details-boxplots-grid.component.scss'],
 })
 export class ModelDetailsBoxplotsGridComponent {
+  private readonly breakpointObserver = inject(BreakpointObserver);
+
   modelDataList = input.required<ModelData[]>();
   sexes = input.required<IndividualData.SexEnum[]>();
   title = input.required<string>();
+
+  private readonly defaultLargeBreakpoint = '992px';
+
+  private readonly largeBreakpoint = (() => {
+    if (typeof document !== 'undefined') {
+      const breakpointValue = getComputedStyle(document.documentElement).getPropertyValue(
+        '--lg-breakpoint',
+      );
+      return breakpointValue?.trim() || this.defaultLargeBreakpoint;
+    }
+    return this.defaultLargeBreakpoint;
+  })();
+
+  private readonly observeLargeScreen = toSignal(
+    this.breakpointObserver.observe(`(min-width: ${this.largeBreakpoint})`),
+    { initialValue: { matches: false, breakpoints: {} } },
+  );
+
+  legendIndex = computed(() => {
+    const totalPlots = this.modelDataList().length;
+    const isLargeScreen = this.observeLargeScreen().matches ?? false;
+
+    if (!isLargeScreen) {
+      // 1-column layout: legend on last plot
+      return totalPlots - 1;
+    } else {
+      // 2-column layout: legend on leftmost of last row
+      return totalPlots % 2 === 0 ? totalPlots - 2 : totalPlots - 1;
+    }
+  });
 }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -48,6 +48,7 @@
       <div class="boxplots-evidence-type">
         <model-ad-model-details-boxplots-grid
           [modelDataList]="getSelectedModelDataForEvidenceType(evidenceType)"
+          [genotypeOrder]="genotypeOrder()"
           [sexes]="selectedSexOption().value"
           [title]="evidenceType"
         />

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -1,0 +1,60 @@
+<section>
+  <div class="title-container">
+    <h2>{{ title() }}</h2>
+    <p>
+      The results shown on this page are derived from the analysis of post-mortem brains from
+      {{ modelName() }} mice and matched control animals.
+    </p>
+    <explorers-modal-link
+      text="Data and Methods for this study"
+      title="About the Study"
+      [wikiParams]="wikiParams()"
+    />
+  </div>
+
+  <div class="filters-container full-width-container">
+    <p>Use the following dropdown menus to select the results that are displayed.</p>
+
+    <div class="filters">
+      <div class="filter">
+        <label for="tissue">Tissue</label>
+        <p-select
+          inputId="tissue"
+          [options]="tissueOptions()"
+          [(ngModel)]="selectedTissueOption"
+          placeholder="Select Tissue"
+        ></p-select>
+      </div>
+
+      <div class="filter">
+        <label for="sex">Sex</label>
+        <p-select
+          inputId="sex"
+          [options]="sexOptions"
+          optionLabel="label"
+          [(ngModel)]="selectedSexOption"
+          placeholder="Select Sex"
+        ></p-select>
+      </div>
+    </div>
+  </div>
+
+  <div class="table-of-contents-container full-width-container">
+    <h2>Table of Contents</h2>
+  </div>
+
+  <div class="boxplots-container">
+    @for (evidenceType of evidenceTypes(); track evidenceType; let last = $last) {
+      <div class="boxplots-evidence-type">
+        <model-ad-model-details-boxplots-grid
+          [modelDataList]="getSelectedModelDataForEvidenceType(evidenceType)"
+          [sexes]="selectedSexOption().value"
+          [title]="evidenceType"
+        />
+        @if (!last) {
+          <hr class="boxplots-separator" />
+        }
+      </div>
+    }
+  </div>
+</section>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -1,0 +1,55 @@
+@use 'styles/src/lib/variables';
+
+[class*='-container'] {
+  padding-top: var(--section-padding);
+  padding-bottom: var(--section-padding);
+}
+
+.title-container {
+  p {
+    padding-bottom: 25px;
+  }
+}
+
+.full-width-container {
+  width: 100vw;
+  margin-left: calc(-1 * (100vw - 100%) / 2);
+  padding-left: calc((100vw - 100%) / 2);
+  padding-right: calc((100vw - 100%) / 2);
+}
+
+.filters-container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background-color: var(--color-gray-300);
+
+  .filters {
+    display: flex;
+    flex-direction: row;
+    gap: 50px;
+
+    .filter {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+
+      label {
+        font-weight: 700;
+        line-height: 18px;
+        font-size: 20px;
+        padding-bottom: 10px;
+      }
+    }
+  }
+}
+
+.table-of-contents-container {
+  box-shadow: 0 4px 4px 0 rgb(0 0 0 / 25%);
+}
+
+.boxplots-separator {
+  margin-top: 80px;
+  margin-bottom: 80px;
+  border: 2px solid var(--color-gray-300);
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -1,0 +1,43 @@
+import { provideHttpClient } from '@angular/common/http';
+import { SvgIconService } from '@sagebionetworks/explorers/services';
+import {
+  MockWikiComponent,
+  SvgIconServiceStub,
+  validWikiParams,
+} from '@sagebionetworks/explorers/testing';
+import { modelMock } from '@sagebionetworks/model-ad/testing';
+import { render, screen } from '@testing-library/angular';
+import { ModelDetailsBoxplotsSelectorComponent } from './model-details-boxplots-selector.component';
+
+const mockTitle = 'Pathology';
+
+async function setup(model = modelMock, title = mockTitle, wikiParams = validWikiParams) {
+  return render(ModelDetailsBoxplotsSelectorComponent, {
+    imports: [MockWikiComponent],
+    componentInputs: {
+      title: title,
+      modelName: model.model,
+      modelDataList: model.pathology,
+      wikiParams: wikiParams,
+    },
+    providers: [provideHttpClient(), { provide: SvgIconService, useClass: SvgIconServiceStub }],
+  });
+}
+
+describe('ModelDetailsBoxplotsSelectorComponent', () => {
+  it('should render title', async () => {
+    await setup();
+    expect(screen.getByRole('heading', { level: 2, name: mockTitle })).toBeVisible();
+  });
+
+  it('should render description with model name', async () => {
+    await setup();
+    expect(screen.getByText(modelMock.model, { exact: false })).toBeVisible();
+  });
+
+  it('should render filters', async () => {
+    await setup();
+    expect(screen.getByRole('combobox', { name: /tissue/i })).toBeVisible();
+    expect(screen.getByRole('combobox', { name: /sex/i })).toBeVisible();
+  });
+});

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -6,7 +6,7 @@ import {
   validWikiParams,
 } from '@sagebionetworks/explorers/testing';
 import { modelMock } from '@sagebionetworks/model-ad/testing';
-import { render, screen } from '@testing-library/angular';
+import { render, screen, waitFor } from '@testing-library/angular';
 import { ModelDetailsBoxplotsSelectorComponent } from './model-details-boxplots-selector.component';
 
 const mockTitle = 'Pathology';
@@ -39,5 +39,24 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     await setup();
     expect(screen.getByRole('combobox', { name: /tissue/i })).toBeVisible();
     expect(screen.getByRole('combobox', { name: /sex/i })).toBeVisible();
+  });
+
+  it('should automatically select first tissue when data loads', async () => {
+    await setup();
+    const tissueSelect = screen.getByRole('combobox', { name: /tissue/i });
+
+    const firstTissue = modelMock.pathology[0].tissue;
+    await waitFor(() => {
+      expect(tissueSelect).toHaveAccessibleName(firstTissue);
+    });
+  });
+
+  it('should use default value for sex', async () => {
+    await setup();
+    const sexSelect = screen.getByRole('combobox', { name: /sex/i });
+
+    await waitFor(() => {
+      expect(sexSelect).toHaveAccessibleName('Male & Female');
+    });
   });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -15,6 +15,7 @@ import { ModelDetailsBoxplotsGridComponent } from '../model-details-boxplots-gri
 export class ModelDetailsBoxplotsSelectorComponent {
   title = input.required<string>();
   modelName = input.required<string>();
+  modelControls = input.required<string[]>();
   modelDataList = input.required<ModelData[]>();
   wikiParams = input.required<SynapseWikiParams>();
 
@@ -25,15 +26,9 @@ export class ModelDetailsBoxplotsSelectorComponent {
   ];
   selectedSexOption = signal(this.sexOptions[0]);
 
-  isLoading = computed(() => {
-    const modelData = this.modelDataList();
-    return !modelData || modelData.length === 0;
-  });
-
   tissueOptions = computed(() => {
     return Array.from(new Set(this.modelDataList().map((item) => item.tissue)));
   });
-
   selectedTissueOption = signal('');
 
   constructor() {
@@ -49,6 +44,18 @@ export class ModelDetailsBoxplotsSelectorComponent {
     return this.modelDataList().filter(
       (modelData) => modelData.tissue === this.selectedTissueOption(),
     );
+  });
+
+  genotypeOrder = computed(() => {
+    const baseGenotypes = new Set([...this.modelControls(), this.modelName()]);
+    const extraGenotypes = [
+      ...new Set(
+        this.selectedModelDataList().flatMap((modelData) =>
+          modelData.data.map((item) => item.genotype),
+        ),
+      ),
+    ].filter((genotype) => !baseGenotypes.has(genotype));
+    return [...baseGenotypes, ...extraGenotypes];
   });
 
   evidenceTypes = computed(() => {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -1,0 +1,63 @@
+import { Component, computed, effect, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SynapseWikiParams } from '@sagebionetworks/explorers/models';
+import { ModalLinkComponent } from '@sagebionetworks/explorers/util';
+import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
+import { SelectModule } from 'primeng/select';
+import { ModelDetailsBoxplotsGridComponent } from '../model-details-boxplots-grid/model-details-boxplots-grid.component';
+
+@Component({
+  selector: 'model-ad-model-details-boxplots-selector',
+  imports: [FormsModule, SelectModule, ModelDetailsBoxplotsGridComponent, ModalLinkComponent],
+  templateUrl: './model-details-boxplots-selector.component.html',
+  styleUrls: ['./model-details-boxplots-selector.component.scss'],
+})
+export class ModelDetailsBoxplotsSelectorComponent {
+  title = input.required<string>();
+  modelName = input.required<string>();
+  modelDataList = input.required<ModelData[]>();
+  wikiParams = input.required<SynapseWikiParams>();
+
+  sexOptions: { label: string; value: IndividualData.SexEnum[] }[] = [
+    { label: 'Male & Female', value: ['Male', 'Female'] },
+    { label: 'Female', value: ['Female'] },
+    { label: 'Male', value: ['Male'] },
+  ];
+  selectedSexOption = signal(this.sexOptions[0]);
+
+  isLoading = computed(() => {
+    const modelData = this.modelDataList();
+    return !modelData || modelData.length === 0;
+  });
+
+  tissueOptions = computed(() => {
+    return Array.from(new Set(this.modelDataList().map((item) => item.tissue)));
+  });
+
+  selectedTissueOption = signal('');
+
+  constructor() {
+    effect(() => {
+      const options = this.tissueOptions();
+      if (options.length > 0 && !this.selectedTissueOption()) {
+        this.selectedTissueOption.set(options[0]);
+      }
+    });
+  }
+
+  selectedModelDataList = computed(() => {
+    return this.modelDataList().filter(
+      (modelData) => modelData.tissue === this.selectedTissueOption(),
+    );
+  });
+
+  evidenceTypes = computed(() => {
+    return Array.from(new Set(this.selectedModelDataList().map((item) => item.evidence_type)));
+  });
+
+  getSelectedModelDataForEvidenceType(evidenceType: string) {
+    return this.selectedModelDataList().filter(
+      (modelData) => modelData.evidence_type === evidenceType,
+    );
+  }
+}

--- a/libs/model-ad/model-details/src/lib/model-details.component.html
+++ b/libs/model-ad/model-details/src/lib/model-details.component.html
@@ -20,6 +20,7 @@
           <model-ad-model-details-boxplots-selector
             [title]="'Biomarkers'"
             [modelName]="model.model"
+            [modelControls]="model.matched_controls"
             [modelDataList]="model.biomarkers"
             [wikiParams]="biomarkersWikiParams"
           />
@@ -28,6 +29,7 @@
           <model-ad-model-details-boxplots-selector
             [title]="'Pathology'"
             [modelName]="model.model"
+            [modelControls]="model.matched_controls"
             [modelDataList]="model.pathology"
             [wikiParams]="pathologyWikiParams"
           />

--- a/libs/model-ad/model-details/src/lib/model-details.component.html
+++ b/libs/model-ad/model-details/src/lib/model-details.component.html
@@ -17,15 +17,20 @@
           <model-ad-model-details-omics [modelName]="model.model" />
         }
         @case ('biomarkers') {
-          <h2>Biomarkers</h2>
-          <model-ad-model-details-boxplots-grid
-            [title]="model.biomarkers[0].evidence_type"
-            [modelDataList]="model.biomarkers.slice(0, 3)"
-            [sexes]="['Male', 'Female']"
+          <model-ad-model-details-boxplots-selector
+            [title]="'Biomarkers'"
+            [modelName]="model.model"
+            [modelDataList]="model.biomarkers"
+            [wikiParams]="biomarkersWikiParams"
           />
         }
         @case ('pathology') {
-          <h2>Pathology</h2>
+          <model-ad-model-details-boxplots-selector
+            [title]="'Pathology'"
+            [modelName]="model.model"
+            [modelDataList]="model.pathology"
+            [wikiParams]="pathologyWikiParams"
+          />
         }
         @case ('resources') {
           <model-ad-model-details-resources [model]="model" />

--- a/libs/model-ad/model-details/src/lib/model-details.component.scss
+++ b/libs/model-ad/model-details/src/lib/model-details.component.scss
@@ -2,6 +2,7 @@
 
 .model-details {
   min-height: calc(100vh - var(--header-height) - var(--footer-height));
+  overflow-x: hidden;
 
   &.loading {
     display: flex;

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -2,13 +2,13 @@ import { Location } from '@angular/common';
 import { AfterViewInit, Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
-import { Panel } from '@sagebionetworks/explorers/models';
+import { Panel, SynapseWikiParams } from '@sagebionetworks/explorers/models';
 import { HelperService } from '@sagebionetworks/explorers/services';
 import { PanelNavigationComponent } from '@sagebionetworks/explorers/ui';
 import { LoadingIconComponent } from '@sagebionetworks/explorers/util';
 import { Model, ModelsService } from '@sagebionetworks/model-ad/api-client-angular';
 import { ConfigService, ROUTE_PATHS } from '@sagebionetworks/model-ad/config';
-import { ModelDetailsBoxplotsGridComponent } from './components/model-details-boxplots-grid/model-details-boxplots-grid.component';
+import { ModelDetailsBoxplotsSelectorComponent } from './components/model-details-boxplots-selector/model-details-boxplots-selector.component';
 import { ModelDetailsHeroComponent } from './components/model-details-hero/model-details-hero.component';
 import { ModelDetailsOmicsComponent } from './components/model-details-omics/model-details-omics.component';
 import { ModelDetailsResourcesComponent } from './components/model-details-resources/model-details-resources.component';
@@ -21,7 +21,7 @@ import { ModelDetailsResourcesComponent } from './components/model-details-resou
     ModelDetailsOmicsComponent,
     ModelDetailsResourcesComponent,
     ModelDetailsHeroComponent,
-    ModelDetailsBoxplotsGridComponent,
+    ModelDetailsBoxplotsSelectorComponent,
   ],
   templateUrl: './model-details.component.html',
   styleUrls: ['./model-details.component.scss'],
@@ -38,6 +38,9 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   isLoading = true;
 
   model: Model | undefined;
+
+  biomarkersWikiParams: SynapseWikiParams = { ownerId: 'syn66271427', wikiId: '632871' };
+  pathologyWikiParams: SynapseWikiParams = { ownerId: 'syn66271427', wikiId: '632872' };
 
   panels: Panel[] = [
     {

--- a/libs/model-ad/styles/src/_index.scss
+++ b/libs/model-ad/styles/src/_index.scss
@@ -2,3 +2,4 @@
 @forward './lib/mixins';
 @forward './lib/variables';
 @forward './lib/components/fonts';
+@forward './lib/components/typography';

--- a/libs/model-ad/styles/src/lib/components/_typography.scss
+++ b/libs/model-ad/styles/src/lib/components/_typography.scss
@@ -1,0 +1,14 @@
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3,
+h4,
+.h4,
+h5,
+.h5,
+h6,
+.h6 {
+  color: var(--color-heading);
+}

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -17,6 +17,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [summaries]="summaries"
       [title]="title"
       [xAxisTitle]="xAxisTitle"
+      [xAxisLabelFormatter]="xAxisLabelFormatter"
       [yAxisTitle]="yAxisTitle"
       [yAxisMin]="yAxisMin"
       [yAxisMax]="yAxisMax"
@@ -33,6 +34,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
     summaries = props.summaries;
     title = props.title;
     xAxisTitle = props.xAxisTitle;
+    xAxisLabelFormatter = props.xAxisLabelFormatter;
     yAxisTitle = props.yAxisTitle;
     yAxisMin = props.yAxisMin;
     yAxisMax = props.yAxisMax;

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -18,6 +18,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [title]="title"
       [xAxisTitle]="xAxisTitle"
       [xAxisLabelFormatter]="xAxisLabelFormatter"
+      [xAxisCategories]="xAxisCategories"
       [yAxisTitle]="yAxisTitle"
       [yAxisMin]="yAxisMin"
       [yAxisMax]="yAxisMax"
@@ -35,6 +36,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
     title = props.title;
     xAxisTitle = props.xAxisTitle;
     xAxisLabelFormatter = props.xAxisLabelFormatter;
+    xAxisCategories = props.xAxisCategories;
     yAxisTitle = props.yAxisTitle;
     yAxisMin = props.yAxisMin;
     yAxisMax = props.yAxisMax;

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -18,7 +18,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity"></div>`,
   }),
 };
 export default meta;
@@ -56,6 +56,7 @@ export const DynamicSummary: Story = {
     points: dynamicBoxplotPoints,
     xAxisTitle: 'MODEL',
     yAxisTitle: 'Insoluble A&beta;40 #objects/sqmm',
+    xAxisCategories: ['Experimental', 'Control2', 'Control1'],
     pointTooltipFormatter: (pt: CategoryPoint, params: CallbackDataParams) =>
       `${pt.pointCategory}: ${pt.value}`,
     pointCategoryColors: { Male: 'yellow', Female: 'green' },

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -13,11 +13,12 @@ const meta: Meta<BoxplotDirective> = {
   component: BoxplotDirective,
   title: 'directives/sageBoxplot',
   argTypes: {
+    xAxisLabelFormatter: { control: false },
     pointTooltipFormatter: { control: false },
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity"></div>`,
   }),
 };
 export default meta;

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -21,6 +21,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() title = '';
   @Input() xAxisTitle: string | undefined;
   @Input() xAxisLabelFormatter: undefined | ((value: string) => string);
+  @Input() xAxisCategories: undefined | string[];
   @Input() yAxisTitle = '';
   @Input() yAxisMin: number | undefined;
   @Input() yAxisMax: number | undefined;
@@ -52,6 +53,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       title: this.title,
       xAxisTitle: this.xAxisTitle,
       xAxisLabelFormatter: this.xAxisLabelFormatter,
+      xAxisCategories: this.xAxisCategories,
       yAxisTitle: this.yAxisTitle,
       yAxisMin: this.yAxisMin,
       yAxisMax: this.yAxisMax,

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -20,6 +20,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() summaries: CategoryBoxplotSummary[] | undefined;
   @Input() title = '';
   @Input() xAxisTitle: string | undefined;
+  @Input() xAxisLabelFormatter: undefined | ((value: string) => string);
   @Input() yAxisTitle = '';
   @Input() yAxisMin: number | undefined;
   @Input() yAxisMax: number | undefined;
@@ -50,6 +51,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       summaries: this.summaries,
       title: this.title,
       xAxisTitle: this.xAxisTitle,
+      xAxisLabelFormatter: this.xAxisLabelFormatter,
       yAxisTitle: this.yAxisTitle,
       yAxisMin: this.yAxisMin,
       yAxisMax: this.yAxisMax,

--- a/libs/shared/typescript/charts/src/index.ts
+++ b/libs/shared/typescript/charts/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/boxplot-chart';
 export * from './lib/mocks';
 export * from './lib/models';
+export * from './lib/utils';

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -62,6 +62,7 @@ export class BoxplotChart {
       summaries,
       title,
       xAxisTitle,
+      xAxisLabelFormatter,
       yAxisTitle,
       yAxisMin,
       yAxisMax,
@@ -309,6 +310,13 @@ export class BoxplotChart {
             color: 'black',
             fontWeight: 'bold',
             fontSize: '14px',
+            interval: 0, // ensure all labels are shown
+            formatter: (value) => {
+              if (xAxisLabelFormatter) {
+                return xAxisLabelFormatter(value);
+              }
+              return value;
+            },
           },
           axisTick: {
             alignWithLabel: true,

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -84,9 +84,10 @@ export class BoxplotChart {
     }
 
     const xAxisCategories =
-      noPoints && summaries
+      boxplotProps.xAxisCategories ??
+      (noPoints && summaries
         ? (getUniqueValues(summaries, 'xAxisCategory') as string[])
-        : (getUniqueValues(points, 'xAxisCategory') as string[]);
+        : (getUniqueValues(points, 'xAxisCategory') as string[]));
     const pointCategories = getUniqueValues(points, 'pointCategory') as string[];
     const hasPointCategories = pointCategories.length > 0;
 

--- a/libs/shared/typescript/charts/src/lib/models/boxplot.ts
+++ b/libs/shared/typescript/charts/src/lib/models/boxplot.ts
@@ -47,6 +47,7 @@ export interface BoxplotProps {
   summaries?: CategoryBoxplotSummary[];
   title?: string;
   xAxisTitle?: string;
+  xAxisLabelFormatter?: (value: string) => string;
   yAxisTitle?: string;
   yAxisMin?: number;
   yAxisMax?: number;

--- a/libs/shared/typescript/charts/src/lib/models/boxplot.ts
+++ b/libs/shared/typescript/charts/src/lib/models/boxplot.ts
@@ -48,6 +48,8 @@ export interface BoxplotProps {
   title?: string;
   xAxisTitle?: string;
   xAxisLabelFormatter?: (value: string) => string;
+  /* if defined will determine the order in which categories appear on the x-axis */
+  xAxisCategories?: string[];
   yAxisTitle?: string;
   yAxisMin?: number;
   yAxisMax?: number;

--- a/libs/shared/typescript/charts/src/lib/utils/chart-utils.ts
+++ b/libs/shared/typescript/charts/src/lib/utils/chart-utils.ts
@@ -53,3 +53,22 @@ export function setNoDataOption(chart: ECharts) {
   // notMerge must be set to true to override any existing options set on the chart
   chart.setOption(noDataOptions, true);
 }
+
+/**
+ * Measures the rendered width of text using canvas context.
+ *
+ * @param text - The text to measure
+ * @param font - CSS font specification (e.g., "16px Arial", "bold 14px sans-serif")
+ * @returns The width in pixels, or a fallback estimate if canvas is not available
+ */
+export function getTextWidth(text: string, font: string): number {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    return text.length * 8;
+  }
+
+  context.font = font;
+  return context.measureText(text).width;
+}


### PR DESCRIPTION
## Description

Adds the model details boxplot selector and content to the model details biomarkers and pathology tabs.

> [!NOTE]
> The boxplot style and selector's download buttons, complete table of contents, and share links will be added in future tickets.

## Related Issue

- [MG-216](https://sagebionetworks.jira.com/browse/MG-216)
- [MG-217](https://sagebionetworks.jira.com/browse/MG-217)
- [MG-219](https://sagebionetworks.jira.com/browse/MG-219)

## Changelog

- Adds model details boxplot selector
- Adds content to model details biomarkers and pathology tabs
- Ensures legend is shown on correct model details boxplot when there is an even number of plots in both one and two column layouts
- Wraps very long model details boxplot y-axis titles
- Wraps model details boxplot x-axis labels to align with design via new boxplot input: `xAxisLabelFormatter`
- Ensures genotypes appear in the expected order in model details boxplot (matched controls, model, other genotypes) via new boxplot input: `xAxisCategories`
- Ensures headings in Model-AD have the correct color applied

## Preview

`model-ad-build-images && model-ad-docker-start`

### Selector

https://github.com/user-attachments/assets/92519b01-64af-4cdf-af35-796750c2d4e2

### Biomarkers / Pathology

`http://localhost:8000/models/Trem2-R47H_NSS`

biomarkers | pathology
:---:|:---:
<img width="1427" height="4649" alt="localhost_8000_models_Trem2-R47H_NSS_biomarkers" src="https://github.com/user-attachments/assets/923a7b38-b1f0-4b36-900a-e98857190496" /> | <img width="1427" height="5295" alt="localhost_8000_models_Trem2-R47H_NSS_pathology" src="https://github.com/user-attachments/assets/01e23bd9-a9d5-4979-835f-843fe5e30687" />

### Legend Location

https://github.com/user-attachments/assets/df7ebad4-b81b-4738-9f2c-18bb988ca424

### Agora Boxplot

I also validated that Agora's boxplot was unchanged by these updates: 

`agora-build-images && agora-docker-start`

`https://agora.adknowledgeportal.org/genes/ENSG00000171862/evidence/rna`
<img width="1911" height="620" alt="agora_prod" src="https://github.com/user-attachments/assets/88032b88-94ce-4706-9441-6aded30c6236" />

`http://localhost:8000/genes/ENSG00000171862/evidence/rna`
<img width="1907" height="620" alt="agora_MG-219" src="https://github.com/user-attachments/assets/026c1c30-8012-470d-961c-f7e94a1a0dc0" />


[MG-216]: https://sagebionetworks.jira.com/browse/MG-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-217]: https://sagebionetworks.jira.com/browse/MG-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-219]: https://sagebionetworks.jira.com/browse/MG-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ