### PR TITLE
fix(model-ad): load model details page for models with special characters in model name (MG-323)

### DIFF
--- a/apps/model-ad/app/src/app/app.config.ts
+++ b/apps/model-ad/app/src/app/app.config.ts
@@ -10,6 +10,7 @@ import { provideClientHydration } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import {
   provideRouter,
+  UrlSerializer,
   withComponentInputBinding,
   withEnabledBlockingInitialNavigation,
   withInMemoryScrolling,
@@ -19,6 +20,7 @@ import { configFactory, ConfigService } from '@sagebionetworks/model-ad/config';
 import { provideMarkdown } from 'ngx-markdown';
 import { MessageService } from 'primeng/api';
 import { providePrimeNG } from 'primeng/config';
+import { CustomUrlSerializer } from './app.custom-url-serializer';
 import { routes } from './app.routes';
 import { ModelAdPreset } from './primeNGPreset';
 
@@ -58,6 +60,7 @@ export const appConfig: ApplicationConfig = {
         scrollPositionRestoration: 'enabled',
       }),
     ),
+    { provide: UrlSerializer, useClass: CustomUrlSerializer },
     MessageService,
   ],
 };

--- a/apps/model-ad/app/src/app/app.custom-url-serializer.ts
+++ b/apps/model-ad/app/src/app/app.custom-url-serializer.ts
@@ -1,0 +1,19 @@
+import { inject } from '@angular/core';
+import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
+import { HelperService } from '@sagebionetworks/explorers/services';
+
+// CustomUrlSerializer encodes special characters (forward slash in parentheses, parentheses)
+// so they are treated as data rather than as part of the route
+export class CustomUrlSerializer implements UrlSerializer {
+  private readonly defaultSerializer = new DefaultUrlSerializer();
+  helperService = inject(HelperService);
+
+  parse(url: any): UrlTree {
+    url = this.helperService.encodeParenthesesForwardSlashes(url);
+    return this.defaultSerializer.parse(url);
+  }
+
+  serialize(tree: UrlTree): any {
+    return this.defaultSerializer.serialize(tree);
+  }
+}

--- a/apps/model-ad/app/src/app/app.routes.ts
+++ b/apps/model-ad/app/src/app/app.routes.ts
@@ -97,6 +97,12 @@ export const routes: Route[] = [
     loadChildren: () =>
       import('@sagebionetworks/model-ad/model-details').then((routes) => routes.routes),
   },
+  // ensure that all models match a route, so the custom url serializer can encode special characters
+  {
+    path: `${ROUTE_PATHS.MODELS}/**`,
+    loadChildren: () =>
+      import('@sagebionetworks/model-ad/model-details').then((routes) => routes.routes),
+  },
   {
     path: ROUTE_PATHS.TERMS_OF_SERVICE,
     loadChildren: () =>

--- a/libs/explorers/services/src/lib/helper.service.spec.ts
+++ b/libs/explorers/services/src/lib/helper.service.spec.ts
@@ -34,4 +34,13 @@ describe('Service: Helper', () => {
     const result = helperService.getPanelUrl(url, 'summary', '');
     expect(result).toEqual(expected);
   });
+
+  it('should encode urls', () => {
+    expect(helperService.encodeParenthesesForwardSlashes('/models/5xFAD (UCI)')).toBe(
+      '/models/5xFAD %28UCI%29',
+    );
+    expect(helperService.encodeParenthesesForwardSlashes('/models/5xFAD (IU/Jax/Pitt)')).toBe(
+      '/models/5xFAD %28IU%2FJax%2FPitt%29',
+    );
+  });
 });

--- a/libs/explorers/services/src/lib/helper.service.ts
+++ b/libs/explorers/services/src/lib/helper.service.ts
@@ -73,4 +73,15 @@ export class HelperService {
       };
     }
   }
+
+  encodeParenthesesForwardSlashes(uri: string) {
+    return (
+      uri
+        // forward slash within parentheses
+        .replace(/\(([^)]*)\)/g, (match, content) => `(${content.replace(/\//g, '%2F')})`)
+        // parentheses
+        .replace(/\(/g, '%28')
+        .replace(/\)/g, '%29')
+    );
+  }
 }

--- a/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.html
@@ -8,7 +8,7 @@
 
     <h4>{{ `Modified Gene${model().genetic_info.length > 1 ? 's' : '' }`}}</h4>
     <div class="modified-genes">
-      @for (gene of model().genetic_info; track gene.ensembl_gene_id) {
+      @for (gene of model().genetic_info; track gene.ensembl_gene_id + gene.allele) {
         <div class="modified-gene">
           <p>
             {{ gene.modified_gene }} |

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -147,7 +147,10 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
     this.activePanel = activePanel;
     this.activeParent = activeParent;
 
-    const basePath = `/${ROUTE_PATHS.MODELS}/${this.model?.model}`;
+    const encodedModel = this.helperService.encodeParenthesesForwardSlashes(
+      encodeURIComponent(this.model?.model || ''),
+    );
+    const basePath = `/${ROUTE_PATHS.MODELS}/${encodedModel}`;
     const fullPath = this.helperService.getPanelUrl(basePath, this.activePanel, this.activeParent);
     this.location.replaceState(fullPath);
   }


### PR DESCRIPTION
## Description

This PR adds URL encoding so the model details page will load for model names with special characters. 

## Related Issue

- [MG-323](https://sagebionetworks.jira.com/browse/MG-323)

## Changelog

- Adds custom URL serializer to encode special characters in model names (parentheses and forward slashes in parentheses)
- Adds fallback `/models/**` route to ensure that all models match the model details route, so the custom url serializer can encode special characters
- Adds e2e tests to ensure that model details pages load for models with special characters
- Fixes the tracking expression to use a unique set of fields in the model details modified genes `@for` loop

## Preview

`model-ad-build-images && model-ad-docker-start`

`http://localhost:8000/models/5xFAD (UCI)`

https://github.com/user-attachments/assets/535911bf-78d8-4ca7-beb6-639061ab02e5

`http://localhost:8000/models/5xFAD (IU/Jax/Pitt)`

https://github.com/user-attachments/assets/a8ffe0c2-e408-40a2-9188-238fe02bb442

