### PR TITLE
chore(explorers): use major version of nrwl/nx-set-shas (SMR-307)

### DIFF
--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -38,8 +38,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.head.sha || github.ref }}
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        # Pin to v4.2.1 until https://github.com/nrwl/nx-set-shas/issues/186 is fixed
-        uses: nrwl/nx-set-shas@v4.2.1
+        uses: nrwl/nx-set-shas@v4
 
       - name: Set up the dev container
         id: setup-dev-container


### PR DESCRIPTION
## Description

We pinned a minor version of `nrwl/nx-set-shas` action in the `e2e-explorer.yaml` workflow due to a bug in how `pull_request_target` triggers were handled. The bug has been fixed, so we can pin the major version in the workflow instead.

## Related Issue

- [SMR-307](https://sagebionetworks.jira.com/browse/SMR-307)

## Changelog

- Use major version of `nrwl/nx-set-shas` in `e2e-explorer.yaml`


[SMR-307]: https://sagebionetworks.jira.com/browse/SMR-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ