### PR TITLE
refactor(openchallenges): separate the words of OpenAPI tags with spaces instead of using pascal case (SMR-324)

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeAnalyticsApi.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeAnalyticsApi.java
@@ -31,7 +31,7 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.12.0")
 @Validated
-@Tag(name = "ChallengeAnalytics", description = "Operations about challenge analytics.")
+@Tag(name = "Challenge Analytics", description = "the Challenge Analytics API")
 public interface ChallengeAnalyticsApi {
 
     default ChallengeAnalyticsApiDelegate getDelegate() {
@@ -49,7 +49,7 @@ public interface ChallengeAnalyticsApi {
         operationId = "getChallengesPerYear",
         summary = "Get the number of challenges tracked per year",
         description = "Returns the number of challenges tracked per year",
-        tags = { "ChallengeAnalytics" },
+        tags = { "Challenge Analytics" },
         responses = {
             @ApiResponse(responseCode = "200", description = "An object", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengesPerYearDto.class)),

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeContributionApi.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengeContributionApi.java
@@ -34,7 +34,7 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.12.0")
 @Validated
-@Tag(name = "ChallengeContribution", description = "Operations about challenge contributions.")
+@Tag(name = "Challenge Contribution", description = "Operations about challenge contributions.")
 public interface ChallengeContributionApi {
 
     default ChallengeContributionApiDelegate getDelegate() {
@@ -58,7 +58,7 @@ public interface ChallengeContributionApi {
         operationId = "createChallengeContribution",
         summary = "Create a new contribution for a challenge",
         description = "Creates a new contribution record associated with a challenge ID. ",
-        tags = { "ChallengeContribution" },
+        tags = { "Challenge Contribution" },
         responses = {
             @ApiResponse(responseCode = "201", description = "Contribution created successfully", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengeContributionDto.class)),
@@ -121,7 +121,7 @@ public interface ChallengeContributionApi {
         operationId = "deleteChallengeContribution",
         summary = "Delete a specific challenge contribution",
         description = "Delete a specific challenge contribution.",
-        tags = { "ChallengeContribution" },
+        tags = { "Challenge Contribution" },
         responses = {
             @ApiResponse(responseCode = "204", description = "Contribution deleted successfully"),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = {
@@ -171,7 +171,7 @@ public interface ChallengeContributionApi {
         operationId = "deleteChallengeContributions",
         summary = "Delete the contributions for a specific challenge",
         description = "Deletes the associated contributions for a given challenge, identified by its ID.",
-        tags = { "ChallengeContribution" },
+        tags = { "Challenge Contribution" },
         responses = {
             @ApiResponse(responseCode = "204", description = "Deletion successful"),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = {
@@ -220,7 +220,7 @@ public interface ChallengeContributionApi {
         operationId = "getChallengeContribution",
         summary = "Get a specific challenge contribution",
         description = "Retrieves a specific contribution record for a challenge, identified by its ID. ",
-        tags = { "ChallengeContribution" },
+        tags = { "Challenge Contribution" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Challenge contribution retrieved successfully", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengeContributionDto.class)),
@@ -268,7 +268,7 @@ public interface ChallengeContributionApi {
         operationId = "listChallengeContributions",
         summary = "List challenge contributions",
         description = "List challenge contributions",
-        tags = { "ChallengeContribution" },
+        tags = { "Challenge Contribution" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Success", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengeContributionsPageDto.class)),

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApi.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/ChallengePlatformApi.java
@@ -35,7 +35,7 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.12.0")
 @Validated
-@Tag(name = "ChallengePlatform", description = "Operations about challenge platforms.")
+@Tag(name = "Challenge Platform", description = "the Challenge Platform API")
 public interface ChallengePlatformApi {
 
     default ChallengePlatformApiDelegate getDelegate() {
@@ -57,7 +57,7 @@ public interface ChallengePlatformApi {
         operationId = "createChallengePlatform",
         summary = "Create a challenge platform",
         description = "Create a challenge platform with the specified ID",
-        tags = { "ChallengePlatform" },
+        tags = { "Challenge Platform" },
         responses = {
             @ApiResponse(responseCode = "201", description = "Success", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengePlatformDto.class)),
@@ -113,7 +113,7 @@ public interface ChallengePlatformApi {
         operationId = "deleteChallengePlatform",
         summary = "Delete a challenge platform",
         description = "Deletes a challenge platform by its unique ID. This action is irreversible. ",
-        tags = { "ChallengePlatform" },
+        tags = { "Challenge Platform" },
         responses = {
             @ApiResponse(responseCode = "204", description = "Deletion successful"),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = {
@@ -159,7 +159,7 @@ public interface ChallengePlatformApi {
         operationId = "getChallengePlatform",
         summary = "Get a challenge platform",
         description = "Returns the challenge platform identified by its unique ID",
-        tags = { "ChallengePlatform" },
+        tags = { "Challenge Platform" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Success", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengePlatformDto.class)),
@@ -201,7 +201,7 @@ public interface ChallengePlatformApi {
         operationId = "listChallengePlatforms",
         summary = "List challenge platforms",
         description = "List challenge platforms",
-        tags = { "ChallengePlatform" },
+        tags = { "Challenge Platform" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Success", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengePlatformsPageDto.class)),
@@ -248,7 +248,7 @@ public interface ChallengePlatformApi {
         operationId = "updateChallengePlatform",
         summary = "Update an existing challenge platform",
         description = "Updates an existing challenge platform. ",
-        tags = { "ChallengePlatform" },
+        tags = { "Challenge Platform" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Challange platform updated successfully", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = ChallengePlatformDto.class)),

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/EdamConceptApi.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/api/EdamConceptApi.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.12.0")
 @Validated
-@Tag(name = "EdamConcept", description = "Operations about EDAM concepts.")
+@Tag(name = "Edam Concept", description = "the Edam Concept API")
 public interface EdamConceptApi {
 
     default EdamConceptApiDelegate getDelegate() {
@@ -52,7 +52,7 @@ public interface EdamConceptApi {
         operationId = "listEdamConcepts",
         summary = "List EDAM concepts",
         description = "List EDAM concepts",
-        tags = { "EdamConcept" },
+        tags = { "Edam Concept" },
         responses = {
             @ApiResponse(responseCode = "200", description = "Success", content = {
                 @Content(mediaType = "application/json", schema = @Schema(implementation = EdamConceptsPageDto.class)),

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeContributionsPageDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeContributionsPageDto.java
@@ -50,14 +50,13 @@ public class ChallengeContributionsPageDto {
   /**
    * Constructor with only required parameters
    */
-  public ChallengeContributionsPageDto(Integer number, Integer size, Long totalElements, Integer totalPages, Boolean hasNext, Boolean hasPrevious, List<@Valid ChallengeContributionDto> challengeContributions) {
+  public ChallengeContributionsPageDto(Integer number, Integer size, Long totalElements, Integer totalPages, Boolean hasNext, Boolean hasPrevious) {
     this.number = number;
     this.size = size;
     this.totalElements = totalElements;
     this.totalPages = totalPages;
     this.hasNext = hasNext;
     this.hasPrevious = hasPrevious;
-    this.challengeContributions = challengeContributions;
   }
 
   public ChallengeContributionsPageDto number(Integer number) {
@@ -197,8 +196,8 @@ public class ChallengeContributionsPageDto {
    * A list of challenge contributions.
    * @return challengeContributions
    */
-  @NotNull @Valid 
-  @Schema(name = "challengeContributions", description = "A list of challenge contributions.", requiredMode = Schema.RequiredMode.REQUIRED)
+  @Valid 
+  @Schema(name = "challengeContributions", description = "A list of challenge contributions.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("challengeContributions")
   public List<@Valid ChallengeContributionDto> getChallengeContributions() {
     return challengeContributions;

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformsPageDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengePlatformsPageDto.java
@@ -50,14 +50,13 @@ public class ChallengePlatformsPageDto {
   /**
    * Constructor with only required parameters
    */
-  public ChallengePlatformsPageDto(Integer number, Integer size, Long totalElements, Integer totalPages, Boolean hasNext, Boolean hasPrevious, List<@Valid ChallengePlatformDto> challengePlatforms) {
+  public ChallengePlatformsPageDto(Integer number, Integer size, Long totalElements, Integer totalPages, Boolean hasNext, Boolean hasPrevious) {
     this.number = number;
     this.size = size;
     this.totalElements = totalElements;
     this.totalPages = totalPages;
     this.hasNext = hasNext;
     this.hasPrevious = hasPrevious;
-    this.challengePlatforms = challengePlatforms;
   }
 
   public ChallengePlatformsPageDto number(Integer number) {
@@ -197,8 +196,8 @@ public class ChallengePlatformsPageDto {
    * A list of challenge platforms.
    * @return challengePlatforms
    */
-  @NotNull @Valid 
-  @Schema(name = "challengePlatforms", description = "A list of challenge platforms.", requiredMode = Schema.RequiredMode.REQUIRED)
+  @Valid 
+  @Schema(name = "challengePlatforms", description = "A list of challenge platforms.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("challengePlatforms")
   public List<@Valid ChallengePlatformDto> getChallengePlatforms() {
     return challengePlatforms;

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/EdamConceptsPageDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/EdamConceptsPageDto.java
@@ -50,14 +50,13 @@ public class EdamConceptsPageDto {
   /**
    * Constructor with only required parameters
    */
-  public EdamConceptsPageDto(Integer number, Integer size, Long totalElements, Integer totalPages, Boolean hasNext, Boolean hasPrevious, List<@Valid EdamConceptDto> edamConcepts) {
+  public EdamConceptsPageDto(Integer number, Integer size, Long totalElements, Integer totalPages, Boolean hasNext, Boolean hasPrevious) {
     this.number = number;
     this.size = size;
     this.totalElements = totalElements;
     this.totalPages = totalPages;
     this.hasNext = hasNext;
     this.hasPrevious = hasPrevious;
-    this.edamConcepts = edamConcepts;
   }
 
   public EdamConceptsPageDto number(Integer number) {
@@ -197,8 +196,8 @@ public class EdamConceptsPageDto {
    * A list of EDAM concepts.
    * @return edamConcepts
    */
-  @NotNull @Valid 
-  @Schema(name = "edamConcepts", description = "A list of EDAM concepts.", requiredMode = Schema.RequiredMode.REQUIRED)
+  @Valid 
+  @Schema(name = "edamConcepts", description = "A list of EDAM concepts.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("edamConcepts")
   public List<@Valid EdamConceptDto> getEdamConcepts() {
     return edamConcepts;

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -19,7 +19,7 @@ tags:
     x-audience:
       - public
   - description: Operations about challenge contributions.
-    name: ChallengeContribution
+    name: Challenge Contribution
     x-audience:
       - public
   - description: Operations about challenge analytics.
@@ -262,13 +262,13 @@ paths:
         - apiBearerAuth: []
       summary: Delete the contributions for a specific challenge
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - internal
       x-accepts:
         - application/problem+json
       x-tags:
-        - tag: ChallengeContribution
+        - tag: Challenge Contribution
     get:
       description: List challenge contributions
       operationId: listChallengeContributions
@@ -303,14 +303,14 @@ paths:
             error
       summary: List challenge contributions
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-accepts:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengeContribution
+        - tag: Challenge Contribution
     post:
       description: |
         Creates a new contribution record associated with a challenge ID.
@@ -372,7 +372,7 @@ paths:
         - apiBearerAuth: []
       summary: Create a new contribution for a challenge
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-content-type: application/json
@@ -380,7 +380,7 @@ paths:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengeContribution
+        - tag: Challenge Contribution
   /challenges/{challengeId}/contributions/{organizationId}/role/{role}:
     delete:
       description: Delete a specific challenge contribution.
@@ -442,13 +442,13 @@ paths:
         - apiBearerAuth: []
       summary: Delete a specific challenge contribution
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-accepts:
         - application/problem+json
       x-tags:
-        - tag: ChallengeContribution
+        - tag: Challenge Contribution
     get:
       description: |
         Retrieves a specific contribution record for a challenge, identified by its ID.
@@ -506,14 +506,14 @@ paths:
             error
       summary: Get a specific challenge contribution
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-accepts:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengeContribution
+        - tag: Challenge Contribution
   /challenge-analytics/challenges-per-year:
     get:
       description: Returns the number of challenges tracked per year
@@ -534,14 +534,14 @@ paths:
             error
       summary: Get the number of challenges tracked per year
       tags:
-        - ChallengeAnalytics
+        - Challenge Analytics
       x-audience:
         - public
       x-accepts:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengeAnalytics
+        - tag: Challenge Analytics
   /challenge-platforms:
     get:
       description: List challenge platforms
@@ -577,14 +577,14 @@ paths:
             error
       summary: List challenge platforms
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-accepts:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengePlatform
+        - tag: Challenge Platform
     post:
       description: Create a challenge platform with the specified ID
       operationId: createChallengePlatform
@@ -630,7 +630,7 @@ paths:
         - apiBearerAuth: []
       summary: Create a challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-content-type: application/json
@@ -638,7 +638,7 @@ paths:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengePlatform
+        - tag: Challenge Platform
   /challenge-platforms/{challengePlatformId}:
     delete:
       description: |
@@ -685,13 +685,13 @@ paths:
         - apiBearerAuth: []
       summary: Delete a challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-accepts:
         - application/problem+json
       x-tags:
-        - tag: ChallengePlatform
+        - tag: Challenge Platform
     get:
       description: Returns the challenge platform identified by its unique ID
       operationId: getChallengePlatform
@@ -726,14 +726,14 @@ paths:
             error
       summary: Get a challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-accepts:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengePlatform
+        - tag: Challenge Platform
     put:
       description: |
         Updates an existing challenge platform.
@@ -801,7 +801,7 @@ paths:
         - apiBearerAuth: []
       summary: Update an existing challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-content-type: application/json
@@ -809,7 +809,7 @@ paths:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: ChallengePlatform
+        - tag: Challenge Platform
   /edam-concepts:
     get:
       description: List EDAM concepts
@@ -845,14 +845,14 @@ paths:
             error
       summary: List EDAM concepts
       tags:
-        - EdamConcept
+        - Edam Concept
       x-audience:
         - public
       x-accepts:
         - application/json
         - application/problem+json
       x-tags:
-        - tag: EdamConcept
+        - tag: Edam Concept
 components:
   parameters:
     challengeSearchQuery:
@@ -1639,7 +1639,7 @@ components:
                 $ref: '#/components/schemas/ChallengeContribution'
               type: array
           required:
-            - challengeContributions
+            - Challenge Contributions
           type: object
       description: A page of challenge challenge contributions.
       example:
@@ -1808,7 +1808,7 @@ components:
                 $ref: '#/components/schemas/ChallengePlatform'
               type: array
           required:
-            - challengePlatforms
+            - Challenge Platforms
           type: object
       description: A page of challenge platforms.
       example:
@@ -1967,7 +1967,7 @@ components:
                 $ref: '#/components/schemas/EdamConcept'
               type: array
           required:
-            - edamConcepts
+            - Edam Concept
           type: object
       description: A page of EDAM concepts.
       example:

--- a/libs/openchallenges/api-client-angular/src/lib/model/challengeContributionsPage.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/challengeContributionsPage.ts
@@ -40,5 +40,5 @@ export interface ChallengeContributionsPage {
   /**
    * A list of challenge contributions.
    */
-  challengeContributions: Array<ChallengeContribution>;
+  challengeContributions?: Array<ChallengeContribution>;
 }

--- a/libs/openchallenges/api-client-angular/src/lib/model/challengePlatformsPage.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/challengePlatformsPage.ts
@@ -40,5 +40,5 @@ export interface ChallengePlatformsPage {
   /**
    * A list of challenge platforms.
    */
-  challengePlatforms: Array<ChallengePlatform>;
+  challengePlatforms?: Array<ChallengePlatform>;
 }

--- a/libs/openchallenges/api-client-angular/src/lib/model/edamConceptsPage.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/edamConceptsPage.ts
@@ -40,5 +40,5 @@ export interface EdamConceptsPage {
   /**
    * A list of EDAM concepts.
    */
-  edamConcepts: Array<EdamConcept>;
+  edamConcepts?: Array<EdamConcept>;
 }

--- a/libs/openchallenges/api-client-java/api/openapi.yaml
+++ b/libs/openchallenges/api-client-java/api/openapi.yaml
@@ -30,10 +30,10 @@ tags:
       - public
     x-displayName: Challenge
   - description: Operations about challenge contributions.
-    name: ChallengeContribution
+    name: Challenge Contribution
     x-audience:
       - public
-    x-displayName: ChallengeContribution
+    x-displayName: Challenge Contribution
   - description: Operations about challenge analytics.
     name: ChallengeAnalytics
     x-audience:
@@ -49,6 +49,12 @@ tags:
     x-audience:
       - public
     x-displayName: EdamConcept
+  - name: Challenge Analytics
+    x-displayName: Challenge Analytics
+  - name: Challenge Platform
+    x-displayName: Challenge Platform
+  - name: Edam Concept
+    x-displayName: Edam Concept
   - description: Operations about images
     name: Image
     x-audience:
@@ -434,7 +440,7 @@ paths:
             error
       summary: List challenge contributions
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-accepts:
@@ -501,7 +507,7 @@ paths:
         - apiBearerAuth: []
       summary: Create a new contribution for a challenge
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-content-type: application/json
@@ -569,7 +575,7 @@ paths:
         - apiBearerAuth: []
       summary: Delete a specific challenge contribution
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-accepts:
@@ -631,7 +637,7 @@ paths:
             error
       summary: Get a specific challenge contribution
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       x-audience:
         - public
       x-accepts:
@@ -657,7 +663,7 @@ paths:
             error
       summary: Get the number of challenges tracked per year
       tags:
-        - ChallengeAnalytics
+        - Challenge Analytics
       x-audience:
         - public
       x-accepts:
@@ -698,7 +704,7 @@ paths:
             error
       summary: List challenge platforms
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-accepts:
@@ -749,7 +755,7 @@ paths:
         - apiBearerAuth: []
       summary: Create a challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-content-type: application/json
@@ -802,7 +808,7 @@ paths:
         - apiBearerAuth: []
       summary: Delete a challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-accepts:
@@ -841,7 +847,7 @@ paths:
             error
       summary: Get a challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-accepts:
@@ -914,7 +920,7 @@ paths:
         - apiBearerAuth: []
       summary: Update an existing challenge platform
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       x-audience:
         - public
       x-content-type: application/json
@@ -956,7 +962,7 @@ paths:
             error
       summary: List EDAM concepts
       tags:
-        - EdamConcept
+        - Edam Concept
       x-audience:
         - public
       x-accepts:
@@ -2258,7 +2264,7 @@ components:
                 $ref: '#/components/schemas/ChallengeContribution'
               type: array
           required:
-            - challengeContributions
+            - Challenge Contributions
           type: object
       description: A page of challenge challenge contributions.
       example:
@@ -2430,7 +2436,7 @@ components:
                 $ref: '#/components/schemas/ChallengePlatform'
               type: array
           required:
-            - challengePlatforms
+            - Challenge Platforms
           type: object
       description: A page of challenge platforms.
       example:
@@ -2599,7 +2605,7 @@ components:
                 $ref: '#/components/schemas/EdamConcept'
               type: array
           required:
-            - edamConcepts
+            - Edam Concept
           type: object
       description: A page of EDAM concepts.
       example:
@@ -2973,10 +2979,13 @@ x-tagGroups:
   - name: OpenChallenges Challenge API
     tags:
       - Challenge
-      - ChallengeContribution
+      - Challenge Contribution
       - ChallengeAnalytics
       - ChallengePlatform
       - EdamConcept
+      - Challenge Analytics
+      - Challenge Platform
+      - Edam Concept
   - name: OpenChallenges Image API
     tags:
       - Image

--- a/libs/openchallenges/api-client-java/src/main/java/org/sagebionetworks/openchallenges/api/client/model/ChallengeContributionsPage.java
+++ b/libs/openchallenges/api-client-java/src/main/java/org/sagebionetworks/openchallenges/api/client/model/ChallengeContributionsPage.java
@@ -78,7 +78,7 @@ public class ChallengeContributionsPage {
 
   public static final String JSON_PROPERTY_CHALLENGE_CONTRIBUTIONS = "challengeContributions";
 
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   private List<ChallengeContribution> challengeContributions = new ArrayList<>();
 
   public ChallengeContributionsPage() {}
@@ -216,7 +216,7 @@ public class ChallengeContributionsPage {
   }
 
   public ChallengeContributionsPage challengeContributions(
-    @jakarta.annotation.Nonnull List<ChallengeContribution> challengeContributions
+    @jakarta.annotation.Nullable List<ChallengeContribution> challengeContributions
   ) {
     this.challengeContributions = challengeContributions;
     return this;
@@ -236,17 +236,17 @@ public class ChallengeContributionsPage {
    * A list of challenge contributions.
    * @return challengeContributions
    */
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHALLENGE_CONTRIBUTIONS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public List<ChallengeContribution> getChallengeContributions() {
     return challengeContributions;
   }
 
   @JsonProperty(JSON_PROPERTY_CHALLENGE_CONTRIBUTIONS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setChallengeContributions(
-    @jakarta.annotation.Nonnull List<ChallengeContribution> challengeContributions
+    @jakarta.annotation.Nullable List<ChallengeContribution> challengeContributions
   ) {
     this.challengeContributions = challengeContributions;
   }

--- a/libs/openchallenges/api-client-java/src/main/java/org/sagebionetworks/openchallenges/api/client/model/ChallengePlatformsPage.java
+++ b/libs/openchallenges/api-client-java/src/main/java/org/sagebionetworks/openchallenges/api/client/model/ChallengePlatformsPage.java
@@ -78,7 +78,7 @@ public class ChallengePlatformsPage {
 
   public static final String JSON_PROPERTY_CHALLENGE_PLATFORMS = "challengePlatforms";
 
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   private List<ChallengePlatform> challengePlatforms = new ArrayList<>();
 
   public ChallengePlatformsPage() {}
@@ -216,7 +216,7 @@ public class ChallengePlatformsPage {
   }
 
   public ChallengePlatformsPage challengePlatforms(
-    @jakarta.annotation.Nonnull List<ChallengePlatform> challengePlatforms
+    @jakarta.annotation.Nullable List<ChallengePlatform> challengePlatforms
   ) {
     this.challengePlatforms = challengePlatforms;
     return this;
@@ -236,17 +236,17 @@ public class ChallengePlatformsPage {
    * A list of challenge platforms.
    * @return challengePlatforms
    */
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHALLENGE_PLATFORMS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public List<ChallengePlatform> getChallengePlatforms() {
     return challengePlatforms;
   }
 
   @JsonProperty(JSON_PROPERTY_CHALLENGE_PLATFORMS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setChallengePlatforms(
-    @jakarta.annotation.Nonnull List<ChallengePlatform> challengePlatforms
+    @jakarta.annotation.Nullable List<ChallengePlatform> challengePlatforms
   ) {
     this.challengePlatforms = challengePlatforms;
   }

--- a/libs/openchallenges/api-client-java/src/main/java/org/sagebionetworks/openchallenges/api/client/model/EdamConceptsPage.java
+++ b/libs/openchallenges/api-client-java/src/main/java/org/sagebionetworks/openchallenges/api/client/model/EdamConceptsPage.java
@@ -78,7 +78,7 @@ public class EdamConceptsPage {
 
   public static final String JSON_PROPERTY_EDAM_CONCEPTS = "edamConcepts";
 
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   private List<EdamConcept> edamConcepts = new ArrayList<>();
 
   public EdamConceptsPage() {}
@@ -215,7 +215,9 @@ public class EdamConceptsPage {
     this.hasPrevious = hasPrevious;
   }
 
-  public EdamConceptsPage edamConcepts(@jakarta.annotation.Nonnull List<EdamConcept> edamConcepts) {
+  public EdamConceptsPage edamConcepts(
+    @jakarta.annotation.Nullable List<EdamConcept> edamConcepts
+  ) {
     this.edamConcepts = edamConcepts;
     return this;
   }
@@ -232,16 +234,16 @@ public class EdamConceptsPage {
    * A list of EDAM concepts.
    * @return edamConcepts
    */
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EDAM_CONCEPTS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public List<EdamConcept> getEdamConcepts() {
     return edamConcepts;
   }
 
   @JsonProperty(JSON_PROPERTY_EDAM_CONCEPTS)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setEdamConcepts(@jakarta.annotation.Nonnull List<EdamConcept> edamConcepts) {
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setEdamConcepts(@jakarta.annotation.Nullable List<EdamConcept> edamConcepts) {
     this.edamConcepts = edamConcepts;
   }
 

--- a/libs/openchallenges/api-client-python/docs/ChallengeContributionsPage.md
+++ b/libs/openchallenges/api-client-python/docs/ChallengeContributionsPage.md
@@ -4,15 +4,15 @@ A page of challenge challenge contributions.
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**number** | **int** | The page number. | 
-**size** | **int** | The number of items in a single page. | 
-**total_elements** | **int** | Total number of elements in the result set. | 
-**total_pages** | **int** | Total number of pages in the result set. | 
-**has_next** | **bool** | Returns if there is a next page. | 
-**has_previous** | **bool** | Returns if there is a previous page. | 
-**challenge_contributions** | [**List[ChallengeContribution]**](ChallengeContribution.md) | A list of challenge contributions. | 
+| Name                        | Type                                                        | Description                                 | Notes      |
+| --------------------------- | ----------------------------------------------------------- | ------------------------------------------- | ---------- |
+| **number**                  | **int**                                                     | The page number.                            |
+| **size**                    | **int**                                                     | The number of items in a single page.       |
+| **total_elements**          | **int**                                                     | Total number of elements in the result set. |
+| **total_pages**             | **int**                                                     | Total number of pages in the result set.    |
+| **has_next**                | **bool**                                                    | Returns if there is a next page.            |
+| **has_previous**            | **bool**                                                    | Returns if there is a previous page.        |
+| **challenge_contributions** | [**List[ChallengeContribution]**](ChallengeContribution.md) | A list of challenge contributions.          | [optional] |
 
 ## Example
 
@@ -31,6 +31,5 @@ challenge_contributions_page_dict = challenge_contributions_page_instance.to_dic
 # create an instance of ChallengeContributionsPage from a dict
 challenge_contributions_page_from_dict = ChallengeContributionsPage.from_dict(challenge_contributions_page_dict)
 ```
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
-

--- a/libs/openchallenges/api-client-python/docs/ChallengePlatformsPage.md
+++ b/libs/openchallenges/api-client-python/docs/ChallengePlatformsPage.md
@@ -4,15 +4,15 @@ A page of challenge platforms.
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**number** | **int** | The page number. | 
-**size** | **int** | The number of items in a single page. | 
-**total_elements** | **int** | Total number of elements in the result set. | 
-**total_pages** | **int** | Total number of pages in the result set. | 
-**has_next** | **bool** | Returns if there is a next page. | 
-**has_previous** | **bool** | Returns if there is a previous page. | 
-**challenge_platforms** | [**List[ChallengePlatform]**](ChallengePlatform.md) | A list of challenge platforms. | 
+| Name                    | Type                                                | Description                                 | Notes      |
+| ----------------------- | --------------------------------------------------- | ------------------------------------------- | ---------- |
+| **number**              | **int**                                             | The page number.                            |
+| **size**                | **int**                                             | The number of items in a single page.       |
+| **total_elements**      | **int**                                             | Total number of elements in the result set. |
+| **total_pages**         | **int**                                             | Total number of pages in the result set.    |
+| **has_next**            | **bool**                                            | Returns if there is a next page.            |
+| **has_previous**        | **bool**                                            | Returns if there is a previous page.        |
+| **challenge_platforms** | [**List[ChallengePlatform]**](ChallengePlatform.md) | A list of challenge platforms.              | [optional] |
 
 ## Example
 
@@ -31,6 +31,5 @@ challenge_platforms_page_dict = challenge_platforms_page_instance.to_dict()
 # create an instance of ChallengePlatformsPage from a dict
 challenge_platforms_page_from_dict = ChallengePlatformsPage.from_dict(challenge_platforms_page_dict)
 ```
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
-

--- a/libs/openchallenges/api-client-python/docs/EdamConceptsPage.md
+++ b/libs/openchallenges/api-client-python/docs/EdamConceptsPage.md
@@ -4,15 +4,15 @@ A page of EDAM concepts.
 
 ## Properties
 
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**number** | **int** | The page number. | 
-**size** | **int** | The number of items in a single page. | 
-**total_elements** | **int** | Total number of elements in the result set. | 
-**total_pages** | **int** | Total number of pages in the result set. | 
-**has_next** | **bool** | Returns if there is a next page. | 
-**has_previous** | **bool** | Returns if there is a previous page. | 
-**edam_concepts** | [**List[EdamConcept]**](EdamConcept.md) | A list of EDAM concepts. | 
+| Name               | Type                                    | Description                                 | Notes      |
+| ------------------ | --------------------------------------- | ------------------------------------------- | ---------- |
+| **number**         | **int**                                 | The page number.                            |
+| **size**           | **int**                                 | The number of items in a single page.       |
+| **total_elements** | **int**                                 | Total number of elements in the result set. |
+| **total_pages**    | **int**                                 | Total number of pages in the result set.    |
+| **has_next**       | **bool**                                | Returns if there is a next page.            |
+| **has_previous**   | **bool**                                | Returns if there is a previous page.        |
+| **edam_concepts**  | [**List[EdamConcept]**](EdamConcept.md) | A list of EDAM concepts.                    | [optional] |
 
 ## Example
 
@@ -31,6 +31,5 @@ edam_concepts_page_dict = edam_concepts_page_instance.to_dict()
 # create an instance of EdamConceptsPage from a dict
 edam_concepts_page_from_dict = EdamConceptsPage.from_dict(edam_concepts_page_dict)
 ```
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
-

--- a/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_contributions_page.py
+++ b/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_contributions_page.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from openchallenges_api_client_python.models.challenge_contribution import (
     ChallengeContribution,
 )
@@ -44,8 +44,10 @@ class ChallengeContributionsPage(BaseModel):
     has_previous: StrictBool = Field(
         description="Returns if there is a previous page.", alias="hasPrevious"
     )
-    challenge_contributions: List[ChallengeContribution] = Field(
-        description="A list of challenge contributions.", alias="challengeContributions"
+    challenge_contributions: Optional[List[ChallengeContribution]] = Field(
+        default=None,
+        description="A list of challenge contributions.",
+        alias="challengeContributions",
     )
     __properties: ClassVar[List[str]] = [
         "number",

--- a/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_platforms_page.py
+++ b/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_platforms_page.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from openchallenges_api_client_python.models.challenge_platform import ChallengePlatform
 from typing import Optional, Set
 from typing_extensions import Self
@@ -42,8 +42,10 @@ class ChallengePlatformsPage(BaseModel):
     has_previous: StrictBool = Field(
         description="Returns if there is a previous page.", alias="hasPrevious"
     )
-    challenge_platforms: List[ChallengePlatform] = Field(
-        description="A list of challenge platforms.", alias="challengePlatforms"
+    challenge_platforms: Optional[List[ChallengePlatform]] = Field(
+        default=None,
+        description="A list of challenge platforms.",
+        alias="challengePlatforms",
     )
     __properties: ClassVar[List[str]] = [
         "number",

--- a/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/edam_concepts_page.py
+++ b/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/edam_concepts_page.py
@@ -42,8 +42,8 @@ class EdamConceptsPage(BaseModel):
     has_previous: StrictBool = Field(
         description="Returns if there is a previous page.", alias="hasPrevious"
     )
-    edam_concepts: List[Optional[EdamConcept]] = Field(
-        description="A list of EDAM concepts.", alias="edamConcepts"
+    edam_concepts: Optional[List[Optional[EdamConcept]]] = Field(
+        default=None, description="A list of EDAM concepts.", alias="edamConcepts"
     )
     __properties: ClassVar[List[str]] = [
         "number",

--- a/libs/openchallenges/api-client-python/test/test_challenge_contributions_page.py
+++ b/libs/openchallenges/api-client-python/test/test_challenge_contributions_page.py
@@ -59,13 +59,6 @@ class TestChallengeContributionsPage(unittest.TestCase):
                 total_pages = 99,
                 has_next = True,
                 has_previous = True,
-                challenge_contributions = [
-                    openchallenges_api_client_python.models.challenge_contribution.ChallengeContribution(
-                        id = 1, 
-                        challenge_id = 1, 
-                        organization_id = 1, 
-                        role = 'challenge_organizer', )
-                    ],
         )
         """
 

--- a/libs/openchallenges/api-client-python/test/test_challenge_platforms_page.py
+++ b/libs/openchallenges/api-client-python/test/test_challenge_platforms_page.py
@@ -60,14 +60,6 @@ class TestChallengePlatformsPage(unittest.TestCase):
                 total_pages = 99,
                 has_next = True,
                 has_previous = True,
-                challenge_platforms = [
-                    openchallenges_api_client_python.models.challenge_platform.ChallengePlatform(
-                        id = 1, 
-                        slug = 'example-challenge-platform', 
-                        name = 'Example Challenge Platform', 
-                        avatar_key = 'logo/dream.png', 
-                        website_url = 'https://openchallenges.io', )
-                    ],
         )
         """
 

--- a/libs/openchallenges/api-client-python/test/test_edam_concepts_page.py
+++ b/libs/openchallenges/api-client-python/test/test_edam_concepts_page.py
@@ -56,12 +56,6 @@ class TestEdamConceptsPage(unittest.TestCase):
                 total_pages = 99,
                 has_next = True,
                 has_previous = True,
-                edam_concepts = [
-                    openchallenges_api_client_python.models.edam_concept.EdamConcept(
-                        id = 1, 
-                        class_id = 'http://edamontology.org/data_0850', 
-                        preferred_label = 'Sequence set', )
-                    ],
         )
         """
 

--- a/libs/openchallenges/api-description/openapi/challenge-public.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge-public.openapi.yaml
@@ -18,7 +18,7 @@ tags:
     description: Operations about challenges.
     x-audience:
       - public
-  - name: ChallengeContribution
+  - name: Challenge Contribution
     description: Operations about challenge contributions.
     x-audience:
       - public
@@ -128,7 +128,7 @@ paths:
       - $ref: '#/components/parameters/challengeId'
     get:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: List challenge contributions
       description: List challenge contributions
       operationId: listChallengeContributions
@@ -147,7 +147,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Create a new contribution for a challenge
       description: |
         Creates a new contribution record associated with a challenge ID.
@@ -186,7 +186,7 @@ paths:
       - $ref: '#/components/parameters/challengeContributionRole'
     get:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Get a specific challenge contribution
       description: |
         Retrieves a specific contribution record for a challenge, identified by its ID.
@@ -208,7 +208,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Delete a specific challenge contribution
       description: Delete a specific challenge contribution.
       operationId: deleteChallengeContribution
@@ -230,7 +230,7 @@ paths:
   /challenge-analytics/challenges-per-year:
     get:
       tags:
-        - ChallengeAnalytics
+        - Challenge Analytics
       summary: Get the number of challenges tracked per year
       description: Returns the number of challenges tracked per year
       operationId: getChallengesPerYear
@@ -248,7 +248,7 @@ paths:
   /challenge-platforms:
     get:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: List challenge platforms
       description: List challenge platforms
       operationId: listChallengePlatforms
@@ -269,7 +269,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Create a challenge platform
       description: Create a challenge platform with the specified ID
       operationId: createChallengePlatform
@@ -303,7 +303,7 @@ paths:
       - $ref: '#/components/parameters/challengePlatformId'
     get:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Get a challenge platform
       description: Returns the challenge platform identified by its unique ID
       operationId: getChallengePlatform
@@ -322,7 +322,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     put:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Update an existing challenge platform
       description: |
         Updates an existing challenge platform.
@@ -358,7 +358,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Delete a challenge platform
       description: |
         Deletes a challenge platform by its unique ID. This action is irreversible.
@@ -381,7 +381,7 @@ paths:
   /edam-concepts:
     get:
       tags:
-        - EdamConcept
+        - Edam Concept
       summary: List EDAM concepts
       description: List EDAM concepts
       operationId: listEdamConcepts
@@ -884,7 +884,7 @@ components:
               items:
                 $ref: '#/components/schemas/ChallengeContribution'
           required:
-            - challengeContributions
+            - Challenge Contributions
       x-java-class-annotations:
         - '@lombok.Builder'
     ChallengeContributionCreateRequest:
@@ -1001,7 +1001,7 @@ components:
               items:
                 $ref: '#/components/schemas/ChallengePlatform'
           required:
-            - challengePlatforms
+            - Challenge Platforms
       x-java-class-annotations:
         - '@lombok.Builder'
     ChallengePlatformCreateRequest:
@@ -1109,7 +1109,7 @@ components:
               items:
                 $ref: '#/components/schemas/EdamConcept'
           required:
-            - edamConcepts
+            - Edam Concept
       x-java-class-annotations:
         - '@lombok.Builder'
   parameters:

--- a/libs/openchallenges/api-description/openapi/challenge-service.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge-service.openapi.yaml
@@ -18,7 +18,7 @@ tags:
     description: Operations about challenges.
     x-audience:
       - public
-  - name: ChallengeContribution
+  - name: Challenge Contribution
     description: Operations about challenge contributions.
     x-audience:
       - public
@@ -128,7 +128,7 @@ paths:
       - $ref: '#/components/parameters/challengeId'
     get:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: List challenge contributions
       description: List challenge contributions
       operationId: listChallengeContributions
@@ -147,7 +147,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Create a new contribution for a challenge
       description: |
         Creates a new contribution record associated with a challenge ID.
@@ -181,7 +181,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Delete the contributions for a specific challenge
       description: Deletes the associated contributions for a given challenge, identified by its ID.
       operationId: deleteChallengeContributions
@@ -207,7 +207,7 @@ paths:
       - $ref: '#/components/parameters/challengeContributionRole'
     get:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Get a specific challenge contribution
       description: |
         Retrieves a specific contribution record for a challenge, identified by its ID.
@@ -229,7 +229,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Delete a specific challenge contribution
       description: Delete a specific challenge contribution.
       operationId: deleteChallengeContribution
@@ -251,7 +251,7 @@ paths:
   /challenge-analytics/challenges-per-year:
     get:
       tags:
-        - ChallengeAnalytics
+        - Challenge Analytics
       summary: Get the number of challenges tracked per year
       description: Returns the number of challenges tracked per year
       operationId: getChallengesPerYear
@@ -269,7 +269,7 @@ paths:
   /challenge-platforms:
     get:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: List challenge platforms
       description: List challenge platforms
       operationId: listChallengePlatforms
@@ -290,7 +290,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Create a challenge platform
       description: Create a challenge platform with the specified ID
       operationId: createChallengePlatform
@@ -324,7 +324,7 @@ paths:
       - $ref: '#/components/parameters/challengePlatformId'
     get:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Get a challenge platform
       description: Returns the challenge platform identified by its unique ID
       operationId: getChallengePlatform
@@ -343,7 +343,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     put:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Update an existing challenge platform
       description: |
         Updates an existing challenge platform.
@@ -379,7 +379,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Delete a challenge platform
       description: |
         Deletes a challenge platform by its unique ID. This action is irreversible.
@@ -402,7 +402,7 @@ paths:
   /edam-concepts:
     get:
       tags:
-        - EdamConcept
+        - Edam Concept
       summary: List EDAM concepts
       description: List EDAM concepts
       operationId: listEdamConcepts
@@ -905,7 +905,7 @@ components:
               items:
                 $ref: '#/components/schemas/ChallengeContribution'
           required:
-            - challengeContributions
+            - Challenge Contributions
       x-java-class-annotations:
         - '@lombok.Builder'
     ChallengeContributionCreateRequest:
@@ -1022,7 +1022,7 @@ components:
               items:
                 $ref: '#/components/schemas/ChallengePlatform'
           required:
-            - challengePlatforms
+            - Challenge Platforms
       x-java-class-annotations:
         - '@lombok.Builder'
     ChallengePlatformCreateRequest:
@@ -1130,7 +1130,7 @@ components:
               items:
                 $ref: '#/components/schemas/EdamConcept'
           required:
-            - edamConcepts
+            - Edam Concept
       x-java-class-annotations:
         - '@lombok.Builder'
   parameters:

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -29,11 +29,11 @@ tags:
     x-audience:
       - public
     x-displayName: Challenge
-  - name: ChallengeContribution
+  - name: Challenge Contribution
     description: Operations about challenge contributions.
     x-audience:
       - public
-    x-displayName: ChallengeContribution
+    x-displayName: Challenge Contribution
   - name: ChallengeAnalytics
     description: Operations about challenge analytics.
     x-audience:
@@ -49,6 +49,12 @@ tags:
     x-audience:
       - public
     x-displayName: EdamConcept
+  - name: Challenge Analytics
+    x-displayName: Challenge Analytics
+  - name: Challenge Platform
+    x-displayName: Challenge Platform
+  - name: Edam Concept
+    x-displayName: Edam Concept
   - name: Image
     description: Operations about images
     x-audience:
@@ -260,7 +266,7 @@ paths:
       - $ref: '#/components/parameters/challengeId'
     get:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: List challenge contributions
       description: List challenge contributions
       operationId: listChallengeContributions
@@ -279,7 +285,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Create a new contribution for a challenge
       description: |
         Creates a new contribution record associated with a challenge ID.
@@ -318,7 +324,7 @@ paths:
       - $ref: '#/components/parameters/challengeContributionRole'
     get:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Get a specific challenge contribution
       description: |
         Retrieves a specific contribution record for a challenge, identified by its ID.
@@ -340,7 +346,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
-        - ChallengeContribution
+        - Challenge Contribution
       summary: Delete a specific challenge contribution
       description: Delete a specific challenge contribution.
       operationId: deleteChallengeContribution
@@ -362,7 +368,7 @@ paths:
   /challenge-analytics/challenges-per-year:
     get:
       tags:
-        - ChallengeAnalytics
+        - Challenge Analytics
       summary: Get the number of challenges tracked per year
       description: Returns the number of challenges tracked per year
       operationId: getChallengesPerYear
@@ -380,7 +386,7 @@ paths:
   /challenge-platforms:
     get:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: List challenge platforms
       description: List challenge platforms
       operationId: listChallengePlatforms
@@ -401,7 +407,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     post:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Create a challenge platform
       description: Create a challenge platform with the specified ID
       operationId: createChallengePlatform
@@ -435,7 +441,7 @@ paths:
       - $ref: '#/components/parameters/challengePlatformId'
     get:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Get a challenge platform
       description: Returns the challenge platform identified by its unique ID
       operationId: getChallengePlatform
@@ -454,7 +460,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     put:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Update an existing challenge platform
       description: |
         Updates an existing challenge platform.
@@ -490,7 +496,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     delete:
       tags:
-        - ChallengePlatform
+        - Challenge Platform
       summary: Delete a challenge platform
       description: |
         Deletes a challenge platform by its unique ID. This action is irreversible.
@@ -513,7 +519,7 @@ paths:
   /edam-concepts:
     get:
       tags:
-        - EdamConcept
+        - Edam Concept
       summary: List EDAM concepts
       description: List EDAM concepts
       operationId: listEdamConcepts
@@ -1298,7 +1304,7 @@ components:
               items:
                 $ref: '#/components/schemas/ChallengeContribution'
           required:
-            - challengeContributions
+            - Challenge Contributions
       x-java-class-annotations:
         - '@lombok.Builder'
     ChallengeContributionCreateRequest:
@@ -1415,7 +1421,7 @@ components:
               items:
                 $ref: '#/components/schemas/ChallengePlatform'
           required:
-            - challengePlatforms
+            - Challenge Platforms
       x-java-class-annotations:
         - '@lombok.Builder'
     ChallengePlatformCreateRequest:
@@ -1523,7 +1529,7 @@ components:
               items:
                 $ref: '#/components/schemas/EdamConcept'
           required:
-            - edamConcepts
+            - Edam Concept
       x-java-class-annotations:
         - '@lombok.Builder'
     ImageKey:
@@ -1900,10 +1906,13 @@ x-tagGroups:
   - name: OpenChallenges Challenge API
     tags:
       - Challenge
-      - ChallengeContribution
+      - Challenge Contribution
       - ChallengeAnalytics
       - ChallengePlatform
       - EdamConcept
+      - Challenge Analytics
+      - Challenge Platform
+      - Edam Concept
   - name: OpenChallenges Image API
     tags:
       - Image

--- a/libs/openchallenges/api-description/src/challenge.openapi.yaml
+++ b/libs/openchallenges/api-description/src/challenge.openapi.yaml
@@ -17,7 +17,7 @@ tags:
   - name: Challenge
     description: Operations about challenges.
     x-audience: [public]
-  - name: ChallengeContribution
+  - name: Challenge Contribution
     description: Operations about challenge contributions.
     x-audience: [public]
   - name: ChallengeAnalytics

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeContributionsPage.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeContributionsPage.yaml
@@ -10,6 +10,6 @@ allOf:
         items:
           $ref: ChallengeContribution.yaml
     required:
-      - challengeContributions
+      - Challenge Contributions
 x-java-class-annotations:
   - '@lombok.Builder'

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformsPage.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengePlatformsPage.yaml
@@ -10,6 +10,6 @@ allOf:
         items:
           $ref: ChallengePlatform.yaml
     required:
-      - challengePlatforms
+      - Challenge Platforms
 x-java-class-annotations:
   - '@lombok.Builder'

--- a/libs/openchallenges/api-description/src/components/schemas/EdamConceptsPage.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/EdamConceptsPage.yaml
@@ -10,6 +10,6 @@ allOf:
         items:
           $ref: EdamConcept.yaml
     required:
-      - edamConcepts
+      - Edam Concept
 x-java-class-annotations:
   - '@lombok.Builder'

--- a/libs/openchallenges/api-description/src/paths/challenge-analytics/challenges-per-year.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenge-analytics/challenges-per-year.yaml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - ChallengeAnalytics
+    - Challenge Analytics
   summary: Get the number of challenges tracked per year
   description: Returns the number of challenges tracked per year
   operationId: getChallengesPerYear

--- a/libs/openchallenges/api-description/src/paths/challenge-platforms.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenge-platforms.yaml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - ChallengePlatform
+    - Challenge Platform
   summary: List challenge platforms
   description: List challenge platforms
   operationId: listChallengePlatforms
@@ -20,7 +20,7 @@ get:
       $ref: ../components/responses/InternalServerError.yaml
 post:
   tags:
-    - ChallengePlatform
+    - Challenge Platform
   summary: Create a challenge platform
   description: Create a challenge platform with the specified ID
   operationId: createChallengePlatform

--- a/libs/openchallenges/api-description/src/paths/challenge-platforms/@{challengePlatformId}.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenge-platforms/@{challengePlatformId}.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/path/challengePlatformId.yaml
 get:
   tags:
-    - ChallengePlatform
+    - Challenge Platform
   summary: Get a challenge platform
   description: Returns the challenge platform identified by its unique ID
   operationId: getChallengePlatform
@@ -20,7 +20,7 @@ get:
       $ref: ../../components/responses/InternalServerError.yaml
 put:
   tags:
-    - ChallengePlatform
+    - Challenge Platform
   summary: Update an existing challenge platform
   description: |
     Updates an existing challenge platform.
@@ -55,7 +55,7 @@ put:
       $ref: ../../components/responses/InternalServerError.yaml
 delete:
   tags:
-    - ChallengePlatform
+    - Challenge Platform
   summary: Delete a challenge platform
   description: |
     Deletes a challenge platform by its unique ID. This action is irreversible.

--- a/libs/openchallenges/api-description/src/paths/challenge-platforms/@{challengePlatformName}.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenge-platforms/@{challengePlatformName}.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../components/parameters/path/challengePlatformName.yaml
 get:
   tags:
-    - ChallengePlatform
+    - Challenge Platform
   summary: Get a challenge platform
   description: Returns the challenge platform specified by its unique name
   operationId: getChallengePlatformByName
@@ -19,7 +19,7 @@ get:
       $ref: ../../components/responses/InternalServerError.yaml
 delete:
   tags:
-    - ChallengePlatform
+    - Challenge Platform
   summary: Delete a challenge platform
   description: |
     Deletes a challenge platform identified by its unique name. This action is irreversible.

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions.yaml
@@ -2,7 +2,7 @@ parameters:
   - $ref: ../../../components/parameters/path/challengeId.yaml
 get:
   tags:
-    - ChallengeContribution
+    - Challenge Contribution
   summary: List challenge contributions
   description: List challenge contributions
   operationId: listChallengeContributions
@@ -20,7 +20,7 @@ get:
       $ref: ../../../components/responses/InternalServerError.yaml
 post:
   tags:
-    - ChallengeContribution
+    - Challenge Contribution
   summary: Create a new contribution for a challenge
   description: |
     Creates a new contribution record associated with a challenge ID.
@@ -53,7 +53,7 @@ post:
       $ref: ../../../components/responses/InternalServerError.yaml
 delete:
   tags:
-    - ChallengeContribution
+    - Challenge Contribution
   summary: Delete the contributions for a specific challenge
   description: Deletes the associated contributions for a given challenge, identified by its ID.
   operationId: deleteChallengeContributions

--- a/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions/@{organizationId}/role/${role}.yaml
+++ b/libs/openchallenges/api-description/src/paths/challenges/@{challengeId}/contributions/@{organizationId}/role/${role}.yaml
@@ -4,7 +4,7 @@ parameters:
   - $ref: ../../../../../../components/parameters/path/challengeContributionRole.yaml
 get:
   tags:
-    - ChallengeContribution
+    - Challenge Contribution
   summary: Get a specific challenge contribution
   description: |
     Retrieves a specific contribution record for a challenge, identified by its ID.
@@ -25,7 +25,7 @@ get:
       $ref: ../../../../../../components/responses/InternalServerError.yaml
 delete:
   tags:
-    - ChallengeContribution
+    - Challenge Contribution
   summary: Delete a specific challenge contribution
   description: Delete a specific challenge contribution.
   operationId: deleteChallengeContribution

--- a/libs/openchallenges/api-description/src/paths/edam-concepts.yaml
+++ b/libs/openchallenges/api-description/src/paths/edam-concepts.yaml
@@ -1,6 +1,6 @@
 get:
   tags:
-    - EdamConcept
+    - Edam Concept
   summary: List EDAM concepts
   description: List EDAM concepts
   operationId: listEdamConcepts


### PR DESCRIPTION
## Description

Separate the words of OpenAPI tags with spaces instead of using pascal case.

## Related Issue

- [SMR-324](https://sagebionetworks.jira.com/browse/SMR-324)

## Changelog

- Separate the words of OpenAPI tags with spaces instead of using pascal case.
- Generate all the API clients and server stubs.
