### PR TITLE
fix(model-ad): female should be listed first in combined sex dropdown (MG-346)

### DIFF
--- a/apps/model-ad/api/src/models/models.ts
+++ b/apps/model-ad/api/src/models/models.ts
@@ -9,7 +9,7 @@ export { Model } from '@sagebionetworks/model-ad/api-client-angular';
 
 const IndividualDataSchema = new Schema<IndividualData>({
   genotype: { type: String, required: true },
-  sex: { type: String, required: true, enum: ['Male', 'Female'] },
+  sex: { type: String, required: true, enum: ['Female', 'Male'] },
   individual_id: { type: String, required: true },
   value: { type: Number, required: true },
 });

--- a/libs/model-ad/api-description/openapi/api-public.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-public.openapi.yaml
@@ -193,8 +193,8 @@ components:
         sex:
           type: string
           enum:
-            - Male
             - Female
+            - Male
           description: Sex of the individual
         individual_id:
           type: string

--- a/libs/model-ad/api-description/openapi/api-service.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-service.openapi.yaml
@@ -193,8 +193,8 @@ components:
         sex:
           type: string
           enum:
-            - Male
             - Female
+            - Male
           description: Sex of the individual
         individual_id:
           type: string

--- a/libs/model-ad/api-description/openapi/openapi.yaml
+++ b/libs/model-ad/api-description/openapi/openapi.yaml
@@ -194,8 +194,8 @@ components:
         sex:
           type: string
           enum:
-            - Male
             - Female
+            - Male
           description: Sex of the individual
         individual_id:
           type: string

--- a/libs/model-ad/api-description/src/components/schemas/IndividualData.yaml
+++ b/libs/model-ad/api-description/src/components/schemas/IndividualData.yaml
@@ -7,8 +7,8 @@ properties:
   sex:
     type: string
     enum:
-      - Male
       - Female
+      - Male
     description: Sex of the individual
   individual_id:
     type: string

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.spec.ts
@@ -18,7 +18,7 @@ const mockModelData: ModelData = {
 
 async function setup(
   modelData = mockModelData,
-  sexes: IndividualData.SexEnum[] = ['Male', 'Female'],
+  sexes: IndividualData.SexEnum[] = ['Female', 'Male'],
 ) {
   const { fixture } = await render(ModelDetailsBoxplotComponent, {
     imports: [],
@@ -45,7 +45,7 @@ describe('ModelDetailsBoxplotComponent', () => {
   });
 
   it('should include both sexes when both are selected', async () => {
-    const { component } = await setup(mockModelData, ['Male', 'Female']);
+    const { component } = await setup(mockModelData, ['Female', 'Male']);
 
     const points = component.points();
     expect(points).toHaveLength(4);

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.spec.ts
@@ -10,7 +10,7 @@ async function setup(modelDataList = mockModelDataList) {
     imports: [],
     componentInputs: {
       modelDataList: modelDataList,
-      sexes: ['Male', 'Female'],
+      sexes: ['Female', 'Male'],
       title: mockTitle,
     },
   });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -60,7 +60,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     const sexSelect = screen.getByRole('combobox', { name: /sex/i });
 
     await waitFor(() => {
-      expect(sexSelect).toHaveAccessibleName('Male & Female');
+      expect(sexSelect).toHaveAccessibleName('Female & Male');
     });
   });
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -40,7 +40,7 @@ export class ModelDetailsBoxplotsSelectorComponent {
   wikiParams = input.required<SynapseWikiParams>();
 
   sexOptions: { label: string; value: IndividualData.SexEnum[] }[] = [
-    { label: 'Male & Female', value: ['Male', 'Female'] },
+    { label: 'Female & Male', value: ['Female', 'Male'] },
     { label: 'Female', value: ['Female'] },
     { label: 'Male', value: ['Male'] },
   ];


### PR DESCRIPTION
## Description

'Female' should be listed first in combined sex dropdown.

## Related Issue

- [MG-346](https://sagebionetworks.jira.com/browse/MG-346)

## Changelog

- Female is listed first in combined sex dropdown and in API enum

## Preview

`model-ad-build-images && model-ad-docker-start`
`https://dev.modeladexplorer.org/models/3xTg-AD/biomarkers` | `http://localhost:8000/models/3xTg-AD/biomarkers`
:---: | :---:
<img width="1146" height="365" alt="image" src="https://github.com/user-attachments/assets/4202a8c3-f650-4155-9653-b040cb0a636a" /> | <img width="1143" height="444" alt="image" src="https://github.com/user-attachments/assets/7f80526c-88f1-4c9b-8c68-5bb61c36392a" />


[MG-346]: https://sagebionetworks.jira.com/browse/MG-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ