### PR TITLE
refactor(openchallenges): ensure that data indexed in OpenSearch are up-to-date with the latest data changes (SMR-344)

### DIFF
--- a/apps/amp-als/dataset-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
+++ b/apps/amp-als/dataset-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
@@ -2,8 +2,8 @@ CREATE TABLE dataset (
   id                    BIGSERIAL PRIMARY KEY,
   name                  VARCHAR(255) NOT NULL,
   description           VARCHAR(1000) NOT NULL,
-  created_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+  created_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Create function to update the updated_at column

--- a/apps/openchallenges/auth-service/src/main/java/org/sagebionetworks/openchallenges/auth/service/model/entity/ApiKey.java
+++ b/apps/openchallenges/auth-service/src/main/java/org/sagebionetworks/openchallenges/auth/service/model/entity/ApiKey.java
@@ -42,7 +42,7 @@ public class ApiKey {
   private OffsetDateTime lastUsedAt;
 
   @CreationTimestamp
-  @Column(name = "created_at", nullable = false)
+  @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
 
   @UpdateTimestamp

--- a/apps/openchallenges/auth-service/src/main/java/org/sagebionetworks/openchallenges/auth/service/model/entity/User.java
+++ b/apps/openchallenges/auth-service/src/main/java/org/sagebionetworks/openchallenges/auth/service/model/entity/User.java
@@ -44,7 +44,7 @@ public class User {
   private Boolean enabled = true;
 
   @CreationTimestamp
-  @Column(name = "created_at", nullable = false)
+  @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
 
   @UpdateTimestamp

--- a/apps/openchallenges/auth-service/src/main/resources/db/migration/V1.0.0__create_initial_schema.sql
+++ b/apps/openchallenges/auth-service/src/main/resources/db/migration/V1.0.0__create_initial_schema.sql
@@ -5,21 +5,21 @@ CREATE TABLE app_user (
     password_hash VARCHAR(255) NOT NULL,
     role VARCHAR(50) NOT NULL DEFAULT 'user',
     enabled BOOLEAN NOT NULL DEFAULT true,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 -- Create api_key table
 CREATE TABLE api_key (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES app_user(id),
     key_hash VARCHAR(255) NOT NULL UNIQUE,
     key_prefix VARCHAR(20) NOT NULL,
     name VARCHAR(100) NOT NULL,
     expires_at TIMESTAMP WITH TIME ZONE,
     last_used_at TIMESTAMP WITH TIME ZONE,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 -- Create indexes for better performance
@@ -27,19 +27,3 @@ CREATE INDEX idx_api_key_user_id ON api_key(user_id);
 CREATE INDEX idx_api_key_key_hash ON api_key(key_hash);
 CREATE INDEX idx_api_key_expires_at ON api_key(expires_at);
 CREATE INDEX idx_app_user_username ON app_user(username);
-
--- Create function to update updated_at timestamp
-CREATE OR REPLACE FUNCTION update_updated_at_column()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
-END;
-$$ language 'plpgsql';
-
--- Create triggers to automatically update updated_at
-CREATE TRIGGER update_app_user_updated_at BEFORE UPDATE ON app_user
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-
-CREATE TRIGGER update_api_key_updated_at BEFORE UPDATE ON api_key
-    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/apps/openchallenges/auth-service/src/main/resources/db/migration/V1.0.1__insert_default_users.sql
+++ b/apps/openchallenges/auth-service/src/main/resources/db/migration/V1.0.1__insert_default_users.sql
@@ -1,20 +1,20 @@
 -- Insert default admin user
 -- Password is 'changeme' hashed with BCrypt (strength 12)
 -- You should change this password in production
-INSERT INTO app_user (username, password_hash, role) VALUES
-('admin', '$2a$12$lWQA8qj1Pp9NfAsWY53rQuK/uChV.EJ1RTxhisDFuV0uHrJFm0/J6', 'admin');
+INSERT INTO app_user (username, password_hash, role, created_at, updated_at) VALUES
+('admin', '$2a$12$lWQA8qj1Pp9NfAsWY53rQuK/uChV.EJ1RTxhisDFuV0uHrJFm0/J6', 'admin', NOW(), NOW());
 
 -- Insert default researcher user
 -- Password is 'changeme' hashed with BCrypt (strength 12)
 -- You should change this password in production
-INSERT INTO app_user (username, password_hash, role) VALUES
-('researcher', '$2a$12$lWQA8qj1Pp9NfAsWY53rQuK/uChV.EJ1RTxhisDFuV0uHrJFm0/J6', 'user');
+INSERT INTO app_user (username, password_hash, role, created_at, updated_at) VALUES
+('researcher', '$2a$12$lWQA8qj1Pp9NfAsWY53rQuK/uChV.EJ1RTxhisDFuV0uHrJFm0/J6', 'user', NOW(), NOW());
 
 -- Insert default challenge service user
 -- Password is 'changeme' hashed with BCrypt (strength 12)
 -- You should change this password in production
-INSERT INTO app_user (username, password_hash, role) VALUES
-('challenge-service', '$2a$12$lWQA8qj1Pp9NfAsWY53rQuK/uChV.EJ1RTxhisDFuV0uHrJFm0/J6', 'service');
+INSERT INTO app_user (username, password_hash, role, created_at, updated_at) VALUES
+('challenge-service', '$2a$12$lWQA8qj1Pp9NfAsWY53rQuK/uChV.EJ1RTxhisDFuV0uHrJFm0/J6', 'service', NOW(), NOW());
 
 -- Note: These are placeholder BCrypt hashes. In a real implementation,
 -- you would either:

--- a/apps/openchallenges/auth-service/src/main/resources/db/migration/V1.0.2__insert_service_dev_api_keys.sql
+++ b/apps/openchallenges/auth-service/src/main/resources/db/migration/V1.0.2__insert_service_dev_api_keys.sql
@@ -1,9 +1,11 @@
 -- Insert API key that the challenge service can use to interact with the organization service
-INSERT INTO api_key (user_id, key_hash, key_prefix, name, expires_at) VALUES
+INSERT INTO api_key (user_id, key_hash, key_prefix, name, expires_at, created_at, updated_at) VALUES
 (
     (SELECT id FROM app_user WHERE username = 'challenge-service'),
     '$2a$12$DMm4WSPALi5M8hQEE5caU.CpHY4czx8nDt1aqn.FlY2sk3sKvBBlq',
     'oc_dev_',
     'Login Session',
-    NULL -- No expiration for this key
+    NULL, -- No expiration for this key
+    NOW(),
+    NOW()
 );

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeEntity.java
@@ -18,8 +18,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
@@ -137,10 +139,12 @@ public class ChallengeEntity {
   @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
   private EdamConceptEntity operation;
 
-  @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, updatable = false)
   @GenericField(name = "created_at", sortable = Sortable.YES)
+  @CreationTimestamp
   private OffsetDateTime createdAt;
 
-  @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+  @Column(name = "updated_at", nullable = false)
+  @UpdateTimestamp
   private OffsetDateTime updatedAt;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeIncentiveEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeIncentiveEntity.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Entity
@@ -37,6 +38,7 @@ public class ChallengeIncentiveEntity {
   @JoinColumn(name = "challenge_id", nullable = false)
   private ChallengeEntity challenge;
 
-  @Column(name = "created_at")
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CreationTimestamp
   private OffsetDateTime createdAt;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeInputDataTypeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeInputDataTypeEntity.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "challenge_input_data_type")
@@ -36,6 +37,7 @@ public class ChallengeInputDataTypeEntity {
   @JoinColumn(name = "edam_concept_id", nullable = false)
   private EdamConceptEntity edamConcept;
 
-  @Column(name = "created_at")
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CreationTimestamp
   private OffsetDateTime createdAt;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengePlatformEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengePlatformEntity.java
@@ -11,6 +11,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
@@ -52,9 +54,11 @@ public class ChallengePlatformEntity {
   @Column(name = "website_url", nullable = false, length = 500)
   private String websiteUrl;
 
-  @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CreationTimestamp
   private OffsetDateTime createdAt;
 
-  @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+  @Column(name = "updated_at", nullable = false)
+  @UpdateTimestamp
   private OffsetDateTime updatedAt;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeStar.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeStar.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Entity
@@ -37,6 +38,7 @@ public class ChallengeStar {
   @GenericField
   private Long userId;
 
-  @Column(name = "created_at")
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CreationTimestamp
   private OffsetDateTime createdAt;
 }

--- a/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeSubmissionTypeEntity.java
+++ b/apps/openchallenges/challenge-service/src/main/java/org/sagebionetworks/openchallenges/challenge/service/model/entity/ChallengeSubmissionTypeEntity.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 
 @Entity
@@ -37,6 +38,7 @@ public class ChallengeSubmissionTypeEntity {
   @JoinColumn(name = "challenge_id", nullable = false)
   private ChallengeEntity challenge;
 
-  @Column(name = "created_at")
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CreationTimestamp
   private OffsetDateTime createdAt;
 }

--- a/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
+++ b/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
@@ -5,8 +5,8 @@ CREATE TABLE challenge_platform (
   name VARCHAR(255) NOT NULL UNIQUE,
   avatar_key VARCHAR(255),
   website_url VARCHAR(500) NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL
 );
 
 -- create edam_concept table
@@ -31,8 +31,8 @@ CREATE TABLE challenge (
   start_date DATE,
   end_date DATE,
   operation_id BIGINT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
   CONSTRAINT fk_platform FOREIGN KEY (platform_id) REFERENCES challenge_platform(id),
   CONSTRAINT fk_operation FOREIGN KEY (operation_id) REFERENCES edam_concept(id),
   CONSTRAINT slug_check CHECK (
@@ -60,7 +60,7 @@ CREATE TABLE challenge_incentive (
     name IN ('monetary', 'publication', 'speaking_engagement', 'other')
   ),
   challenge_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMPTZ NOT NULL,
   CONSTRAINT fk_challenge_inc FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT unique_incentive UNIQUE (name, challenge_id)
 );
@@ -72,7 +72,7 @@ CREATE TABLE challenge_submission_type (
     name IN ('container_image', 'prediction_file', 'notebook', 'mlcube', 'other')
   ),
   challenge_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMPTZ NOT NULL,
   CONSTRAINT fk_challenge_sub FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT unique_submission_type UNIQUE (name, challenge_id)
 );
@@ -82,7 +82,7 @@ CREATE TABLE challenge_input_data_type (
   id BIGSERIAL PRIMARY KEY,
   challenge_id BIGINT NOT NULL,
   edam_concept_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMPTZ NOT NULL,
   CONSTRAINT fk_challenge_input FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT fk_edam_concept FOREIGN KEY (edam_concept_id) REFERENCES edam_concept(id),
   CONSTRAINT unique_input_data_type UNIQUE (challenge_id, edam_concept_id)
@@ -93,7 +93,7 @@ CREATE TABLE challenge_star (
   id BIGSERIAL PRIMARY KEY,
   challenge_id BIGINT NOT NULL,
   user_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMPTZ NOT NULL,
   CONSTRAINT fk_challenge_star FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT unique_star UNIQUE (challenge_id, user_id)
 );

--- a/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
+++ b/apps/openchallenges/challenge-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
@@ -5,8 +5,8 @@ CREATE TABLE challenge_platform (
   name VARCHAR(255) NOT NULL UNIQUE,
   avatar_key VARCHAR(255),
   website_url VARCHAR(500) NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL,
-  updated_at TIMESTAMPTZ NOT NULL
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 -- create edam_concept table
@@ -31,8 +31,8 @@ CREATE TABLE challenge (
   start_date DATE,
   end_date DATE,
   operation_id BIGINT,
-  created_at TIMESTAMPTZ NOT NULL,
-  updated_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
   CONSTRAINT fk_platform FOREIGN KEY (platform_id) REFERENCES challenge_platform(id),
   CONSTRAINT fk_operation FOREIGN KEY (operation_id) REFERENCES edam_concept(id),
   CONSTRAINT slug_check CHECK (
@@ -60,7 +60,7 @@ CREATE TABLE challenge_incentive (
     name IN ('monetary', 'publication', 'speaking_engagement', 'other')
   ),
   challenge_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   CONSTRAINT fk_challenge_inc FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT unique_incentive UNIQUE (name, challenge_id)
 );
@@ -72,7 +72,7 @@ CREATE TABLE challenge_submission_type (
     name IN ('container_image', 'prediction_file', 'notebook', 'mlcube', 'other')
   ),
   challenge_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   CONSTRAINT fk_challenge_sub FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT unique_submission_type UNIQUE (name, challenge_id)
 );
@@ -82,7 +82,7 @@ CREATE TABLE challenge_input_data_type (
   id BIGSERIAL PRIMARY KEY,
   challenge_id BIGINT NOT NULL,
   edam_concept_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   CONSTRAINT fk_challenge_input FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT fk_edam_concept FOREIGN KEY (edam_concept_id) REFERENCES edam_concept(id),
   CONSTRAINT unique_input_data_type UNIQUE (challenge_id, edam_concept_id)
@@ -93,7 +93,7 @@ CREATE TABLE challenge_star (
   id BIGSERIAL PRIMARY KEY,
   challenge_id BIGINT NOT NULL,
   user_id BIGINT NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   CONSTRAINT fk_challenge_star FOREIGN KEY (challenge_id) REFERENCES challenge(id),
   CONSTRAINT unique_star UNIQUE (challenge_id, user_id)
 );

--- a/apps/openchallenges/organization-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
+++ b/apps/openchallenges/organization-service/src/main/resources/db/migration/V1.0.0__create_tables.sql
@@ -7,8 +7,8 @@ CREATE TABLE organization (
   avatar_key            VARCHAR(255),
   website_url           VARCHAR(500),
   description           VARCHAR(1000),
-  created_at            TIMESTAMPTZ NOT NULL,
-  updated_at            TIMESTAMPTZ NOT NULL,
+  created_at            TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at            TIMESTAMP WITH TIME ZONE NOT NULL,
   acronym               VARCHAR(20),
   CONSTRAINT login_check CHECK (
     char_length(login) >= 2 AND login ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'


### PR DESCRIPTION
## Description

Ensure that data indexed in OpenSearch are up-to-date with the latest data changes.

## Related Issue

- [SMR-344](https://sagebionetworks.jira.com/browse/SMR-344)

## Changelog

- No longer use `ON CASCADE DELETE` at the database level.
- Use `TIMESTAMP WITH TIME ZONE` everywhere.
- Set creation and update timestamp values in the Java code.

[SMR-344]: https://sagebionetworks.jira.com/browse/SMR-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ