### PR TITLE
fix: run `*-api-description:clean` tasks from project folder (SMR-333)

### DIFF
--- a/libs/amp-als/api-description/project.json
+++ b/libs/amp-als/api-description/project.json
@@ -38,7 +38,8 @@
     "clean": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "rm -fr openapi/*"
+        "command": "rm -fr openapi/*",
+        "cwd": "{projectRoot}"
       }
     }
   },

--- a/libs/openchallenges/api-description/project.json
+++ b/libs/openchallenges/api-description/project.json
@@ -19,8 +19,7 @@
         ],
         "parallel": true,
         "cwd": "{projectRoot}"
-      },
-      "dependsOn": ["clean"]
+      }
     },
     "build": {
       "executor": "nx:run-commands",
@@ -44,7 +43,8 @@
     "clean": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "rm -fr openapi/*"
+        "command": "rm -fr openapi/*",
+        "cwd": "{projectRoot}"
       }
     }
   },


### PR DESCRIPTION
## Description

Run `*-api-description:clean` tasks from project folder.

## Related Issue

- [SMR-333](https://sagebionetworks.jira.com/browse/SMR-333)

## Changelog

- Run `*-api-description:clean` tasks from project folder.

