### PR TITLE
chore(explorers): bump model-ad-data to mv69 and agora-data to mv73 (MG-302)

### DIFF
--- a/apps/agora/data/.env.example
+++ b/apps/agora/data/.env.example
@@ -7,6 +7,6 @@ DB_HOST="agora-mongo" # must match mongo service name
 
 # specifies data release manifest and team images folder
 DATA_FILE="syn13363290"
-DATA_VERSION="72"
+DATA_VERSION="73"
 TEAM_IMAGES_ID="syn12861877"
 SYNAPSE_AUTH_TOKEN="agora-service-user-pat-here"

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="67"
+DATA_VERSION="69"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"


### PR DESCRIPTION
## Description

Bump data versions in model-ad-data and agora-data to align with deployed develop DB.

## Related Issue

- [MG-302](https://sagebionetworks.jira.com/browse/MG-302)

## Changelog

- Bump `model-ad-data` to mv69
- Bump `agora-data` to mv73
