### PR TITLE
fix(sage-monorepo): update `scan-images` GitHub workflow (SMR-382)

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
 
       # Deliberately chosen master here to keep up-to-date.
       - name: Run Trivy vulnerability scanner for any major issues
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: ghcr.io/sage-bionetworks/${{ matrix.image }}:edge
           ignore-unfixed: true
@@ -53,7 +53,7 @@ jobs:
       # Show all detected issues.
       # Note this will show a lot more, including major un-fixed ones.
       - name: Run Trivy vulnerability scanner for local output
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.32.0
         with:
           image-ref: ghcr.io/sage-bionetworks/${{ matrix.image }}:edge
           format: table


### PR DESCRIPTION
## Description

Update `scan-images` GitHub workflow.

## Related Issue

- [SMR-382](https://sagebionetworks.jira.com/browse/SMR-382)

## Changelog

- Update the actions used by the `scan-images` workflow.

