### PR TITLE
fix(model-ad): adjust boxplot y-axis labels (MG-337)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -5,7 +5,7 @@
   [points]="points()"
   [xAxisLabelFormatter]="xAxisLabelFormatter"
   [xAxisCategories]="genotypeOrder()"
-  [yAxisTitle]="formatYAxisTitle()"
+  [yAxisTitle]="yAxisTitle()"
   [pointTooltipFormatter]="pointTooltipFormatter"
   [pointCategoryColors]="pointCategoryColors"
   [pointCategoryShapes]="pointCategoryShapes"

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
@@ -62,32 +62,6 @@ describe('ModelDetailsBoxplotComponent', () => {
     expect(points).toHaveLength(0);
   });
 
-  it('should format Y-axis title with decoded Greek entities and title case', async () => {
-    const { component } = await setup(mockModelData);
-    const yAxisTitle = component.formatYAxisTitle();
-    expect(yAxisTitle).toBe('Aβ42 (ng/ml)');
-  });
-
-  it('should format Y-axis title without Greek entities', async () => {
-    const { component } = await setup({
-      ...mockModelData,
-      evidence_type: 'Beta amyloid',
-      units: 'pg/mg',
-    });
-    const yAxisTitle = component.formatYAxisTitle();
-    expect(yAxisTitle).toBe('Beta Amyloid (pg/mg)');
-  });
-
-  it('should include a line break in very long Y-axis titles', async () => {
-    const { component } = await setup({
-      ...mockModelData,
-      evidence_type: 'Some very very very long title',
-      units: 'these units are long too',
-    });
-    const yAxisTitle = component.formatYAxisTitle();
-    expect(yAxisTitle).toContain('\n');
-  });
-
   it('should format x-axis labels', async () => {
     const { component } = await setup();
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -17,7 +17,6 @@ export class ModelDetailsBoxplotComponent {
   titleCasePipe = inject(TitleCasePipe);
   decodeGreekEntityPipe = inject(DecodeGreekEntityPipe);
 
-  private readonly Y_AXIS_TITLE_LINE_BREAK_THRESHOLD = 30;
   private readonly X_AXIS_LABEL_MAX_WIDTH = 100;
   private readonly X_AXIS_LABEL_FONT = "bold 14px 'DM Sans Variable', sans-serif";
 
@@ -49,6 +48,8 @@ export class ModelDetailsBoxplotComponent {
       .sort((a, b) => a.pointCategory.localeCompare(b.pointCategory));
   });
 
+  yAxisTitle = computed(() => this.modelData().units);
+
   createTooltipText(individual: IndividualData, units: string): string {
     return `${individual.sex}\n${individual.value} ${units}\nIndividual ID: ${individual.individual_id}`;
   }
@@ -64,16 +65,5 @@ export class ModelDetailsBoxplotComponent {
       return value.replace(/[-*]/, (match) => match + '\n');
     }
     return value;
-  };
-
-  formatYAxisTitle = () => {
-    const evidenceType = this.decodeGreekEntityPipe.transform(
-      this.titleCasePipe.transform(this.modelData().evidence_type),
-    );
-    const units = this.modelData().units;
-
-    const nChars = evidenceType.length + units.length;
-    const sep = nChars > this.Y_AXIS_TITLE_LINE_BREAK_THRESHOLD ? '\n' : ' ';
-    return `${evidenceType}${sep}(${units})`;
   };
 }


### PR DESCRIPTION
## Description

We would like the Model-AD boxplot y-axis title to just display the units, since the evidence type is already displayed per plot grid. 

## Related Issue

- [MG-337](https://sagebionetworks.jira.com/browse/MG-337) 

## Changelog

- Changes boxplot y-axis title to just display the units
 
## Preview

`model-ad-build-images && model-ad-docker-start`

`http://localhost:8000/models/3xTg-AD/biomarkers`
<img width="872" height="733" alt="MG-337_biomarkers" src="https://github.com/user-attachments/assets/66300662-06e9-474a-8a25-7178d01d5448" />

`http://localhost:8000/models/3xTg-AD/pathology`
<img width="866" height="723" alt="MG-337_pathology" src="https://github.com/user-attachments/assets/ea5d698c-8dfb-4da0-8f2a-f3249d8a8218" />
