### PR TITLE
fix(agora): fix teams page memory leak (AG-1843)

### DIFF
--- a/libs/agora/teams/src/lib/teams.component.ts
+++ b/libs/agora/teams/src/lib/teams.component.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { Team, TeamsList, TeamsService } from '@sagebionetworks/agora/api-client-angular';
 import { HelperService } from '@sagebionetworks/agora/services';
 import { catchError, finalize, map, Observable, of } from 'rxjs';
 import { TeamListComponent } from './team-list/team-list.component';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'agora-teams',
@@ -12,6 +13,8 @@ import { TeamListComponent } from './team-list/team-list.component';
   styleUrls: ['./teams.component.scss'],
 })
 export class TeamsComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+
   helperService = inject(HelperService);
   teamsService = inject(TeamsService);
 
@@ -25,6 +28,7 @@ export class TeamsComponent implements OnInit {
     this.helperService.setLoading(true);
 
     this.teams$ = this.teamsService.listTeams().pipe(
+      takeUntilDestroyed(this.destroyRef),
       map((res: TeamsList) => res.items || []),
       catchError((error: Error) => {
         console.error('Error loading teams:', error.message);


### PR DESCRIPTION
## Description
The teams page has a memory leak that can be fixed by using Angular 16+ DestroyRef feature.

## Related Issue

[AG-1843](https://sagebionetworks.jira.com/browse/AG-1843)

## Changelog
- Use DestroyRef to address memory leak


[AG-1843]: https://sagebionetworks.jira.com/browse/AG-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ