### PR TITLE
refactor(openchallenges): migrate incentives data to challenge.incentives (SMR-345)

### DIFF
--- a/apps/openchallenges/challenge-service/build.gradle.kts
+++ b/apps/openchallenges/challenge-service/build.gradle.kts
@@ -1,6 +1,7 @@
 buildscript {
   dependencies {
     classpath(libs.flyway.database.postgresql)
+    classpath(libs.postgresql)
   }
 }
 

--- a/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.9__refactor_incentives_to_array.sql
+++ b/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.9__refactor_incentives_to_array.sql
@@ -1,0 +1,30 @@
+-- Migration to refactor challenge incentives from separate table to array column
+-- This migration consolidates incentives into the challenge table as an array
+
+-- Step 1: Add incentives array column to challenge table
+ALTER TABLE challenge ADD COLUMN incentives VARCHAR(50)[] DEFAULT NULL;
+
+-- Step 2: Migrate existing incentive data from challenge_incentive table to array column
+UPDATE challenge
+SET incentives = (
+  SELECT ARRAY_AGG(ci.name ORDER BY ci.name)
+  FROM challenge_incentive ci
+  WHERE ci.challenge_id = challenge.id
+)
+WHERE EXISTS (
+  SELECT 1 FROM challenge_incentive ci WHERE ci.challenge_id = challenge.id
+);
+
+-- Step 3: Add check constraints to ensure valid incentive values and no duplicates
+ALTER TABLE challenge ADD CONSTRAINT challenge_incentives_values_check
+  CHECK (
+    incentives <@ ARRAY['monetary', 'publication', 'speaking_engagement', 'other']::VARCHAR(50)[]
+  );
+
+-- Ensure no duplicate values in the incentives array (acts as a set)
+-- Note: PostgreSQL doesn't allow subqueries in check constraints, so we'll enforce this at the application level
+-- or create a custom function if needed. For now, we rely on the unique constraint from the original table
+-- and careful application logic to prevent duplicates.
+
+-- Step 4: Drop the challenge_incentive table since data is now in the array column
+DROP TABLE challenge_incentive;

--- a/apps/openchallenges/challenge-service/src/main/resources/db/rollback/V1.0.9__refactor_incentives_to_array_rollback.sql
+++ b/apps/openchallenges/challenge-service/src/main/resources/db/rollback/V1.0.9__refactor_incentives_to_array_rollback.sql
@@ -1,0 +1,27 @@
+-- Rollback script for V1.0.9__refactor_incentives_to_array.sql
+-- This script reverts the incentives array back to a separate table structure
+
+-- Step 1: Recreate the challenge_incentive table
+CREATE TABLE challenge_incentive (
+  id BIGSERIAL PRIMARY KEY,
+  name VARCHAR(50) NOT NULL CHECK (
+    name IN ('monetary', 'publication', 'speaking_engagement', 'other')
+  ),
+  challenge_id BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_challenge_inc FOREIGN KEY (challenge_id) REFERENCES challenge(id),
+  CONSTRAINT unique_incentive UNIQUE (name, challenge_id)
+);
+
+-- Step 2: Migrate data from array column back to separate table
+INSERT INTO challenge_incentive (name, challenge_id, created_at)
+SELECT 
+  unnest(incentives) as name,
+  id as challenge_id,
+  created_at
+FROM challenge 
+WHERE incentives IS NOT NULL AND array_length(incentives, 1) > 0;
+
+-- Step 3: Remove the incentives array column from challenge table
+ALTER TABLE challenge DROP CONSTRAINT IF EXISTS challenge_incentives_check;
+ALTER TABLE challenge DROP COLUMN incentives;


### PR DESCRIPTION
## Description

Migrate the incentives data to the new `challenge.incentives` column in the OpenChallenges PostgreSQL database to streamline the business logic in the Challenge API controller.

## Design

TODO

## Related Issue

- [SMR-345](https://sagebionetworks.jira.com/browse/SMR-345)

## Changelog

- Add Flyway migration step that create the table column `challenge.incentives`, populate it with values from the table `challenge_incentive` before dropping it.

TODO:

- Drop the table `challenge_incentive` again.

## Preview

### Start the OC database

```bash
nx run-many -p openchallenges-postgres -t build-image,serve-detach --parallel 1
```

### Apply the DB migration using Flyway

```bash
cd apps/openchallenges/challenge-service
./gradlew flywayClean --no-configuration-cache
./gradlew flywayMigrate --no-configuration-cache
```

### Show selected known challenges that have incentives

```bash
docker exec -it openchallenges-postgres psql -U challenge_service -d challenge_service -c "SELECT id, name, incentives FROM challenge WHERE id IN (1, 2, 3, 5, 6, 7) ORDER BY id;"
```

Output:

```console
 id |                   name                    |            incentives             
----+-------------------------------------------+-----------------------------------
  1 | Network Topology and Parameter Inference  | {publication}
  2 | Breast Cancer Prognosis                   | {publication,speaking_engagement}
  3 | Phil Bowen ALS Prediction Prize4Life      | {monetary}
  5 | NIEHS-NCATS-UNC Toxicogenetics            | {publication,speaking_engagement}
  6 | Whole-Cell Parameter Estimation           | {publication,speaking_engagement}
  7 | HPN-DREAM Breast Cancer Network Inference | {monetary,publication}
(6 rows)
```

### Statistics

```bash
docker exec -it openchallenges-postgres psql -U challenge_service -d challenge_service -c "
SELECT 
  'Total challenges' as metric, COUNT(*) as count FROM challenge
UNION ALL
SELECT 
  'Challenges with incentives', COUNT(*) FROM challenge WHERE incentives IS NOT NULL
UNION ALL  
SELECT
  'Challenges with empty arrays', COUNT(*) FROM challenge WHERE incentives = '{}'
UNION ALL
SELECT
  'Challenges with NULL incentives', COUNT(*) FROM challenge WHERE incentives IS NULL;"
```

Output:

```console
             metric              | count 
---------------------------------+-------
 Total challenges                |   679
 Challenges with incentives      |   511
 Challenges with empty arrays    |     0
 Challenges with NULL incentives |   168
(4 rows)
```

[SMR-345]: https://sagebionetworks.jira.com/browse/SMR-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ