### PR TITLE
chore(sage-monorepo): remove Nx MCP server from mcp.json

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -11,10 +11,6 @@
     "openchallenges-mcp-server": {
       "type": "sse",
       "url": "http://localhost:8000/mcp-server/sse"
-    },
-    "nx-mcp": {
-      "type": "http",
-      "url": "http://localhost:9329/mcp"
     }
   }
 }


### PR DESCRIPTION
## Description

Remove Nx MCP server from mcp.json following Nx Console extension for VS Code.

## Changelog

- Remove Nx MCP server from mcp.json following Nx Console extension for VS Code.

## Preview

<img width="835" height="243" alt="image" src="https://github.com/user-attachments/assets/f2f6ebc9-d155-42ff-8796-36972e41e0b9" />

