### PR TITLE
chore(openchallenges): remove dev OC MCP server from `mcp.json`

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -12,10 +12,6 @@
       "type": "sse",
       "url": "http://localhost:8000/mcp-server/sse"
     },
-    "openchallenges-mcp-server-dev": {
-      "type": "sse",
-      "url": "http://localhost:8887/mcp-server/sse"
-    },
     "nx-mcp": {
       "type": "http",
       "url": "http://localhost:9329/mcp"


### PR DESCRIPTION
## Description

Remove dev OC MCP server from `mcp.json` because of the limit of 128 MCP tools that Copilot can consume.

## Changelog

- Remove dev OC MCP server from `mcp.json`.
