### PR TITLE
fix: override stylus package version after npmjs team removed the package after seemingly false positive CVE report (SMR-296)

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
       "axios": "1.8.2",
       "cross-spawn": "7.0.6",
       "redoc": "2.5.0",
+      "stylus": "0.0.1-security",
       "tar-fs": "2.1.3"
     }
   }

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
       "axios": "1.8.2",
       "cross-spawn": "7.0.6",
       "redoc": "2.5.0",
-      "stylus": "0.0.1-security",
+      "stylus": "github:stylus/stylus#0.54.4",
       "tar-fs": "2.1.3"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   axios: 1.8.2
   cross-spawn: 7.0.6
   redoc: 2.5.0
-  stylus: 0.0.1-security
+  stylus: github:stylus/stylus#0.54.4
   tar-fs: 2.1.3
 
 importers:
@@ -231,7 +231,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 20.0.3
-        version: 20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)
+        version: 20.0.3(3de37dba7a1a4e43c8d9516ed9229b27)
       '@angular-devkit/core':
         specifier: 20.0.3
         version: 20.0.3(chokidar@4.0.3)
@@ -270,7 +270,7 @@ importers:
         version: 6.8.0(@nx/devkit@21.2.1(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)))(@nx/js@21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)))(dotenv@16.5.0)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(tslib@2.4.1)
       '@nx/angular':
         specifier: 21.2.1
-        version: 21.2.1(1e67b5e58dcb36cea52a255ec56e75bf)
+        version: 21.2.1(f87e49bda42a4a65f134da438803224f)
       '@nx/cypress':
         specifier: 21.2.1
         version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@zkochan/js-yaml@0.0.7)(cypress@14.3.2)(debug@4.3.7)(eslint@8.57.0)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)
@@ -309,7 +309,7 @@ importers:
         version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@zkochan/js-yaml@0.0.7)(cypress@14.3.2)(debug@4.3.7)(eslint@8.57.0)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(storybook@8.6.12(prettier@3.3.3))(typescript@5.8.3)
       '@nx/vite':
         specifier: 21.2.1
-        version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)
+        version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)
       '@nx/web':
         specifier: 21.2.1
         version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
@@ -342,7 +342,7 @@ importers:
         version: 8.6.12(@types/react@18.3.7)(storybook@8.6.12(prettier@3.3.3))
       '@storybook/angular':
         specifier: 8.6.12
-        version: 8.6.12(ba89164553851694dc7434ec6a80b700)
+        version: 8.6.12(79affedf83aa44f8d6206f50e4d79187)
       '@storybook/core-server':
         specifier: 8.6.12
         version: 8.6.12(storybook@8.6.12(prettier@3.3.3))
@@ -435,7 +435,7 @@ importers:
         version: 8.34.1(eslint@8.57.0)(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: 4.3.1
-        version: 4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
+        version: 4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))
       '@vitest/ui':
         specifier: 1.6.0
         version: 1.6.0(vitest@3.1.2)
@@ -615,22 +615,22 @@ importers:
         version: 5.8.3
       vite:
         specifier: 6.2.1
-        version: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+        version: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
       vitest:
         specifier: 3.1.2
-        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
 
   libs/sage-monorepo/nx-plugin:
     dependencies:
       '@nx/devkit':
         specifier: 19.8.0
-        version: 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+        version: 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       '@nx/js':
         specifier: 19.8.0
-        version: 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)
+        version: 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250723)
       nx:
         specifier: 19.8.0
-        version: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+        version: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       tslib:
         specifier: ^2.3.0
         version: 2.4.1
@@ -4365,6 +4365,7 @@ packages:
 
   '@nx/vite@21.2.1':
     resolution: {integrity: sha512-GwlYum+I/HaF438Losx0VjB1eNM+0ywPOXMzFAai7I1A/7CTm3w5MblTvQazhs9mZPNbVISTQn+YMhHohLNbVw==}
+    version: 21.2.1
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
       vitest: ^1.3.1 || ^2.0.0 || ^3.0.0
@@ -6699,12 +6700,14 @@ packages:
 
   '@vitejs/plugin-basic-ssl@2.0.0':
     resolution: {integrity: sha512-gc9Tjg8bUxBVSTzeWT3Njc0Cl3PakHFKdNfABnZWiUgbxqmHDEn7uECv3fHVylxoYgNzAcmU7ZrILz+BwSo3sA==}
+    version: 2.0.0
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     peerDependencies:
       vite: ^6.0.0
 
   '@vitejs/plugin-react@4.3.1':
     resolution: {integrity: sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==}
+    version: 4.3.1
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
@@ -6717,6 +6720,7 @@ packages:
 
   '@vitest/mocker@3.1.2':
     resolution: {integrity: sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==}
+    version: 3.1.2
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -6987,6 +6991,10 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  amdefine@1.0.1:
+    resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
+    engines: {node: '>=0.4.2'}
 
   angular-google-tag-manager@1.11.0:
     resolution: {integrity: sha512-r9sHS+LO9LUoQsiqPo05yTfGRpA3oODc/0AmL0QA1SbeboHKBkCRZIUHkv5w6+GGmWR/G+ZR52eHNLWcgTwIAA==}
@@ -8264,6 +8272,9 @@ packages:
         optional: true
       lightningcss:
         optional: true
+
+  css-parse@1.7.0:
+    resolution: {integrity: sha512-OI38lO4JQQX2GSisTqwiSFxiWNmLajXdW4tCCxAuiwGKjusHALQadSHBSxGlU8lrFp47IkLuU2AfSYz31qpETQ==}
 
   css-prefers-color-scheme@6.0.3:
     resolution: {integrity: sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==}
@@ -10066,6 +10077,10 @@ packages:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  glob@7.0.6:
+    resolution: {integrity: sha512-f8c0rE8JiCxpa52kWPAOa3ZaYEnzofDzCQLCn3Vdk0Z5OVLq3BsRFJI4S4ykpeVW6QMGBUkMeUpoEgWnMTnw5Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -14285,6 +14300,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  sax@0.5.8:
+    resolution: {integrity: sha512-c0YL9VcSfcdH3F1Qij9qpYJFpKFKMXNOkLWFssBL3RuF7ZS8oZhllR2rWlCRjDTJsfq3R6wbSsaRU6o0rkEdNw==}
+
   sax@1.2.1:
     resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
 
@@ -14664,6 +14682,10 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
+  source-map@0.1.43:
+    resolution: {integrity: sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==}
+    engines: {node: '>=0.8.0'}
+
   source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
@@ -15005,13 +15027,16 @@ packages:
 
   stylus-loader@7.1.3:
     resolution: {integrity: sha512-TY0SKwiY7D2kMd3UxaWKSf3xHF0FFN/FAfsSqfrhxRT/koXTwffq2cgEWDkLQz7VojMu7qEEHt5TlMjkPx9UDw==}
+    version: 7.1.3
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      stylus: 0.0.1-security
+      stylus: '>=0.52.4'
       webpack: ^5.0.0
 
-  stylus@0.0.1-security:
-    resolution: {integrity: sha512-qTLX5NJwuj5dqdJyi1eAjXGE4HfjWDoPLbSIpYWn/rAEdiyZnsngS/Yj0BRjM7wC41e/+spK4QCXFqz7LM0fFQ==}
+  stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b:
+    resolution: {tarball: https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b}
+    version: 0.54.4
+    hasBin: true
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -15592,8 +15617,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.0-dev.20250722:
-    resolution: {integrity: sha512-6ZrhtZw1gMpOMXA5A8qzoOrF++iCoifZIJbbUSblrf6a9mHXhUQ9KTiD7S4/8pjPL+2PWm4FfG3bUb710t4ypw==}
+  typescript@5.9.0-dev.20250723:
+    resolution: {integrity: sha512-cW9lMDuujd4h4Q/gHT7YdIxO3JElYuztGLsV9+kWkZncfifCVjAB3lmqpsiyKtztd//Uqt4ZPZ8SmY+qpoVelg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15836,11 +15861,13 @@ packages:
 
   vite-node@3.1.2:
     resolution: {integrity: sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==}
+    version: 3.1.2
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite@6.2.1:
     resolution: {integrity: sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==}
+    version: 6.2.1
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -15850,7 +15877,7 @@ packages:
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
-      stylus: 0.0.1-security
+      stylus: '*'
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
@@ -15881,6 +15908,7 @@ packages:
 
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    version: 6.3.5
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -15890,7 +15918,7 @@ packages:
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
-      stylus: 0.0.1-security
+      stylus: '*'
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
@@ -15921,6 +15949,7 @@ packages:
 
   vitest@3.1.2:
     resolution: {integrity: sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==}
+    version: 3.1.2
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -16459,13 +16488,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)':
+  '@angular-devkit/build-angular@20.0.3(3de37dba7a1a4e43c8d9516ed9229b27)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.2000.3(chokidar@4.0.3)(webpack-dev-server@5.2.1(debug@4.3.7)(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)))(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       '@angular-devkit/core': 20.0.3(chokidar@4.0.3)
-      '@angular/build': 20.0.3(836386c0359c13c4f7ff2a9d5935b93e)
+      '@angular/build': 20.0.3(af7cd2bc3b6f9538257e101724f76ae0)
       '@angular/compiler-cli': 20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3)
       '@babel/core': 7.27.1
       '@babel/generator': 7.27.1
@@ -16478,7 +16507,7 @@ snapshots:
       '@babel/runtime': 7.27.1
       '@discoveryjs/json-ext': 0.6.3
       '@ngtools/webpack': 20.0.3(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.3)
       babel-loader: 10.0.0(@babel/core@7.27.1)(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
@@ -16626,7 +16655,7 @@ snapshots:
       '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)
       tslib: 2.4.1
 
-  '@angular/build@20.0.3(836386c0359c13c4f7ff2a9d5935b93e)':
+  '@angular/build@20.0.3(88aef7c42b7d29b7d8341c042d86d696)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
@@ -16636,63 +16665,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.10(@types/node@22.5.1)
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
-      beasties: 0.3.4
-      browserslist: 4.24.4
-      esbuild: 0.25.5
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 8.3.3
-      magic-string: 0.30.17
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 7.1.0
-      picomatch: 4.0.2
-      piscina: 5.0.0
-      rollup: 4.40.2
-      sass: 1.88.0
-      semver: 7.7.2
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.13
-      tslib: 2.8.1
-      typescript: 5.8.3
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
-      watchpack: 2.4.2
-    optionalDependencies:
-      '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)
-      '@angular/platform-browser': 20.0.4(@angular/animations@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/platform-server': 20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@20.0.4)(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@20.0.4(@angular/animations@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
-      '@angular/ssr': 20.0.3(25804875197254df2ca2a551a068e611)
-      less: 4.3.0
-      lmdb: 3.3.0
-      ng-packagr: 20.0.1(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3)))(tslib@2.4.1)(typescript@5.8.3)
-      postcss: 8.5.3
-      tailwindcss: 3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3))
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@20.0.3(8f3262123df8e6325ffae330a509fbeb)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
-      '@angular/compiler': 20.0.4
-      '@angular/compiler-cli': 20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3)
-      '@babel/core': 7.27.1
-      '@babel/helper-annotate-as-pure': 7.27.1
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.10(@types/node@22.5.1)
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))
       beasties: 0.3.4
       browserslist: 4.24.4
       esbuild: 0.25.5
@@ -16712,7 +16685,7 @@ snapshots:
       tinyglobby: 0.2.13
       tslib: 2.4.1
       typescript: 5.8.3
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
       watchpack: 2.4.2
     optionalDependencies:
       '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)
@@ -16724,7 +16697,7 @@ snapshots:
       ng-packagr: 20.0.1(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3)))(tslib@2.4.1)(typescript@5.8.3)
       postcss: 8.4.38
       tailwindcss: 3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3))
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -16738,6 +16711,62 @@ snapshots:
       - tsx
       - yaml
     optional: true
+
+  '@angular/build@20.0.3(af7cd2bc3b6f9538257e101724f76ae0)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
+      '@angular/compiler': 20.0.4
+      '@angular/compiler-cli': 20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3)
+      '@babel/core': 7.27.1
+      '@babel/helper-annotate-as-pure': 7.27.1
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@inquirer/confirm': 5.1.10(@types/node@22.5.1)
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))
+      beasties: 0.3.4
+      browserslist: 4.24.4
+      esbuild: 0.25.5
+      https-proxy-agent: 7.0.6
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      listr2: 8.3.3
+      magic-string: 0.30.17
+      mrmime: 2.0.1
+      parse5-html-rewriting-stream: 7.1.0
+      picomatch: 4.0.2
+      piscina: 5.0.0
+      rollup: 4.40.2
+      sass: 1.88.0
+      semver: 7.7.2
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.13
+      tslib: 2.8.1
+      typescript: 5.8.3
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
+      watchpack: 2.4.2
+    optionalDependencies:
+      '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)
+      '@angular/platform-browser': 20.0.4(@angular/animations@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))
+      '@angular/platform-server': 20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@20.0.4)(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@20.0.4(@angular/animations@20.0.4(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
+      '@angular/ssr': 20.0.3(25804875197254df2ca2a551a068e611)
+      less: 4.3.0
+      lmdb: 3.3.0
+      ng-packagr: 20.0.1(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3)))(tslib@2.4.1)(typescript@5.8.3)
+      postcss: 8.5.3
+      tailwindcss: 3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3))
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - chokidar
+      - jiti
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   '@angular/cdk@20.0.3(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)':
     dependencies:
@@ -21310,15 +21339,15 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@nrwl/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
+  '@nrwl/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
     dependencies:
-      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
     transitivePeerDependencies:
       - nx
 
-  '@nrwl/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)':
+  '@nrwl/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250723)':
     dependencies:
-      '@nx/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)
+      '@nx/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250723)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -21331,18 +21360,18 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/tao@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
+  '@nrwl/tao@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
     dependencies:
-      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       tslib: 2.4.1
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
       - debug
 
-  '@nrwl/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
+  '@nrwl/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
     dependencies:
-      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
@@ -21407,7 +21436,7 @@ snapshots:
       tmp: 0.2.3
       tslib: 2.4.1
 
-  '@nx/angular@21.2.1(1e67b5e58dcb36cea52a255ec56e75bf)':
+  '@nx/angular@21.2.1(f87e49bda42a4a65f134da438803224f)':
     dependencies:
       '@angular-devkit/core': 20.0.3(chokidar@4.0.3)
       '@angular-devkit/schematics': 20.0.3(chokidar@4.0.3)
@@ -21431,8 +21460,8 @@ snapshots:
       tslib: 2.4.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular-devkit/build-angular': 20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)
-      '@angular/build': 20.0.3(8f3262123df8e6325ffae330a509fbeb)
+      '@angular-devkit/build-angular': 20.0.3(3de37dba7a1a4e43c8d9516ed9229b27)
+      '@angular/build': 20.0.3(88aef7c42b7d29b7d8341c042d86d696)
       ng-packagr: 20.0.1(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3)))(tslib@2.4.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -21495,14 +21524,14 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
+  '@nx/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
     dependencies:
-      '@nrwl/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nrwl/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       semver: 7.6.3
       tmp: 0.2.3
       tslib: 2.4.1
@@ -21618,7 +21647,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)':
+  '@nx/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250723)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.25.2)
@@ -21627,9 +21656,9 @@ snapshots:
       '@babel/preset-env': 7.25.3(@babel/core@7.25.2)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
       '@babel/runtime': 7.25.0
-      '@nrwl/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)
-      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
-      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nrwl/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250723)
+      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       babel-plugin-const-enum: 1.2.0(@babel/core@7.25.2)
       babel-plugin-macros: 2.8.0
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.25.2)(@babel/traverse@7.27.4)
@@ -21646,7 +21675,7 @@ snapshots:
       ora: 5.3.0
       semver: 7.6.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250722)
+      ts-node: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250723)
       tsconfig-paths: 4.2.0
       tslib: 2.4.1
     transitivePeerDependencies:
@@ -21985,7 +22014,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)':
+  '@nx/vite@21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)':
     dependencies:
       '@nx/devkit': 21.2.1(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       '@nx/js': 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
@@ -21996,8 +22025,8 @@ snapshots:
       picomatch: 4.0.2
       semver: 7.7.1
       tsconfig-paths: 4.2.0
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -22055,8 +22084,8 @@ snapshots:
       sass-loader: 16.0.5(@rspack/core@1.3.15(@swc/helpers@0.5.12))(sass-embedded@1.85.1)(sass@1.85.1)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       source-map-loader: 5.0.0(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       style-loader: 3.3.4(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
-      stylus: 0.0.1-security
-      stylus-loader: 7.1.3(stylus@0.0.1-security)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
+      stylus: https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b
+      stylus-loader: 7.1.3(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       terser-webpack-plugin: 5.3.14(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       ts-loader: 9.5.1(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       tsconfig-paths-webpack-plugin: 4.0.0
@@ -22089,13 +22118,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@nx/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
+  '@nx/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
     dependencies:
-      '@nrwl/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
-      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nrwl/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       tslib: 2.4.1
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -23565,10 +23594,10 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.12(prettier@3.3.3)
 
-  '@storybook/angular@8.6.12(ba89164553851694dc7434ec6a80b700)':
+  '@storybook/angular@8.6.12(79affedf83aa44f8d6206f50e4d79187)':
     dependencies:
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
-      '@angular-devkit/build-angular': 20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)
+      '@angular-devkit/build-angular': 20.0.3(3de37dba7a1a4e43c8d9516ed9229b27)
       '@angular-devkit/core': 20.0.3(chokidar@4.0.3)
       '@angular/common': 20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@angular/compiler': 20.0.4
@@ -23860,7 +23889,7 @@ snapshots:
       - '@swc/types'
       - supports-color
 
-  '@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722)':
+  '@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723)':
     dependencies:
       '@swc-node/core': 1.13.3(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)
       '@swc-node/sourcemap-support': 0.5.1
@@ -23869,7 +23898,7 @@ snapshots:
       debug: 4.3.7(supports-color@8.1.1)
       pirates: 4.0.6
       tslib: 2.6.3
-      typescript: 5.9.0-dev.20250722
+      typescript: 5.9.0-dev.20250723
     transitivePeerDependencies:
       - '@swc/types'
       - supports-color
@@ -24005,7 +24034,7 @@ snapshots:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.13
       jest: 29.7.0(@types/node@22.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3))
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
 
   '@testing-library/jest-dom@6.5.0':
     dependencies:
@@ -24775,27 +24804,27 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
 
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
     optional: true
 
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
 
-  '@vitejs/plugin-react@4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -24813,14 +24842,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitest/mocker@3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.6(@types/node@22.5.1)(typescript@5.8.3)
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -24866,7 +24895,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
 
   '@vitest/utils@1.6.0':
     dependencies:
@@ -25161,6 +25190,8 @@ snapshots:
       fast-uri: 3.0.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  amdefine@1.0.1: {}
 
   angular-google-tag-manager@1.11.0(@angular/common@20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@20.0.4):
     dependencies:
@@ -26759,6 +26790,8 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.5
 
+  css-parse@1.7.0: {}
+
   css-prefers-color-scheme@6.0.3(postcss@8.4.38):
     dependencies:
       postcss: 8.4.38
@@ -27636,7 +27669,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 5.9.0-dev.20250722
+      typescript: 5.9.0-dev.20250723
 
   dunder-proto@1.0.1:
     dependencies:
@@ -29081,6 +29114,15 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.0
       path-scurry: 2.0.0
+
+  glob@7.0.6:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   glob@7.2.3:
     dependencies:
@@ -31972,10 +32014,10 @@ snapshots:
 
   nwsapi@2.2.12: {}
 
-  nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7):
+  nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
-      '@nrwl/tao': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nrwl/tao': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.7
@@ -32020,7 +32062,7 @@ snapshots:
       '@nx/nx-linux-x64-musl': 19.8.0
       '@nx/nx-win32-arm64-msvc': 19.8.0
       '@nx/nx-win32-x64-msvc': 19.8.0
-      '@swc-node/register': 1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722)
+      '@swc-node/register': 1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250723)
       '@swc/core': 1.5.29(@swc/helpers@0.5.12)
     transitivePeerDependencies:
       - debug
@@ -34074,6 +34116,8 @@ snapshots:
     optionalDependencies:
       '@parcel/watcher': 2.5.0
 
+  sax@0.5.8: {}
+
   sax@1.2.1: {}
 
   sax@1.4.1: {}
@@ -34663,6 +34707,10 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
+  source-map@0.1.43:
+    dependencies:
+      amdefine: 1.0.1
+
   source-map@0.5.7: {}
 
   source-map@0.6.1: {}
@@ -35087,14 +35135,23 @@ snapshots:
   stylis@4.3.6:
     optional: true
 
-  stylus-loader@7.1.3(stylus@0.0.1-security)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)):
+  stylus-loader@7.1.3(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
-      stylus: 0.0.1-security
+      stylus: https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b
       webpack: 5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)
 
-  stylus@0.0.1-security: {}
+  stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b:
+    dependencies:
+      css-parse: 1.7.0
+      debug: 4.3.7(supports-color@8.1.1)
+      glob: 7.0.6
+      mkdirp: 0.5.6
+      sax: 0.5.8
+      source-map: 0.1.43
+    transitivePeerDependencies:
+      - supports-color
 
   sucrase@3.35.0:
     dependencies:
@@ -35604,7 +35661,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.5.29(@swc/helpers@0.5.12)
 
-  ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250722):
+  ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250723):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -35618,7 +35675,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.0-dev.20250722
+      typescript: 5.9.0-dev.20250723
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -35788,7 +35845,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@5.9.0-dev.20250722: {}
+  typescript@5.9.0-dev.20250723: {}
 
   ua-parser-js@1.0.38: {}
 
@@ -35992,13 +36049,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  vite-node@3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
+  vite-node@3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -36013,7 +36070,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
+  vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -36025,11 +36082,11 @@ snapshots:
       less: 4.1.3
       sass: 1.85.1
       sass-embedded: 1.85.1
-      stylus: 0.0.1-security
+      stylus: https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b
       terser: 5.39.1
       yaml: 2.7.0
 
-  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
+  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
@@ -36044,12 +36101,12 @@ snapshots:
       less: 4.1.3
       sass: 1.88.0
       sass-embedded: 1.85.1
-      stylus: 0.0.1-security
+      stylus: https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b
       terser: 5.39.1
       yaml: 2.7.0
     optional: true
 
-  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
+  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
@@ -36064,14 +36121,14 @@ snapshots:
       less: 4.3.0
       sass: 1.88.0
       sass-embedded: 1.85.1
-      stylus: 0.0.1-security
+      stylus: https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b
       terser: 5.39.1
       yaml: 2.7.0
 
-  vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
+  vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
+      '@vitest/mocker': 3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2
@@ -36088,8 +36145,8 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
-      vite-node: 3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
+      vite-node: 3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@https://codeload.github.com/stylus/stylus/tar.gz/9d341936eaa56e3758a6b915d5e195423342625b)(terser@5.39.1)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   axios: 1.8.2
   cross-spawn: 7.0.6
   redoc: 2.5.0
+  stylus: 0.0.1-security
   tar-fs: 2.1.3
 
 importers:
@@ -230,7 +231,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 20.0.3
-        version: 20.0.3(10a52ebf2e4a4d4ea4e6cc6570b86e3e)
+        version: 20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)
       '@angular-devkit/core':
         specifier: 20.0.3
         version: 20.0.3(chokidar@4.0.3)
@@ -269,7 +270,7 @@ importers:
         version: 6.8.0(@nx/devkit@21.2.1(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)))(@nx/js@21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)))(dotenv@16.5.0)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(tslib@2.4.1)
       '@nx/angular':
         specifier: 21.2.1
-        version: 21.2.1(535e900e4c60e0141bfc749fc485c0a2)
+        version: 21.2.1(1e67b5e58dcb36cea52a255ec56e75bf)
       '@nx/cypress':
         specifier: 21.2.1
         version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@zkochan/js-yaml@0.0.7)(cypress@14.3.2)(debug@4.3.7)(eslint@8.57.0)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)
@@ -308,7 +309,7 @@ importers:
         version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@zkochan/js-yaml@0.0.7)(cypress@14.3.2)(debug@4.3.7)(eslint@8.57.0)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(storybook@8.6.12(prettier@3.3.3))(typescript@5.8.3)
       '@nx/vite':
         specifier: 21.2.1
-        version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)
+        version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)
       '@nx/web':
         specifier: 21.2.1
         version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
@@ -341,7 +342,7 @@ importers:
         version: 8.6.12(@types/react@18.3.7)(storybook@8.6.12(prettier@3.3.3))
       '@storybook/angular':
         specifier: 8.6.12
-        version: 8.6.12(74437d687c0c15af2f626de065963d7f)
+        version: 8.6.12(ba89164553851694dc7434ec6a80b700)
       '@storybook/core-server':
         specifier: 8.6.12
         version: 8.6.12(storybook@8.6.12(prettier@3.3.3))
@@ -434,7 +435,7 @@ importers:
         version: 8.34.1(eslint@8.57.0)(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: 4.3.1
-        version: 4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))
+        version: 4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
       '@vitest/ui':
         specifier: 1.6.0
         version: 1.6.0(vitest@3.1.2)
@@ -614,22 +615,22 @@ importers:
         version: 5.8.3
       vite:
         specifier: 6.2.1
-        version: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+        version: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
       vitest:
         specifier: 3.1.2
-        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
 
   libs/sage-monorepo/nx-plugin:
     dependencies:
       '@nx/devkit':
         specifier: 19.8.0
-        version: 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+        version: 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       '@nx/js':
         specifier: 19.8.0
-        version: 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250714)
+        version: 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)
       nx:
         specifier: 19.8.0
-        version: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+        version: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       tslib:
         specifier: ^2.3.0
         version: 2.4.1
@@ -650,9 +651,6 @@ packages:
 
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
-
-  '@adobe/css-tools@4.3.3':
-    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
 
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
@@ -15009,13 +15007,11 @@ packages:
     resolution: {integrity: sha512-TY0SKwiY7D2kMd3UxaWKSf3xHF0FFN/FAfsSqfrhxRT/koXTwffq2cgEWDkLQz7VojMu7qEEHt5TlMjkPx9UDw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      stylus: '>=0.52.4'
+      stylus: 0.0.1-security
       webpack: ^5.0.0
 
-  stylus@0.64.0:
-    resolution: {integrity: sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==}
-    engines: {node: '>=16'}
-    hasBin: true
+  stylus@0.0.1-security:
+    resolution: {integrity: sha512-qTLX5NJwuj5dqdJyi1eAjXGE4HfjWDoPLbSIpYWn/rAEdiyZnsngS/Yj0BRjM7wC41e/+spK4QCXFqz7LM0fFQ==}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -15596,8 +15592,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.0-dev.20250714:
-    resolution: {integrity: sha512-bwPEUBqpLyZu/skdNU1zkNggyohtulwmjMzkJKLRZLbMrmgPQuwDeSi4W2qADOI4TA3NMxyYF9gg3HdNTWD8/g==}
+  typescript@5.9.0-dev.20250722:
+    resolution: {integrity: sha512-6ZrhtZw1gMpOMXA5A8qzoOrF++iCoifZIJbbUSblrf6a9mHXhUQ9KTiD7S4/8pjPL+2PWm4FfG3bUb710t4ypw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15854,7 +15850,7 @@ packages:
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
-      stylus: '*'
+      stylus: 0.0.1-security
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
@@ -15894,7 +15890,7 @@ packages:
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
-      stylus: '*'
+      stylus: 0.0.1-security
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
@@ -16447,8 +16443,6 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@adobe/css-tools@4.3.3': {}
-
   '@adobe/css-tools@4.4.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
@@ -16465,13 +16459,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@20.0.3(10a52ebf2e4a4d4ea4e6cc6570b86e3e)':
+  '@angular-devkit/build-angular@20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.2000.3(chokidar@4.0.3)(webpack-dev-server@5.2.1(debug@4.3.7)(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)))(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       '@angular-devkit/core': 20.0.3(chokidar@4.0.3)
-      '@angular/build': 20.0.3(0a31e51c2e0890af1c3b421abba1b07c)
+      '@angular/build': 20.0.3(836386c0359c13c4f7ff2a9d5935b93e)
       '@angular/compiler-cli': 20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3)
       '@babel/core': 7.27.1
       '@babel/generator': 7.27.1
@@ -16484,7 +16478,7 @@ snapshots:
       '@babel/runtime': 7.27.1
       '@discoveryjs/json-ext': 0.6.3
       '@ngtools/webpack': 20.0.3(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.3)
       babel-loader: 10.0.0(@babel/core@7.27.1)(webpack@5.99.8(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
@@ -16632,7 +16626,7 @@ snapshots:
       '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)
       tslib: 2.4.1
 
-  '@angular/build@20.0.3(0a31e51c2e0890af1c3b421abba1b07c)':
+  '@angular/build@20.0.3(836386c0359c13c4f7ff2a9d5935b93e)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
@@ -16642,7 +16636,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.10(@types/node@22.5.1)
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
       beasties: 0.3.4
       browserslist: 4.24.4
       esbuild: 0.25.5
@@ -16662,7 +16656,7 @@ snapshots:
       tinyglobby: 0.2.13
       tslib: 2.8.1
       typescript: 5.8.3
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
       watchpack: 2.4.2
     optionalDependencies:
       '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)
@@ -16674,7 +16668,7 @@ snapshots:
       ng-packagr: 20.0.1(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3)))(tslib@2.4.1)(typescript@5.8.3)
       postcss: 8.5.3
       tailwindcss: 3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3))
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -16688,7 +16682,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@20.0.3(9bc629248393e7d78382eaf2f09d14af)':
+  '@angular/build@20.0.3(8f3262123df8e6325ffae330a509fbeb)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
@@ -16698,7 +16692,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.1
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.10(@types/node@22.5.1)
-      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))
+      '@vitejs/plugin-basic-ssl': 2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
       beasties: 0.3.4
       browserslist: 4.24.4
       esbuild: 0.25.5
@@ -16718,7 +16712,7 @@ snapshots:
       tinyglobby: 0.2.13
       tslib: 2.4.1
       typescript: 5.8.3
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
       watchpack: 2.4.2
     optionalDependencies:
       '@angular/core': 20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0)
@@ -16730,7 +16724,7 @@ snapshots:
       ng-packagr: 20.0.1(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3)))(tslib@2.4.1)(typescript@5.8.3)
       postcss: 8.4.38
       tailwindcss: 3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3))
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -21316,15 +21310,15 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@nrwl/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
+  '@nrwl/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
     dependencies:
-      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
     transitivePeerDependencies:
       - nx
 
-  '@nrwl/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250714)':
+  '@nrwl/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)':
     dependencies:
-      '@nx/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250714)
+      '@nx/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -21337,18 +21331,18 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/tao@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
+  '@nrwl/tao@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
     dependencies:
-      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       tslib: 2.4.1
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
       - debug
 
-  '@nrwl/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
+  '@nrwl/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
     dependencies:
-      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
@@ -21413,7 +21407,7 @@ snapshots:
       tmp: 0.2.3
       tslib: 2.4.1
 
-  '@nx/angular@21.2.1(535e900e4c60e0141bfc749fc485c0a2)':
+  '@nx/angular@21.2.1(1e67b5e58dcb36cea52a255ec56e75bf)':
     dependencies:
       '@angular-devkit/core': 20.0.3(chokidar@4.0.3)
       '@angular-devkit/schematics': 20.0.3(chokidar@4.0.3)
@@ -21437,8 +21431,8 @@ snapshots:
       tslib: 2.4.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular-devkit/build-angular': 20.0.3(10a52ebf2e4a4d4ea4e6cc6570b86e3e)
-      '@angular/build': 20.0.3(9bc629248393e7d78382eaf2f09d14af)
+      '@angular-devkit/build-angular': 20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)
+      '@angular/build': 20.0.3(8f3262123df8e6325ffae330a509fbeb)
       ng-packagr: 20.0.1(@angular/compiler-cli@20.0.4(@angular/compiler@20.0.4)(typescript@5.8.3))(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3)))(tslib@2.4.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -21501,14 +21495,14 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
+  '@nx/devkit@19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))':
     dependencies:
-      '@nrwl/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nrwl/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       semver: 7.6.3
       tmp: 0.2.3
       tslib: 2.4.1
@@ -21624,7 +21618,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250714)':
+  '@nx/js@19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.25.2)
@@ -21633,9 +21627,9 @@ snapshots:
       '@babel/preset-env': 7.25.3(@babel/core@7.25.2)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
       '@babel/runtime': 7.25.0
-      '@nrwl/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250714)
-      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
-      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nrwl/js': 19.8.0(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(debug@4.3.7)(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.9.0-dev.20250722)
+      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nx/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       babel-plugin-const-enum: 1.2.0(@babel/core@7.25.2)
       babel-plugin-macros: 2.8.0
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.25.2)(@babel/traverse@7.27.4)
@@ -21652,7 +21646,7 @@ snapshots:
       ora: 5.3.0
       semver: 7.6.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250714)
+      ts-node: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250722)
       tsconfig-paths: 4.2.0
       tslib: 2.4.1
     transitivePeerDependencies:
@@ -21991,7 +21985,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)':
+  '@nx/vite@21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))(typescript@5.8.3)(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))(vitest@3.1.2)':
     dependencies:
       '@nx/devkit': 21.2.1(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       '@nx/js': 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
@@ -22002,8 +21996,8 @@ snapshots:
       picomatch: 4.0.2
       semver: 7.7.1
       tsconfig-paths: 4.2.0
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -22061,8 +22055,8 @@ snapshots:
       sass-loader: 16.0.5(@rspack/core@1.3.15(@swc/helpers@0.5.12))(sass-embedded@1.85.1)(sass@1.85.1)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       source-map-loader: 5.0.0(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       style-loader: 3.3.4(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
-      stylus: 0.64.0
-      stylus-loader: 7.1.3(stylus@0.64.0)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
+      stylus: 0.0.1-security
+      stylus-loader: 7.1.3(stylus@0.0.1-security)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       terser-webpack-plugin: 5.3.14(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       ts-loader: 9.5.1(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5))
       tsconfig-paths-webpack-plugin: 4.0.0
@@ -22095,13 +22089,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@nx/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
+  '@nx/workspace@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)':
     dependencies:
-      '@nrwl/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
-      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
+      '@nrwl/workspace': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nx/devkit': 19.8.0(nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7))
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      nx: 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       tslib: 2.4.1
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -23571,10 +23565,10 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.12(prettier@3.3.3)
 
-  '@storybook/angular@8.6.12(74437d687c0c15af2f626de065963d7f)':
+  '@storybook/angular@8.6.12(ba89164553851694dc7434ec6a80b700)':
     dependencies:
       '@angular-devkit/architect': 0.2000.3(chokidar@4.0.3)
-      '@angular-devkit/build-angular': 20.0.3(10a52ebf2e4a4d4ea4e6cc6570b86e3e)
+      '@angular-devkit/build-angular': 20.0.3(46e7c29dd5e4d10d58ee5134b3389fcf)
       '@angular-devkit/core': 20.0.3(chokidar@4.0.3)
       '@angular/common': 20.0.4(@angular/core@20.0.4(@angular/compiler@20.0.4)(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@angular/compiler': 20.0.4
@@ -23866,7 +23860,7 @@ snapshots:
       - '@swc/types'
       - supports-color
 
-  '@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714)':
+  '@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722)':
     dependencies:
       '@swc-node/core': 1.13.3(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)
       '@swc-node/sourcemap-support': 0.5.1
@@ -23875,7 +23869,7 @@ snapshots:
       debug: 4.3.7(supports-color@8.1.1)
       pirates: 4.0.6
       tslib: 2.6.3
-      typescript: 5.9.0-dev.20250714
+      typescript: 5.9.0-dev.20250722
     transitivePeerDependencies:
       - '@swc/types'
       - supports-color
@@ -24011,7 +24005,7 @@ snapshots:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.13
       jest: 29.7.0(@types/node@22.5.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.1)(typescript@5.8.3))
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
 
   '@testing-library/jest-dom@6.5.0':
     dependencies:
@@ -24781,27 +24775,27 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
 
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
     optional: true
 
-  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
-      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
 
-  '@vitejs/plugin-react@4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.3.1(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -24819,14 +24813,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))':
+  '@vitest/mocker@3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.7.6(@types/node@22.5.1)(typescript@5.8.3)
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -24872,7 +24866,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
 
   '@vitest/utils@1.6.0':
     dependencies:
@@ -27642,7 +27636,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 5.9.0-dev.20250714
+      typescript: 5.9.0-dev.20250722
 
   dunder-proto@1.0.1:
     dependencies:
@@ -31978,10 +31972,10 @@ snapshots:
 
   nwsapi@2.2.12: {}
 
-  nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7):
+  nx@19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
-      '@nrwl/tao': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
+      '@nrwl/tao': 19.8.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722))(@swc/core@1.5.29(@swc/helpers@0.5.12))(debug@4.3.7)
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.7
@@ -32026,7 +32020,7 @@ snapshots:
       '@nx/nx-linux-x64-musl': 19.8.0
       '@nx/nx-win32-arm64-msvc': 19.8.0
       '@nx/nx-win32-x64-msvc': 19.8.0
-      '@swc-node/register': 1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250714)
+      '@swc-node/register': 1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.12))(@swc/types@0.1.9)(typescript@5.9.0-dev.20250722)
       '@swc/core': 1.5.29(@swc/helpers@0.5.12)
     transitivePeerDependencies:
       - debug
@@ -35093,22 +35087,14 @@ snapshots:
   stylis@4.3.6:
     optional: true
 
-  stylus-loader@7.1.3(stylus@0.64.0)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)):
+  stylus-loader@7.1.3(stylus@0.0.1-security)(webpack@5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       webpack: 5.99.9(@swc/core@1.5.29(@swc/helpers@0.5.12))(esbuild@0.25.5)
 
-  stylus@0.64.0:
-    dependencies:
-      '@adobe/css-tools': 4.3.3
-      debug: 4.3.7(supports-color@8.1.1)
-      glob: 10.4.5
-      sax: 1.4.1
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - supports-color
+  stylus@0.0.1-security: {}
 
   sucrase@3.35.0:
     dependencies:
@@ -35618,7 +35604,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.5.29(@swc/helpers@0.5.12)
 
-  ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250714):
+  ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.12))(@types/node@22.5.5)(typescript@5.9.0-dev.20250722):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -35632,7 +35618,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.0-dev.20250714
+      typescript: 5.9.0-dev.20250722
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -35802,7 +35788,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@5.9.0-dev.20250714: {}
+  typescript@5.9.0-dev.20250722: {}
 
   ua-parser-js@1.0.38: {}
 
@@ -36006,13 +35992,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  vite-node@3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0):
+  vite-node@3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -36027,7 +36013,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0):
+  vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -36039,11 +36025,11 @@ snapshots:
       less: 4.1.3
       sass: 1.85.1
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.39.1
       yaml: 2.7.0
 
-  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0):
+  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
@@ -36058,12 +36044,12 @@ snapshots:
       less: 4.1.3
       sass: 1.88.0
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.39.1
       yaml: 2.7.0
     optional: true
 
-  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0):
+  vite@6.3.5(@types/node@22.5.1)(jiti@2.4.2)(less@4.3.0)(sass-embedded@1.85.1)(sass@1.88.0)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
@@ -36078,14 +36064,14 @@ snapshots:
       less: 4.3.0
       sass: 1.88.0
       sass-embedded: 1.85.1
-      stylus: 0.64.0
+      stylus: 0.0.1-security
       terser: 5.39.1
       yaml: 2.7.0
 
-  vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0):
+  vitest@3.1.2(@types/debug@4.1.12)(@types/node@22.5.1)(@vitest/ui@1.6.0)(jiti@2.4.2)(jsdom@22.1.0(canvas@3.1.0))(less@4.1.3)(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.1.2
-      '@vitest/mocker': 3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0))
+      '@vitest/mocker': 3.1.2(msw@2.7.6(@types/node@22.5.1)(typescript@5.8.3))(vite@6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.2
       '@vitest/snapshot': 3.1.2
@@ -36102,8 +36088,8 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
-      vite-node: 3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.39.1)(yaml@2.7.0)
+      vite: 6.2.1(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
+      vite-node: 3.1.2(@types/node@22.5.1)(jiti@2.4.2)(less@4.1.3)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.0.1-security)(terser@5.39.1)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
## Description

Override stylus to use its security placeholder version. This is a hot fix for our CI workflow. Another ticket has been opened to implement a stable fix once it is available. The solution found by the stylus maintainer and community is implemented here, which consists in using the previous version of the package hosted on GitHub.

## Notes

Unlike packages hosted on npmjs, releases on GitHub are not immutable and so are less secure.

## Related Issues

- [SMR-296](https://sagebionetworks.jira.com/browse/SMR-296)

## References

- https://www.npmjs.com/package/stylus?activeTab=readme