### PR TITLE
fix(openchallenges): prevent Caddy from adding trailing slash to the API docs url (SMR-305)

### DIFF
--- a/apps/openchallenges/apex/Caddyfile
+++ b/apps/openchallenges/apex/Caddyfile
@@ -1,6 +1,6 @@
 :8000 {
 	handle_path /api-docs* {
-		redir {env.API_DOCS_URL}{uri}
+		redir {env.API_DOCS_URL}
 	}
 
 	handle_path /api* {


### PR DESCRIPTION
## Description

Prevent Caddy from adding trailing slash to the API docs URL.

## Related Issue

- [SMR-305](https://sagebionetworks.jira.com/browse/SMR-305)



[SMR-305]: https://sagebionetworks.jira.com/browse/SMR-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ