### PR TITLE
feat(openchallenges): enable the user to update the challenge input data types and operation (SMR-371)

### DIFF
--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeUpdateRequestDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeUpdateRequestDto.java
@@ -62,6 +62,8 @@ public class ChallengeUpdateRequestDto {
   @Valid
   private List<Long> inputDataTypes = new ArrayList<>();
 
+  private Long operation;
+
   public ChallengeUpdateRequestDto() {
     super();
   }
@@ -69,7 +71,7 @@ public class ChallengeUpdateRequestDto {
   /**
    * Constructor with only required parameters
    */
-  public ChallengeUpdateRequestDto(String slug, String name, String headline, String description, String doi, ChallengeStatusDto status, Long platformId, String websiteUrl, String avatarUrl, List<ChallengeIncentiveDto> incentives, List<ChallengeSubmissionTypeDto> submissionTypes, List<ChallengeCategoryDto> categories, List<Long> inputDataTypes) {
+  public ChallengeUpdateRequestDto(String slug, String name, String headline, String description, String doi, ChallengeStatusDto status, Long platformId, String websiteUrl, String avatarUrl, List<ChallengeIncentiveDto> incentives, List<ChallengeSubmissionTypeDto> submissionTypes, List<ChallengeCategoryDto> categories, List<Long> inputDataTypes, Long operation) {
     this.slug = slug;
     this.name = name;
     this.headline = headline;
@@ -83,6 +85,7 @@ public class ChallengeUpdateRequestDto {
     this.submissionTypes = submissionTypes;
     this.categories = categories;
     this.inputDataTypes = inputDataTypes;
+    this.operation = operation;
   }
 
   public ChallengeUpdateRequestDto slug(String slug) {
@@ -377,6 +380,26 @@ public class ChallengeUpdateRequestDto {
     this.inputDataTypes = inputDataTypes;
   }
 
+  public ChallengeUpdateRequestDto operation(Long operation) {
+    this.operation = operation;
+    return this;
+  }
+
+  /**
+   * The unique identifier of the EDAM concept.
+   * @return operation
+   */
+  @NotNull 
+  @Schema(name = "operation", example = "1", description = "The unique identifier of the EDAM concept.", requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonProperty("operation")
+  public Long getOperation() {
+    return operation;
+  }
+
+  public void setOperation(Long operation) {
+    this.operation = operation;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -398,12 +421,13 @@ public class ChallengeUpdateRequestDto {
         Objects.equals(this.incentives, challengeUpdateRequest.incentives) &&
         Objects.equals(this.submissionTypes, challengeUpdateRequest.submissionTypes) &&
         Objects.equals(this.categories, challengeUpdateRequest.categories) &&
-        Objects.equals(this.inputDataTypes, challengeUpdateRequest.inputDataTypes);
+        Objects.equals(this.inputDataTypes, challengeUpdateRequest.inputDataTypes) &&
+        Objects.equals(this.operation, challengeUpdateRequest.operation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(slug, name, headline, description, doi, status, platformId, websiteUrl, avatarUrl, incentives, submissionTypes, categories, inputDataTypes);
+    return Objects.hash(slug, name, headline, description, doi, status, platformId, websiteUrl, avatarUrl, incentives, submissionTypes, categories, inputDataTypes, operation);
   }
 
   @Override
@@ -423,6 +447,7 @@ public class ChallengeUpdateRequestDto {
     sb.append("    submissionTypes: ").append(toIndentedString(submissionTypes)).append("\n");
     sb.append("    categories: ").append(toIndentedString(categories)).append("\n");
     sb.append("    inputDataTypes: ").append(toIndentedString(inputDataTypes)).append("\n");
+    sb.append("    operation: ").append(toIndentedString(operation)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -464,6 +489,7 @@ public class ChallengeUpdateRequestDto {
       this.instance.setSubmissionTypes(value.submissionTypes);
       this.instance.setCategories(value.categories);
       this.instance.setInputDataTypes(value.inputDataTypes);
+      this.instance.setOperation(value.operation);
       return this;
     }
 
@@ -529,6 +555,11 @@ public class ChallengeUpdateRequestDto {
     
     public ChallengeUpdateRequestDto.Builder inputDataTypes(List<Long> inputDataTypes) {
       this.instance.inputDataTypes(inputDataTypes);
+      return this;
+    }
+    
+    public ChallengeUpdateRequestDto.Builder operation(Long operation) {
+      this.instance.operation(operation);
       return this;
     }
     

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeUpdateRequestDto.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/dto/ChallengeUpdateRequestDto.java
@@ -59,6 +59,9 @@ public class ChallengeUpdateRequestDto {
   @Valid
   private List<ChallengeCategoryDto> categories = new ArrayList<>();
 
+  @Valid
+  private List<Long> inputDataTypes = new ArrayList<>();
+
   public ChallengeUpdateRequestDto() {
     super();
   }
@@ -66,7 +69,7 @@ public class ChallengeUpdateRequestDto {
   /**
    * Constructor with only required parameters
    */
-  public ChallengeUpdateRequestDto(String slug, String name, String headline, String description, String doi, ChallengeStatusDto status, Long platformId, String websiteUrl, String avatarUrl, List<ChallengeIncentiveDto> incentives, List<ChallengeSubmissionTypeDto> submissionTypes, List<ChallengeCategoryDto> categories) {
+  public ChallengeUpdateRequestDto(String slug, String name, String headline, String description, String doi, ChallengeStatusDto status, Long platformId, String websiteUrl, String avatarUrl, List<ChallengeIncentiveDto> incentives, List<ChallengeSubmissionTypeDto> submissionTypes, List<ChallengeCategoryDto> categories, List<Long> inputDataTypes) {
     this.slug = slug;
     this.name = name;
     this.headline = headline;
@@ -79,6 +82,7 @@ public class ChallengeUpdateRequestDto {
     this.incentives = incentives;
     this.submissionTypes = submissionTypes;
     this.categories = categories;
+    this.inputDataTypes = inputDataTypes;
   }
 
   public ChallengeUpdateRequestDto slug(String slug) {
@@ -345,6 +349,34 @@ public class ChallengeUpdateRequestDto {
     this.categories = categories;
   }
 
+  public ChallengeUpdateRequestDto inputDataTypes(List<Long> inputDataTypes) {
+    this.inputDataTypes = inputDataTypes;
+    return this;
+  }
+
+  public ChallengeUpdateRequestDto addInputDataTypesItem(Long inputDataTypesItem) {
+    if (this.inputDataTypes == null) {
+      this.inputDataTypes = new ArrayList<>();
+    }
+    this.inputDataTypes.add(inputDataTypesItem);
+    return this;
+  }
+
+  /**
+   * Get inputDataTypes
+   * @return inputDataTypes
+   */
+  @NotNull 
+  @Schema(name = "inputDataTypes", requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonProperty("inputDataTypes")
+  public List<Long> getInputDataTypes() {
+    return inputDataTypes;
+  }
+
+  public void setInputDataTypes(List<Long> inputDataTypes) {
+    this.inputDataTypes = inputDataTypes;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -365,12 +397,13 @@ public class ChallengeUpdateRequestDto {
         Objects.equals(this.avatarUrl, challengeUpdateRequest.avatarUrl) &&
         Objects.equals(this.incentives, challengeUpdateRequest.incentives) &&
         Objects.equals(this.submissionTypes, challengeUpdateRequest.submissionTypes) &&
-        Objects.equals(this.categories, challengeUpdateRequest.categories);
+        Objects.equals(this.categories, challengeUpdateRequest.categories) &&
+        Objects.equals(this.inputDataTypes, challengeUpdateRequest.inputDataTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(slug, name, headline, description, doi, status, platformId, websiteUrl, avatarUrl, incentives, submissionTypes, categories);
+    return Objects.hash(slug, name, headline, description, doi, status, platformId, websiteUrl, avatarUrl, incentives, submissionTypes, categories, inputDataTypes);
   }
 
   @Override
@@ -389,6 +422,7 @@ public class ChallengeUpdateRequestDto {
     sb.append("    incentives: ").append(toIndentedString(incentives)).append("\n");
     sb.append("    submissionTypes: ").append(toIndentedString(submissionTypes)).append("\n");
     sb.append("    categories: ").append(toIndentedString(categories)).append("\n");
+    sb.append("    inputDataTypes: ").append(toIndentedString(inputDataTypes)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -429,6 +463,7 @@ public class ChallengeUpdateRequestDto {
       this.instance.setIncentives(value.incentives);
       this.instance.setSubmissionTypes(value.submissionTypes);
       this.instance.setCategories(value.categories);
+      this.instance.setInputDataTypes(value.inputDataTypes);
       return this;
     }
 
@@ -489,6 +524,11 @@ public class ChallengeUpdateRequestDto {
     
     public ChallengeUpdateRequestDto.Builder categories(List<ChallengeCategoryDto> categories) {
       this.instance.categories(categories);
+      return this;
+    }
+    
+    public ChallengeUpdateRequestDto.Builder inputDataTypes(List<Long> inputDataTypes) {
+      this.instance.inputDataTypes(inputDataTypes);
       return this;
     }
     

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeService.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/service/ChallengeService.java
@@ -253,6 +253,7 @@ public class ChallengeService {
     // Update the challenge components
     updateBasicFields(existingChallenge, request);
     updatePlatform(existingChallenge, request.getPlatformId());
+    updateOperation(existingChallenge, request.getOperation());
     updateIncentives(existingChallenge, request.getIncentives());
     updateSubmissionTypes(existingChallenge, request.getSubmissionTypes());
     updateCategories(existingChallenge, request.getCategories());
@@ -289,6 +290,30 @@ public class ChallengeService {
     } else {
       // If platformId is null, remove the platform association
       challenge.setPlatform(null);
+    }
+  }
+
+  private void updateOperation(ChallengeEntity challenge, Long operationId) {
+    if (operationId != null) {
+      // Check if the operation is already set to the same value
+      if (
+        challenge.getOperation() != null && challenge.getOperation().getId().equals(operationId)
+      ) {
+        // Operation is already set to the requested value, no changes needed
+        return;
+      }
+
+      // Find the EDAM concept for the operation
+      EdamConceptEntity operation = edamConceptRepository
+        .findById(operationId)
+        .orElseThrow(() ->
+          new RuntimeException(String.format("EDAM concept with ID %d not found", operationId))
+        );
+
+      challenge.setOperation(operation);
+    } else {
+      // If operationId is null, remove the operation association
+      challenge.setOperation(null);
     }
   }
 

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -1833,6 +1833,10 @@ components:
           items:
             $ref: '#/components/schemas/ChallengeCategory'
           type: array
+        inputDataTypes:
+          items:
+            $ref: '#/components/schemas/EdamConceptId'
+          type: array
       required:
         - avatarUrl
         - categories
@@ -1840,6 +1844,7 @@ components:
         - doi
         - headline
         - incentives
+        - inputDataTypes
         - name
         - platformId
         - slug

--- a/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
+++ b/apps/openchallenges/challenge-service/src/main/resources/openapi.yaml
@@ -1837,6 +1837,11 @@ components:
           items:
             $ref: '#/components/schemas/EdamConceptId'
           type: array
+        operation:
+          description: The unique identifier of the EDAM concept.
+          example: 1
+          format: int64
+          type: integer
       required:
         - avatarUrl
         - categories
@@ -1846,6 +1851,7 @@ components:
         - incentives
         - inputDataTypes
         - name
+        - operation
         - platformId
         - slug
         - status

--- a/libs/openchallenges/api-client-angular/src/lib/model/challengeUpdateRequest.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/challengeUpdateRequest.ts
@@ -52,5 +52,6 @@ export interface ChallengeUpdateRequest {
   incentives: Array<ChallengeIncentive>;
   submissionTypes: Array<ChallengeSubmissionType>;
   categories: Array<ChallengeCategory>;
+  inputDataTypes: Array<number>;
 }
 export namespace ChallengeUpdateRequest {}

--- a/libs/openchallenges/api-client-angular/src/lib/model/challengeUpdateRequest.ts
+++ b/libs/openchallenges/api-client-angular/src/lib/model/challengeUpdateRequest.ts
@@ -53,5 +53,9 @@ export interface ChallengeUpdateRequest {
   submissionTypes: Array<ChallengeSubmissionType>;
   categories: Array<ChallengeCategory>;
   inputDataTypes: Array<number>;
+  /**
+   * The unique identifier of the EDAM concept.
+   */
+  operation: number;
 }
 export namespace ChallengeUpdateRequest {}

--- a/libs/openchallenges/api-client-python/docs/ChallengeUpdateRequest.md
+++ b/libs/openchallenges/api-client-python/docs/ChallengeUpdateRequest.md
@@ -18,6 +18,7 @@ The information required to update a challenge
 | **incentives**       | [**List[ChallengeIncentive]**](ChallengeIncentive.md)           |                                                |
 | **submission_types** | [**List[ChallengeSubmissionType]**](ChallengeSubmissionType.md) |                                                |
 | **categories**       | [**List[ChallengeCategory]**](ChallengeCategory.md)             |                                                |
+| **input_data_types** | **List[int]**                                                   |                                                |
 
 ## Example
 

--- a/libs/openchallenges/api-client-python/docs/ChallengeUpdateRequest.md
+++ b/libs/openchallenges/api-client-python/docs/ChallengeUpdateRequest.md
@@ -19,6 +19,7 @@ The information required to update a challenge
 | **submission_types** | [**List[ChallengeSubmissionType]**](ChallengeSubmissionType.md) |                                                |
 | **categories**       | [**List[ChallengeCategory]**](ChallengeCategory.md)             |                                                |
 | **input_data_types** | **List[int]**                                                   |                                                |
+| **operation**        | **int**                                                         | The unique identifier of the EDAM concept.     |
 
 ## Example
 

--- a/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_update_request.py
+++ b/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_update_request.py
@@ -65,6 +65,9 @@ class ChallengeUpdateRequest(BaseModel):
     submission_types: List[ChallengeSubmissionType] = Field(alias="submissionTypes")
     categories: List[ChallengeCategory]
     input_data_types: List[StrictInt] = Field(alias="inputDataTypes")
+    operation: StrictInt = Field(
+        description="The unique identifier of the EDAM concept."
+    )
     __properties: ClassVar[List[str]] = [
         "slug",
         "name",
@@ -79,6 +82,7 @@ class ChallengeUpdateRequest(BaseModel):
         "submissionTypes",
         "categories",
         "inputDataTypes",
+        "operation",
     ]
 
     @field_validator("slug")
@@ -173,6 +177,7 @@ class ChallengeUpdateRequest(BaseModel):
                 "submissionTypes": obj.get("submissionTypes"),
                 "categories": obj.get("categories"),
                 "inputDataTypes": obj.get("inputDataTypes"),
+                "operation": obj.get("operation"),
             }
         )
         return _obj

--- a/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_update_request.py
+++ b/libs/openchallenges/api-client-python/openchallenges_api_client_python/models/challenge_update_request.py
@@ -64,6 +64,7 @@ class ChallengeUpdateRequest(BaseModel):
     incentives: List[ChallengeIncentive]
     submission_types: List[ChallengeSubmissionType] = Field(alias="submissionTypes")
     categories: List[ChallengeCategory]
+    input_data_types: List[StrictInt] = Field(alias="inputDataTypes")
     __properties: ClassVar[List[str]] = [
         "slug",
         "name",
@@ -77,6 +78,7 @@ class ChallengeUpdateRequest(BaseModel):
         "incentives",
         "submissionTypes",
         "categories",
+        "inputDataTypes",
     ]
 
     @field_validator("slug")
@@ -170,6 +172,7 @@ class ChallengeUpdateRequest(BaseModel):
                 "incentives": obj.get("incentives"),
                 "submissionTypes": obj.get("submissionTypes"),
                 "categories": obj.get("categories"),
+                "inputDataTypes": obj.get("inputDataTypes"),
             }
         )
         return _obj

--- a/libs/openchallenges/api-client-python/test/test_challenge_update_request.py
+++ b/libs/openchallenges/api-client-python/test/test_challenge_update_request.py
@@ -57,7 +57,8 @@ class TestChallengeUpdateRequest(unittest.TestCase):
                     ],
                 input_data_types = [
                     1
-                    ]
+                    ],
+                operation = 1
             )
         else:
             return ChallengeUpdateRequest(
@@ -82,6 +83,7 @@ class TestChallengeUpdateRequest(unittest.TestCase):
                 input_data_types = [
                     1
                     ],
+                operation = 1,
         )
         """
 

--- a/libs/openchallenges/api-client-python/test/test_challenge_update_request.py
+++ b/libs/openchallenges/api-client-python/test/test_challenge_update_request.py
@@ -54,6 +54,9 @@ class TestChallengeUpdateRequest(unittest.TestCase):
                     ],
                 categories = [
                     'featured'
+                    ],
+                input_data_types = [
+                    1
                     ]
             )
         else:
@@ -75,6 +78,9 @@ class TestChallengeUpdateRequest(unittest.TestCase):
                     ],
                 categories = [
                     'featured'
+                    ],
+                input_data_types = [
+                    1
                     ],
         )
         """

--- a/libs/openchallenges/api-description/openapi/challenge-public.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge-public.openapi.yaml
@@ -950,6 +950,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ChallengeCategory'
+        inputDataTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdamConceptId'
       required:
         - slug
         - name
@@ -963,6 +967,7 @@ components:
         - incentives
         - submissionTypes
         - categories
+        - inputDataTypes
     ChallengeJsonLd:
       type: object
       description: A challenge

--- a/libs/openchallenges/api-description/openapi/challenge-public.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge-public.openapi.yaml
@@ -954,6 +954,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EdamConceptId'
+        operation:
+          $ref: '#/components/schemas/EdamConceptId'
       required:
         - slug
         - name
@@ -968,6 +970,7 @@ components:
         - submissionTypes
         - categories
         - inputDataTypes
+        - operation
     ChallengeJsonLd:
       type: object
       description: A challenge

--- a/libs/openchallenges/api-description/openapi/challenge-service.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge-service.openapi.yaml
@@ -971,6 +971,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ChallengeCategory'
+        inputDataTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdamConceptId'
       required:
         - slug
         - name
@@ -984,6 +988,7 @@ components:
         - incentives
         - submissionTypes
         - categories
+        - inputDataTypes
     ChallengeJsonLd:
       type: object
       description: A challenge

--- a/libs/openchallenges/api-description/openapi/challenge-service.openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/challenge-service.openapi.yaml
@@ -975,6 +975,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EdamConceptId'
+        operation:
+          $ref: '#/components/schemas/EdamConceptId'
       required:
         - slug
         - name
@@ -989,6 +991,7 @@ components:
         - submissionTypes
         - categories
         - inputDataTypes
+        - operation
     ChallengeJsonLd:
       type: object
       description: A challenge

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -1370,6 +1370,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EdamConceptId'
+        operation:
+          $ref: '#/components/schemas/EdamConceptId'
       required:
         - slug
         - name
@@ -1384,6 +1386,7 @@ components:
         - submissionTypes
         - categories
         - inputDataTypes
+        - operation
     ChallengeJsonLd:
       type: object
       description: A challenge

--- a/libs/openchallenges/api-description/openapi/openapi.yaml
+++ b/libs/openchallenges/api-description/openapi/openapi.yaml
@@ -1366,6 +1366,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ChallengeCategory'
+        inputDataTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdamConceptId'
       required:
         - slug
         - name
@@ -1379,6 +1383,7 @@ components:
         - incentives
         - submissionTypes
         - categories
+        - inputDataTypes
     ChallengeJsonLd:
       type: object
       description: A challenge

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeUpdateRequest.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeUpdateRequest.yaml
@@ -35,6 +35,8 @@ properties:
     type: array
     items:
       $ref: EdamConceptId.yaml
+  operation:
+    $ref: EdamConceptId.yaml
 required:
   - slug
   - name
@@ -49,3 +51,4 @@ required:
   - submissionTypes
   - categories
   - inputDataTypes
+  - operation

--- a/libs/openchallenges/api-description/src/components/schemas/ChallengeUpdateRequest.yaml
+++ b/libs/openchallenges/api-description/src/components/schemas/ChallengeUpdateRequest.yaml
@@ -31,6 +31,10 @@ properties:
     type: array
     items:
       $ref: ChallengeCategory.yaml
+  inputDataTypes:
+    type: array
+    items:
+      $ref: EdamConceptId.yaml
 required:
   - slug
   - name
@@ -44,3 +48,4 @@ required:
   - incentives
   - submissionTypes
   - categories
+  - inputDataTypes


### PR DESCRIPTION
## Description

Enable the user to update the challenge input data types and operation.

## Related Issue

- [SMR-371](https://sagebionetworks.jira.com/browse/SMR-371)

## Changelog

- Enable the user to update the challenge input data types and operation.
- Update the API clients and server stubs.


[SMR-371]: https://sagebionetworks.jira.com/browse/SMR-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ