### PR TITLE
feat(model-ad): add table links (MG-355)

### DIFF
--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-table-link/comparison-tool-table-link.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-table-link/comparison-tool-table-link.component.html
@@ -1,9 +1,11 @@
-<div class="comparison-tool-table-link">
-  @if (isExternalLink()) {
-    <a target="_blank" href="{{ linkUrl() }}"
-      >{{ linkText() }} <i class="pi pi-external-link"></i
-    ></a>
-  } @else {
-    <a routerLink="{{ linkUrl() }}">{{ linkText() }} <i class="pi pi-external-link"></i></a>
-  }
-</div>
+@if (linkUrl()) {
+  <div class="comparison-tool-table-link">
+    @if (isExternalLink()) {
+      <a target="_blank" href="{{ linkUrl() }}"
+        >{{ linkText() }} <i class="pi pi-external-link"></i
+      ></a>
+    } @else {
+      <a routerLink="{{ internalLinkUrl }}">{{ linkText() }} <i class="pi pi-external-link"></i></a>
+    }
+  </div>
+}

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-table-link/comparison-tool-table-link.component.spec.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-table-link/comparison-tool-table-link.component.spec.ts
@@ -23,5 +23,16 @@ describe('ComparisonToolTableLinkComponent', () => {
     await setup(linkText, linkUrl);
     const link = screen.getByRole('link', { name: /My Link/i });
     expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', linkUrl);
+  });
+
+  it('should render internal link without leading slash character with correct text and url', async () => {
+    const linkText = 'My Link';
+    const linkUrl = 'my-url';
+    const expectedLinkUrl = '/my-url';
+    await setup(linkText, linkUrl);
+    const link = screen.getByRole('link', { name: /My Link/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', expectedLinkUrl);
   });
 });

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-table-link/comparison-tool-table-link.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-table-link/comparison-tool-table-link.component.ts
@@ -12,7 +12,20 @@ export class ComparisonToolTableLinkComponent {
   linkText = input<string>('');
   linkUrl = input<string>('');
 
-  isExternalLink() {
-    return isExternalLink(this.linkUrl());
+  get internalLinkUrl(): string {
+    const url = this.linkUrl().trim();
+
+    // Return URL as-is if it already starts with '/'
+    if (url.startsWith('/')) {
+      return url;
+    }
+
+    // Prepend '/' to make it a proper internal route
+    return `/${url}`;
+  }
+
+  isExternalLink(): boolean {
+    const url = this.linkUrl()?.trim();
+    return url ? isExternalLink(url) : false;
   }
 }


### PR DESCRIPTION
## Description
The comparison tool tables have internal/external links.  If no url is present in the data, don't show the link.

## Related Issue

[MG-355](https://sagebionetworks.jira.com/browse/MG-355?assignee=633b138697148a8301fe2c72&selectedIssue=MG-251)

## Changelog
- Update logic to only show links when link_url is present in the data.
- Internal links in the data are not always prepended with a slash so add a leading slash as needed.
- External link behavior did not require any changes.

## Preview
Before:
<img width="2144" height="1229" alt="image" src="https://github.com/user-attachments/assets/73431eb5-441f-40be-88d7-2145b88105d0" />

After:
<img width="2142" height="1225" alt="image" src="https://github.com/user-attachments/assets/325a414a-bf63-4ddc-b8a4-b36cc666f3cf" />

