### PR TITLE
feat(bixarena): create the initial BixArena OpenAPI description with endpoints for the leaderboards (SMR-402)

### DIFF
--- a/libs/bixarena/README.md
+++ b/libs/bixarena/README.md
@@ -1,1 +1,0 @@
-# BixArena Libs

--- a/libs/bixarena/api-description/openapi/api-public.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-public.openapi.yaml
@@ -1,0 +1,565 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: BixArena API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1
+tags:
+  - name: Leaderboard
+    description: Operations about leaderboards.
+paths:
+  /leaderboards:
+    get:
+      tags:
+        - Leaderboard
+      summary: List all available leaderboards
+      description: Get a list of all available leaderboards with their metadata
+      operationId: listLeaderboards
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: Unique identifier for the leaderboard
+                      example: open-source
+                    name:
+                      type: string
+                      description: Display name for the leaderboard
+                      example: Open Source Models
+                    description:
+                      type: string
+                      description: Description of what this leaderboard measures
+                      example: Performance ranking of open-source AI models
+                    lastUpdated:
+                      type: string
+                      format: date-time
+                      description: When this leaderboard was last updated
+                      example: '2025-08-16T14:30:00Z'
+                  required:
+                    - id
+                    - name
+                    - description
+                    - lastUpdated
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get leaderboard entries
+      description: Get paginated leaderboard entries for a specific leaderboard
+      operationId: getLeaderboard
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/leaderboardSearchQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}/history/{modelId}:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get model performance history
+      description: Get historical performance data for a specific model in a leaderboard
+      operationId: getModelHistory
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/leaderboardModelHistoryQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardModelHistoryPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}/snapshots:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get leaderboard snapshots
+      description: Get a paginated list of available snapshots for a leaderboard
+      operationId: getLeaderboardSnapshots
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/leaderboardSnapshotQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardSnapshotPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  schemas:
+    BasicError:
+      type: object
+      description: Problem details (tools.ietf.org/html/rfc7807)
+      properties:
+        title:
+          type: string
+          description: A human readable documentation for the problem type
+        status:
+          type: integer
+          description: The HTTP status code
+        detail:
+          type: string
+          description: A human readable explanation specific to this occurrence of the problem
+        type:
+          type: string
+          description: An absolute URI that identifies the problem type
+        instance:
+          type: string
+          description: An absolute URI that identifies the specific occurrence of the problem
+      required:
+        - title
+        - status
+      x-java-class-annotations:
+        - '@lombok.AllArgsConstructor'
+        - '@lombok.Builder'
+    LeaderboardSort:
+      type: string
+      description: The field to sort leaderboard entries by.
+      enum:
+        - rank
+        - bt_score
+        - vote_count
+        - created_at
+        - model_name
+      default: rank
+      example: bt_score
+    SortDirection:
+      type: string
+      description: The direction to sort results.
+      enum:
+        - asc
+        - desc
+      default: asc
+      example: desc
+    LeaderboardSearchQuery:
+      type: object
+      description: A leaderboard search query with pagination and filtering options.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 25
+        sort:
+          $ref: '#/components/schemas/LeaderboardSort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+        search:
+          description: Search by model name (case-insensitive partial match).
+          type: string
+          nullable: true
+          example: gpt
+        snapshotId:
+          description: Get a specific historical snapshot instead of latest.
+          type: string
+          nullable: true
+          example: snapshot_2025-08-15_10-00
+    PageMetadata:
+      type: object
+      description: The metadata of a page.
+      properties:
+        number:
+          description: The page number.
+          type: integer
+          format: int32
+          example: 99
+        size:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          example: 99
+        totalElements:
+          description: Total number of elements in the result set.
+          type: integer
+          format: int64
+          example: 99
+        totalPages:
+          description: Total number of pages in the result set.
+          type: integer
+          format: int32
+          example: 99
+        hasNext:
+          description: Returns if there is a next page.
+          type: boolean
+          example: true
+        hasPrevious:
+          description: Returns if there is a previous page.
+          type: boolean
+          example: true
+      required:
+        - number
+        - size
+        - totalElements
+        - totalPages
+        - hasNext
+        - hasPrevious
+    LeaderboardEntry:
+      type: object
+      description: A single entry in a leaderboard representing a model's performance.
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this leaderboard entry
+          example: entry_123
+        modelId:
+          type: string
+          description: Identifier for the model
+          example: model_456
+        modelName:
+          type: string
+          description: Display name of the model
+          example: GPT-4o
+        license:
+          type: string
+          description: License type of the model
+          example: MIT
+        btScore:
+          type: number
+          format: double
+          description: Primary scoring metric (higher is better)
+          example: 0.925
+        voteCount:
+          type: integer
+          description: Number of votes/evaluations
+          example: 1250
+        rank:
+          type: integer
+          description: Current rank position (1-based)
+          example: 1
+        createdAt:
+          type: string
+          format: date-time
+          description: When this entry was created
+          example: '2025-08-16T10:30:00Z'
+        secondaryScore:
+          type: number
+          format: double
+          nullable: true
+          description: Optional secondary scoring metric
+          example: 0.887
+      required:
+        - id
+        - modelId
+        - modelName
+        - license
+        - btScore
+        - voteCount
+        - rank
+        - createdAt
+    LeaderboardPage:
+      type: object
+      description: A page of leaderboard entries.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            lastUpdated:
+              type: string
+              format: date-time
+              description: When this leaderboard was last updated
+              example: '2025-08-16T14:30:00Z'
+            snapshotId:
+              type: string
+              description: Identifier for this snapshot/timepoint
+              example: snapshot_2025-08-16_14-30
+            entries:
+              description: A list of leaderboard entries.
+              type: array
+              items:
+                $ref: '#/components/schemas/LeaderboardEntry'
+          required:
+            - lastUpdated
+            - snapshotId
+            - entries
+    LeaderboardHistorySort:
+      type: string
+      description: The field to sort historical entries by.
+      enum:
+        - created_at
+        - bt_score
+        - rank
+      default: created_at
+      example: created_at
+    LeaderboardModelHistoryQuery:
+      type: object
+      description: A query for retrieving historical leaderboard data for a model.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 50
+        sort:
+          $ref: '#/components/schemas/LeaderboardHistorySort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+        fromDate:
+          description: Include only entries created on or after this date.
+          type: string
+          format: date
+          nullable: true
+          example: '2025-08-01'
+        toDate:
+          description: Include only entries created on or before this date.
+          type: string
+          format: date
+          nullable: true
+          example: '2025-08-16'
+    HistoricalLeaderboardEntry:
+      type: object
+      description: A historical entry representing a model's performance at a specific point in time.
+      properties:
+        snapshotId:
+          type: string
+          description: Identifier for the snapshot/timepoint
+          example: snapshot_2025-08-15_10-00
+        btScore:
+          type: number
+          format: double
+          description: Primary scoring metric at this point in time
+          example: 0.915
+        voteCount:
+          type: integer
+          description: Number of votes/evaluations at this point in time
+          example: 1180
+        rank:
+          type: integer
+          description: Rank position at this point in time (1-based)
+          example: 2
+        createdAt:
+          type: string
+          format: date-time
+          description: When this snapshot was created
+          example: '2025-08-15T10:00:00Z'
+        secondaryScore:
+          type: number
+          format: double
+          nullable: true
+          description: Optional secondary scoring metric at this point in time
+          example: 0.875
+      required:
+        - snapshotId
+        - btScore
+        - voteCount
+        - rank
+        - createdAt
+    LeaderboardModelHistoryPage:
+      type: object
+      description: A page of historical leaderboard entries for a specific model.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            modelId:
+              type: string
+              description: Identifier for the model
+              example: model_456
+            modelName:
+              type: string
+              description: Display name of the model
+              example: GPT-4o
+            history:
+              description: A list of historical leaderboard entries.
+              type: array
+              items:
+                $ref: '#/components/schemas/HistoricalLeaderboardEntry'
+          required:
+            - modelId
+            - modelName
+            - history
+    LeaderboardSnapshotSort:
+      type: string
+      description: The field to sort snapshots by.
+      enum:
+        - created_at
+      default: created_at
+      example: created_at
+    LeaderboardSnapshotQuery:
+      type: object
+      description: A query for retrieving leaderboard snapshots.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 20
+        sort:
+          $ref: '#/components/schemas/LeaderboardSnapshotSort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+    LeaderboardSnapshot:
+      type: object
+      description: A snapshot representing the state of a leaderboard at a specific point in time.
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this snapshot
+          example: snapshot_2025-08-16_14-30
+        createdAt:
+          type: string
+          format: date-time
+          description: When this snapshot was created
+          example: '2025-08-16T14:30:00Z'
+        entryCount:
+          type: integer
+          description: Number of models in this snapshot
+          example: 50
+        description:
+          type: string
+          nullable: true
+          description: Optional description of this snapshot
+          example: Weekly evaluation run
+      required:
+        - id
+        - createdAt
+        - entryCount
+    LeaderboardSnapshotPage:
+      type: object
+      description: A page of leaderboard snapshots.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            snapshots:
+              description: A list of leaderboard snapshots.
+              type: array
+              items:
+                $ref: '#/components/schemas/LeaderboardSnapshot'
+          required:
+            - snapshots
+  responses:
+    InternalServerError:
+      description: The request cannot be fulfilled due to an unexpected server error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    BadRequest:
+      description: Invalid request parameters
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    NotFound:
+      description: The requested resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+  parameters:
+    leaderboardId:
+      name: leaderboardId
+      description: The unique identifier of a leaderboard
+      in: path
+      required: true
+      schema:
+        type: string
+        example: open-source
+    leaderboardSearchQuery:
+      name: leaderboardSearchQuery
+      description: The search query used to find and filter leaderboard entries.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardSearchQuery'
+    modelId:
+      name: modelId
+      description: The unique identifier of a model
+      in: path
+      required: true
+      schema:
+        type: string
+        example: model_456
+    leaderboardModelHistoryQuery:
+      name: leaderboardModelHistoryQuery
+      description: The query used to filter and paginate historical model performance data.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardModelHistoryQuery'
+    leaderboardSnapshotQuery:
+      name: leaderboardSnapshotQuery
+      description: The query used to filter and paginate leaderboard snapshots.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardSnapshotQuery'

--- a/libs/bixarena/api-description/openapi/api-service.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-service.openapi.yaml
@@ -1,0 +1,565 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: BixArena API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1
+tags:
+  - name: Leaderboard
+    description: Operations about leaderboards.
+paths:
+  /leaderboards:
+    get:
+      tags:
+        - Leaderboard
+      summary: List all available leaderboards
+      description: Get a list of all available leaderboards with their metadata
+      operationId: listLeaderboards
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: Unique identifier for the leaderboard
+                      example: open-source
+                    name:
+                      type: string
+                      description: Display name for the leaderboard
+                      example: Open Source Models
+                    description:
+                      type: string
+                      description: Description of what this leaderboard measures
+                      example: Performance ranking of open-source AI models
+                    lastUpdated:
+                      type: string
+                      format: date-time
+                      description: When this leaderboard was last updated
+                      example: '2025-08-16T14:30:00Z'
+                  required:
+                    - id
+                    - name
+                    - description
+                    - lastUpdated
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get leaderboard entries
+      description: Get paginated leaderboard entries for a specific leaderboard
+      operationId: getLeaderboard
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/leaderboardSearchQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}/history/{modelId}:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get model performance history
+      description: Get historical performance data for a specific model in a leaderboard
+      operationId: getModelHistory
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/leaderboardModelHistoryQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardModelHistoryPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}/snapshots:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get leaderboard snapshots
+      description: Get a paginated list of available snapshots for a leaderboard
+      operationId: getLeaderboardSnapshots
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/leaderboardSnapshotQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardSnapshotPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  schemas:
+    BasicError:
+      type: object
+      description: Problem details (tools.ietf.org/html/rfc7807)
+      properties:
+        title:
+          type: string
+          description: A human readable documentation for the problem type
+        status:
+          type: integer
+          description: The HTTP status code
+        detail:
+          type: string
+          description: A human readable explanation specific to this occurrence of the problem
+        type:
+          type: string
+          description: An absolute URI that identifies the problem type
+        instance:
+          type: string
+          description: An absolute URI that identifies the specific occurrence of the problem
+      required:
+        - title
+        - status
+      x-java-class-annotations:
+        - '@lombok.AllArgsConstructor'
+        - '@lombok.Builder'
+    LeaderboardSort:
+      type: string
+      description: The field to sort leaderboard entries by.
+      enum:
+        - rank
+        - bt_score
+        - vote_count
+        - created_at
+        - model_name
+      default: rank
+      example: bt_score
+    SortDirection:
+      type: string
+      description: The direction to sort results.
+      enum:
+        - asc
+        - desc
+      default: asc
+      example: desc
+    LeaderboardSearchQuery:
+      type: object
+      description: A leaderboard search query with pagination and filtering options.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 25
+        sort:
+          $ref: '#/components/schemas/LeaderboardSort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+        search:
+          description: Search by model name (case-insensitive partial match).
+          type: string
+          nullable: true
+          example: gpt
+        snapshotId:
+          description: Get a specific historical snapshot instead of latest.
+          type: string
+          nullable: true
+          example: snapshot_2025-08-15_10-00
+    PageMetadata:
+      type: object
+      description: The metadata of a page.
+      properties:
+        number:
+          description: The page number.
+          type: integer
+          format: int32
+          example: 99
+        size:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          example: 99
+        totalElements:
+          description: Total number of elements in the result set.
+          type: integer
+          format: int64
+          example: 99
+        totalPages:
+          description: Total number of pages in the result set.
+          type: integer
+          format: int32
+          example: 99
+        hasNext:
+          description: Returns if there is a next page.
+          type: boolean
+          example: true
+        hasPrevious:
+          description: Returns if there is a previous page.
+          type: boolean
+          example: true
+      required:
+        - number
+        - size
+        - totalElements
+        - totalPages
+        - hasNext
+        - hasPrevious
+    LeaderboardEntry:
+      type: object
+      description: A single entry in a leaderboard representing a model's performance.
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this leaderboard entry
+          example: entry_123
+        modelId:
+          type: string
+          description: Identifier for the model
+          example: model_456
+        modelName:
+          type: string
+          description: Display name of the model
+          example: GPT-4o
+        license:
+          type: string
+          description: License type of the model
+          example: MIT
+        btScore:
+          type: number
+          format: double
+          description: Primary scoring metric (higher is better)
+          example: 0.925
+        voteCount:
+          type: integer
+          description: Number of votes/evaluations
+          example: 1250
+        rank:
+          type: integer
+          description: Current rank position (1-based)
+          example: 1
+        createdAt:
+          type: string
+          format: date-time
+          description: When this entry was created
+          example: '2025-08-16T10:30:00Z'
+        secondaryScore:
+          type: number
+          format: double
+          nullable: true
+          description: Optional secondary scoring metric
+          example: 0.887
+      required:
+        - id
+        - modelId
+        - modelName
+        - license
+        - btScore
+        - voteCount
+        - rank
+        - createdAt
+    LeaderboardPage:
+      type: object
+      description: A page of leaderboard entries.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            lastUpdated:
+              type: string
+              format: date-time
+              description: When this leaderboard was last updated
+              example: '2025-08-16T14:30:00Z'
+            snapshotId:
+              type: string
+              description: Identifier for this snapshot/timepoint
+              example: snapshot_2025-08-16_14-30
+            entries:
+              description: A list of leaderboard entries.
+              type: array
+              items:
+                $ref: '#/components/schemas/LeaderboardEntry'
+          required:
+            - lastUpdated
+            - snapshotId
+            - entries
+    LeaderboardHistorySort:
+      type: string
+      description: The field to sort historical entries by.
+      enum:
+        - created_at
+        - bt_score
+        - rank
+      default: created_at
+      example: created_at
+    LeaderboardModelHistoryQuery:
+      type: object
+      description: A query for retrieving historical leaderboard data for a model.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 50
+        sort:
+          $ref: '#/components/schemas/LeaderboardHistorySort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+        fromDate:
+          description: Include only entries created on or after this date.
+          type: string
+          format: date
+          nullable: true
+          example: '2025-08-01'
+        toDate:
+          description: Include only entries created on or before this date.
+          type: string
+          format: date
+          nullable: true
+          example: '2025-08-16'
+    HistoricalLeaderboardEntry:
+      type: object
+      description: A historical entry representing a model's performance at a specific point in time.
+      properties:
+        snapshotId:
+          type: string
+          description: Identifier for the snapshot/timepoint
+          example: snapshot_2025-08-15_10-00
+        btScore:
+          type: number
+          format: double
+          description: Primary scoring metric at this point in time
+          example: 0.915
+        voteCount:
+          type: integer
+          description: Number of votes/evaluations at this point in time
+          example: 1180
+        rank:
+          type: integer
+          description: Rank position at this point in time (1-based)
+          example: 2
+        createdAt:
+          type: string
+          format: date-time
+          description: When this snapshot was created
+          example: '2025-08-15T10:00:00Z'
+        secondaryScore:
+          type: number
+          format: double
+          nullable: true
+          description: Optional secondary scoring metric at this point in time
+          example: 0.875
+      required:
+        - snapshotId
+        - btScore
+        - voteCount
+        - rank
+        - createdAt
+    LeaderboardModelHistoryPage:
+      type: object
+      description: A page of historical leaderboard entries for a specific model.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            modelId:
+              type: string
+              description: Identifier for the model
+              example: model_456
+            modelName:
+              type: string
+              description: Display name of the model
+              example: GPT-4o
+            history:
+              description: A list of historical leaderboard entries.
+              type: array
+              items:
+                $ref: '#/components/schemas/HistoricalLeaderboardEntry'
+          required:
+            - modelId
+            - modelName
+            - history
+    LeaderboardSnapshotSort:
+      type: string
+      description: The field to sort snapshots by.
+      enum:
+        - created_at
+      default: created_at
+      example: created_at
+    LeaderboardSnapshotQuery:
+      type: object
+      description: A query for retrieving leaderboard snapshots.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 20
+        sort:
+          $ref: '#/components/schemas/LeaderboardSnapshotSort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+    LeaderboardSnapshot:
+      type: object
+      description: A snapshot representing the state of a leaderboard at a specific point in time.
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this snapshot
+          example: snapshot_2025-08-16_14-30
+        createdAt:
+          type: string
+          format: date-time
+          description: When this snapshot was created
+          example: '2025-08-16T14:30:00Z'
+        entryCount:
+          type: integer
+          description: Number of models in this snapshot
+          example: 50
+        description:
+          type: string
+          nullable: true
+          description: Optional description of this snapshot
+          example: Weekly evaluation run
+      required:
+        - id
+        - createdAt
+        - entryCount
+    LeaderboardSnapshotPage:
+      type: object
+      description: A page of leaderboard snapshots.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            snapshots:
+              description: A list of leaderboard snapshots.
+              type: array
+              items:
+                $ref: '#/components/schemas/LeaderboardSnapshot'
+          required:
+            - snapshots
+  responses:
+    InternalServerError:
+      description: The request cannot be fulfilled due to an unexpected server error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    BadRequest:
+      description: Invalid request parameters
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    NotFound:
+      description: The requested resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+  parameters:
+    leaderboardId:
+      name: leaderboardId
+      description: The unique identifier of a leaderboard
+      in: path
+      required: true
+      schema:
+        type: string
+        example: open-source
+    leaderboardSearchQuery:
+      name: leaderboardSearchQuery
+      description: The search query used to find and filter leaderboard entries.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardSearchQuery'
+    modelId:
+      name: modelId
+      description: The unique identifier of a model
+      in: path
+      required: true
+      schema:
+        type: string
+        example: model_456
+    leaderboardModelHistoryQuery:
+      name: leaderboardModelHistoryQuery
+      description: The query used to filter and paginate historical model performance data.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardModelHistoryQuery'
+    leaderboardSnapshotQuery:
+      name: leaderboardSnapshotQuery
+      description: The query used to filter and paginate leaderboard snapshots.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardSnapshotQuery'

--- a/libs/bixarena/api-description/openapi/openapi.yaml
+++ b/libs/bixarena/api-description/openapi/openapi.yaml
@@ -1,0 +1,565 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: BixArena API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1
+tags:
+  - name: Leaderboard
+    description: Operations about leaderboards.
+paths:
+  /leaderboards:
+    get:
+      tags:
+        - Leaderboard
+      summary: List all available leaderboards
+      description: Get a list of all available leaderboards with their metadata
+      operationId: listLeaderboards
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: Unique identifier for the leaderboard
+                      example: open-source
+                    name:
+                      type: string
+                      description: Display name for the leaderboard
+                      example: Open Source Models
+                    description:
+                      type: string
+                      description: Description of what this leaderboard measures
+                      example: Performance ranking of open-source AI models
+                    lastUpdated:
+                      type: string
+                      format: date-time
+                      description: When this leaderboard was last updated
+                      example: '2025-08-16T14:30:00Z'
+                  required:
+                    - id
+                    - name
+                    - description
+                    - lastUpdated
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get leaderboard entries
+      description: Get paginated leaderboard entries for a specific leaderboard
+      operationId: getLeaderboard
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/leaderboardSearchQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}/history/{modelId}:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get model performance history
+      description: Get historical performance data for a specific model in a leaderboard
+      operationId: getModelHistory
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/modelId'
+        - $ref: '#/components/parameters/leaderboardModelHistoryQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardModelHistoryPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /leaderboards/{leaderboardId}/snapshots:
+    get:
+      tags:
+        - Leaderboard
+      summary: Get leaderboard snapshots
+      description: Get a paginated list of available snapshots for a leaderboard
+      operationId: getLeaderboardSnapshots
+      x-audience:
+        - public
+      parameters:
+        - $ref: '#/components/parameters/leaderboardId'
+        - $ref: '#/components/parameters/leaderboardSnapshotQuery'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaderboardSnapshotPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  schemas:
+    BasicError:
+      type: object
+      description: Problem details (tools.ietf.org/html/rfc7807)
+      properties:
+        title:
+          type: string
+          description: A human readable documentation for the problem type
+        status:
+          type: integer
+          description: The HTTP status code
+        detail:
+          type: string
+          description: A human readable explanation specific to this occurrence of the problem
+        type:
+          type: string
+          description: An absolute URI that identifies the problem type
+        instance:
+          type: string
+          description: An absolute URI that identifies the specific occurrence of the problem
+      required:
+        - title
+        - status
+      x-java-class-annotations:
+        - '@lombok.AllArgsConstructor'
+        - '@lombok.Builder'
+    LeaderboardSort:
+      type: string
+      description: The field to sort leaderboard entries by.
+      enum:
+        - rank
+        - bt_score
+        - vote_count
+        - created_at
+        - model_name
+      default: rank
+      example: bt_score
+    SortDirection:
+      type: string
+      description: The direction to sort results.
+      enum:
+        - asc
+        - desc
+      default: asc
+      example: desc
+    LeaderboardSearchQuery:
+      type: object
+      description: A leaderboard search query with pagination and filtering options.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 25
+        sort:
+          $ref: '#/components/schemas/LeaderboardSort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+        search:
+          description: Search by model name (case-insensitive partial match).
+          type: string
+          nullable: true
+          example: gpt
+        snapshotId:
+          description: Get a specific historical snapshot instead of latest.
+          type: string
+          nullable: true
+          example: snapshot_2025-08-15_10-00
+    PageMetadata:
+      type: object
+      description: The metadata of a page.
+      properties:
+        number:
+          description: The page number.
+          type: integer
+          format: int32
+          example: 99
+        size:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          example: 99
+        totalElements:
+          description: Total number of elements in the result set.
+          type: integer
+          format: int64
+          example: 99
+        totalPages:
+          description: Total number of pages in the result set.
+          type: integer
+          format: int32
+          example: 99
+        hasNext:
+          description: Returns if there is a next page.
+          type: boolean
+          example: true
+        hasPrevious:
+          description: Returns if there is a previous page.
+          type: boolean
+          example: true
+      required:
+        - number
+        - size
+        - totalElements
+        - totalPages
+        - hasNext
+        - hasPrevious
+    LeaderboardEntry:
+      type: object
+      description: A single entry in a leaderboard representing a model's performance.
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this leaderboard entry
+          example: entry_123
+        modelId:
+          type: string
+          description: Identifier for the model
+          example: model_456
+        modelName:
+          type: string
+          description: Display name of the model
+          example: GPT-4o
+        license:
+          type: string
+          description: License type of the model
+          example: MIT
+        btScore:
+          type: number
+          format: double
+          description: Primary scoring metric (higher is better)
+          example: 0.925
+        voteCount:
+          type: integer
+          description: Number of votes/evaluations
+          example: 1250
+        rank:
+          type: integer
+          description: Current rank position (1-based)
+          example: 1
+        createdAt:
+          type: string
+          format: date-time
+          description: When this entry was created
+          example: '2025-08-16T10:30:00Z'
+        secondaryScore:
+          type: number
+          format: double
+          nullable: true
+          description: Optional secondary scoring metric
+          example: 0.887
+      required:
+        - id
+        - modelId
+        - modelName
+        - license
+        - btScore
+        - voteCount
+        - rank
+        - createdAt
+    LeaderboardPage:
+      type: object
+      description: A page of leaderboard entries.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            lastUpdated:
+              type: string
+              format: date-time
+              description: When this leaderboard was last updated
+              example: '2025-08-16T14:30:00Z'
+            snapshotId:
+              type: string
+              description: Identifier for this snapshot/timepoint
+              example: snapshot_2025-08-16_14-30
+            entries:
+              description: A list of leaderboard entries.
+              type: array
+              items:
+                $ref: '#/components/schemas/LeaderboardEntry'
+          required:
+            - lastUpdated
+            - snapshotId
+            - entries
+    LeaderboardHistorySort:
+      type: string
+      description: The field to sort historical entries by.
+      enum:
+        - created_at
+        - bt_score
+        - rank
+      default: created_at
+      example: created_at
+    LeaderboardModelHistoryQuery:
+      type: object
+      description: A query for retrieving historical leaderboard data for a model.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 50
+        sort:
+          $ref: '#/components/schemas/LeaderboardHistorySort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+        fromDate:
+          description: Include only entries created on or after this date.
+          type: string
+          format: date
+          nullable: true
+          example: '2025-08-01'
+        toDate:
+          description: Include only entries created on or before this date.
+          type: string
+          format: date
+          nullable: true
+          example: '2025-08-16'
+    HistoricalLeaderboardEntry:
+      type: object
+      description: A historical entry representing a model's performance at a specific point in time.
+      properties:
+        snapshotId:
+          type: string
+          description: Identifier for the snapshot/timepoint
+          example: snapshot_2025-08-15_10-00
+        btScore:
+          type: number
+          format: double
+          description: Primary scoring metric at this point in time
+          example: 0.915
+        voteCount:
+          type: integer
+          description: Number of votes/evaluations at this point in time
+          example: 1180
+        rank:
+          type: integer
+          description: Rank position at this point in time (1-based)
+          example: 2
+        createdAt:
+          type: string
+          format: date-time
+          description: When this snapshot was created
+          example: '2025-08-15T10:00:00Z'
+        secondaryScore:
+          type: number
+          format: double
+          nullable: true
+          description: Optional secondary scoring metric at this point in time
+          example: 0.875
+      required:
+        - snapshotId
+        - btScore
+        - voteCount
+        - rank
+        - createdAt
+    LeaderboardModelHistoryPage:
+      type: object
+      description: A page of historical leaderboard entries for a specific model.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            modelId:
+              type: string
+              description: Identifier for the model
+              example: model_456
+            modelName:
+              type: string
+              description: Display name of the model
+              example: GPT-4o
+            history:
+              description: A list of historical leaderboard entries.
+              type: array
+              items:
+                $ref: '#/components/schemas/HistoricalLeaderboardEntry'
+          required:
+            - modelId
+            - modelName
+            - history
+    LeaderboardSnapshotSort:
+      type: string
+      description: The field to sort snapshots by.
+      enum:
+        - created_at
+      default: created_at
+      example: created_at
+    LeaderboardSnapshotQuery:
+      type: object
+      description: A query for retrieving leaderboard snapshots.
+      properties:
+        pageNumber:
+          description: The page number.
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
+          example: 0
+        pageSize:
+          description: The number of items in a single page.
+          type: integer
+          format: int32
+          default: 100
+          minimum: 1
+          maximum: 1000
+          example: 20
+        sort:
+          $ref: '#/components/schemas/LeaderboardSnapshotSort'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+    LeaderboardSnapshot:
+      type: object
+      description: A snapshot representing the state of a leaderboard at a specific point in time.
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this snapshot
+          example: snapshot_2025-08-16_14-30
+        createdAt:
+          type: string
+          format: date-time
+          description: When this snapshot was created
+          example: '2025-08-16T14:30:00Z'
+        entryCount:
+          type: integer
+          description: Number of models in this snapshot
+          example: 50
+        description:
+          type: string
+          nullable: true
+          description: Optional description of this snapshot
+          example: Weekly evaluation run
+      required:
+        - id
+        - createdAt
+        - entryCount
+    LeaderboardSnapshotPage:
+      type: object
+      description: A page of leaderboard snapshots.
+      allOf:
+        - $ref: '#/components/schemas/PageMetadata'
+        - type: object
+          properties:
+            snapshots:
+              description: A list of leaderboard snapshots.
+              type: array
+              items:
+                $ref: '#/components/schemas/LeaderboardSnapshot'
+          required:
+            - snapshots
+  responses:
+    InternalServerError:
+      description: The request cannot be fulfilled due to an unexpected server error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    BadRequest:
+      description: Invalid request parameters
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+    NotFound:
+      description: The requested resource was not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BasicError'
+  parameters:
+    leaderboardId:
+      name: leaderboardId
+      description: The unique identifier of a leaderboard
+      in: path
+      required: true
+      schema:
+        type: string
+        example: open-source
+    leaderboardSearchQuery:
+      name: leaderboardSearchQuery
+      description: The search query used to find and filter leaderboard entries.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardSearchQuery'
+    modelId:
+      name: modelId
+      description: The unique identifier of a model
+      in: path
+      required: true
+      schema:
+        type: string
+        example: model_456
+    leaderboardModelHistoryQuery:
+      name: leaderboardModelHistoryQuery
+      description: The query used to filter and paginate historical model performance data.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardModelHistoryQuery'
+    leaderboardSnapshotQuery:
+      name: leaderboardSnapshotQuery
+      description: The query used to filter and paginate leaderboard snapshots.
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        $ref: '#/components/schemas/LeaderboardSnapshotQuery'

--- a/libs/bixarena/api-description/project.json
+++ b/libs/bixarena/api-description/project.json
@@ -1,0 +1,42 @@
+{
+  "name": "bixarena-api-description",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/bixarena/api-description/src",
+  "projectType": "library",
+  "targets": {
+    "build-individuals": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "redocly bundle api-public --output openapi/api-public.openapi.yaml",
+          "redocly bundle api-service --output openapi/api-service.openapi.yaml"
+        ],
+        "cwd": "{projectRoot}"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["redocly bundle bixarena-public --output openapi/openapi.yaml"],
+        "cwd": "{projectRoot}",
+        "parallel": false
+      },
+      "dependsOn": ["build-individuals"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "redocly lint --config redocly.yaml {projectName}"
+      },
+      "dependsOn": ["build"]
+    },
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rm -fr openapi/*",
+        "cwd": "{projectRoot}"
+      }
+    }
+  },
+  "tags": ["language:openapi", "scope:bixarena"]
+}

--- a/libs/bixarena/api-description/redocly.yaml
+++ b/libs/bixarena/api-description/redocly.yaml
@@ -1,0 +1,42 @@
+# Redocly configuration file for BixArena API
+#
+# About `x-audience`:
+# - The optional `x-audience` annotation can be applied to OpenAPI nodes such as tags, paths,
+#   components, and others.
+# - When using decorators like `filter-in` or `filter-out`, only nodes annotated with `x-audience`
+#   are evaluated for inclusion or exclusion.
+# - Nodes without an `x-audience` annotation are not affected by these filters and will always be
+#   included in the output OpenAPI files.
+# - This allows you to selectively expose or hide parts of your API for different audiences, while
+#   keeping unannotated nodes visible in all outputs.
+# - Best practice: Be intentional and always specify the `x-audience` annotation on path nodes.
+
+apis:
+  # BixArena API
+  bixarena-public:
+    root: ./openapi/api-public.openapi.yaml
+    decorators:
+      info-override:
+        version: 1.0.0
+        title: BixArena API
+        license:
+          name: Apache 2.0
+          url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+        contact:
+          name: Support
+          url: https://github.com/Sage-Bionetworks/sage-monorepo
+
+  # Main API
+  api-public:
+    root: ./src/api.openapi.yaml
+    decorators:
+      filter-in:
+        property: x-audience
+        value: [public]
+  api-service:
+    root: ./src/api.openapi.yaml
+    decorators:
+      filter-in:
+        property: x-audience
+        value: [public, internal]
+        matchStrategy: any

--- a/libs/bixarena/api-description/src/api.openapi.yaml
+++ b/libs/bixarena/api-description/src/api.openapi.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: BixArena API
+  license:
+    name: Apache 2.0
+    url: https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/LICENSE.txt
+  contact:
+    name: Support
+    url: https://github.com/Sage-Bionetworks/sage-monorepo
+servers:
+  - url: http://localhost/v1
+tags:
+  - name: Leaderboard
+    description: Operations about leaderboards.
+paths:
+  /leaderboards:
+    $ref: paths/leaderboards.yaml
+  /leaderboards/{leaderboardId}:
+    $ref: paths/leaderboards@{leaderboardId}.yaml
+  /leaderboards/{leaderboardId}/history/{modelId}:
+    $ref: paths/leaderboards@{leaderboardId}@history@{modelId}.yaml
+  /leaderboards/{leaderboardId}/snapshots:
+    $ref: paths/leaderboards@{leaderboardId}@snapshots.yaml

--- a/libs/bixarena/api-description/src/components/README.md
+++ b/libs/bixarena/api-description/src/components/README.md
@@ -1,0 +1,13 @@
+# Reusable components
+
+- You can create the following folders here:
+  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject)
+  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject)
+  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject)
+  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject)
+  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#headerObject)
+  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#requestBodyObject)
+  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#linkObject)
+  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#callbackObject)
+  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securitySchemeObject)
+- Filename of files inside the folders represent component name, e.g. `Customer.yaml`

--- a/libs/bixarena/api-description/src/components/parameters/path/leaderboardId.yaml
+++ b/libs/bixarena/api-description/src/components/parameters/path/leaderboardId.yaml
@@ -1,0 +1,7 @@
+name: leaderboardId
+description: The unique identifier of a leaderboard
+in: path
+required: true
+schema:
+  type: string
+  example: 'open-source'

--- a/libs/bixarena/api-description/src/components/parameters/path/modelId.yaml
+++ b/libs/bixarena/api-description/src/components/parameters/path/modelId.yaml
@@ -1,0 +1,7 @@
+name: modelId
+description: The unique identifier of a model
+in: path
+required: true
+schema:
+  type: string
+  example: 'model_456'

--- a/libs/bixarena/api-description/src/components/parameters/query/leaderboardModelHistoryQuery.yaml
+++ b/libs/bixarena/api-description/src/components/parameters/query/leaderboardModelHistoryQuery.yaml
@@ -1,0 +1,7 @@
+name: leaderboardModelHistoryQuery
+description: The query used to filter and paginate historical model performance data.
+in: query
+style: deepObject
+explode: true
+schema:
+  $ref: ../../schemas/LeaderboardModelHistoryQuery.yaml

--- a/libs/bixarena/api-description/src/components/parameters/query/leaderboardSearchQuery.yaml
+++ b/libs/bixarena/api-description/src/components/parameters/query/leaderboardSearchQuery.yaml
@@ -1,0 +1,7 @@
+name: leaderboardSearchQuery
+description: The search query used to find and filter leaderboard entries.
+in: query
+style: deepObject
+explode: true
+schema:
+  $ref: ../../schemas/LeaderboardSearchQuery.yaml

--- a/libs/bixarena/api-description/src/components/parameters/query/leaderboardSnapshotQuery.yaml
+++ b/libs/bixarena/api-description/src/components/parameters/query/leaderboardSnapshotQuery.yaml
@@ -1,0 +1,7 @@
+name: leaderboardSnapshotQuery
+description: The query used to filter and paginate leaderboard snapshots.
+in: query
+style: deepObject
+explode: true
+schema:
+  $ref: ../../schemas/LeaderboardSnapshotQuery.yaml

--- a/libs/bixarena/api-description/src/components/responses/BadRequest.yaml
+++ b/libs/bixarena/api-description/src/components/responses/BadRequest.yaml
@@ -1,0 +1,5 @@
+description: Invalid request parameters
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/bixarena/api-description/src/components/responses/InternalServerError.yaml
+++ b/libs/bixarena/api-description/src/components/responses/InternalServerError.yaml
@@ -1,0 +1,5 @@
+description: The request cannot be fulfilled due to an unexpected server error
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/bixarena/api-description/src/components/responses/NotFound.yaml
+++ b/libs/bixarena/api-description/src/components/responses/NotFound.yaml
@@ -1,0 +1,5 @@
+description: The requested resource was not found
+content:
+  application/problem+json:
+    schema:
+      $ref: ../schemas/BasicError.yaml

--- a/libs/bixarena/api-description/src/components/schemas/BasicError.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/BasicError.yaml
@@ -1,0 +1,26 @@
+type: object
+description: Problem details (tools.ietf.org/html/rfc7807)
+properties:
+  title:
+    type: string
+    description: A human readable documentation for the problem type
+  status:
+    type: integer
+    description: The HTTP status code
+  detail:
+    type: string
+    description: A human readable explanation specific to this occurrence of
+      the problem
+  type:
+    type: string
+    description: An absolute URI that identifies the problem type
+  instance:
+    type: string
+    description: An absolute URI that identifies the specific occurrence of
+      the problem
+required:
+  - title
+  - status
+x-java-class-annotations:
+  - '@lombok.AllArgsConstructor'
+  - '@lombok.Builder'

--- a/libs/bixarena/api-description/src/components/schemas/HistoricalLeaderboardEntry.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/HistoricalLeaderboardEntry.yaml
@@ -1,0 +1,37 @@
+type: object
+description: A historical entry representing a model's performance at a specific point in time.
+properties:
+  snapshotId:
+    type: string
+    description: Identifier for the snapshot/timepoint
+    example: 'snapshot_2025-08-15_10-00'
+  btScore:
+    type: number
+    format: double
+    description: Primary scoring metric at this point in time
+    example: 0.915
+  voteCount:
+    type: integer
+    description: Number of votes/evaluations at this point in time
+    example: 1180
+  rank:
+    type: integer
+    description: Rank position at this point in time (1-based)
+    example: 2
+  createdAt:
+    type: string
+    format: date-time
+    description: When this snapshot was created
+    example: '2025-08-15T10:00:00Z'
+  secondaryScore:
+    type: number
+    format: double
+    nullable: true
+    description: Optional secondary scoring metric at this point in time
+    example: 0.875
+required:
+  - snapshotId
+  - btScore
+  - voteCount
+  - rank
+  - createdAt

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardEntry.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardEntry.yaml
@@ -1,0 +1,52 @@
+type: object
+description: A single entry in a leaderboard representing a model's performance.
+properties:
+  id:
+    type: string
+    description: Unique identifier for this leaderboard entry
+    example: 'entry_123'
+  modelId:
+    type: string
+    description: Identifier for the model
+    example: 'model_456'
+  modelName:
+    type: string
+    description: Display name of the model
+    example: 'GPT-4o'
+  license:
+    type: string
+    description: License type of the model
+    example: 'MIT'
+  btScore:
+    type: number
+    format: double
+    description: Primary scoring metric (higher is better)
+    example: 0.925
+  voteCount:
+    type: integer
+    description: Number of votes/evaluations
+    example: 1250
+  rank:
+    type: integer
+    description: Current rank position (1-based)
+    example: 1
+  createdAt:
+    type: string
+    format: date-time
+    description: When this entry was created
+    example: '2025-08-16T10:30:00Z'
+  secondaryScore:
+    type: number
+    format: double
+    nullable: true
+    description: Optional secondary scoring metric
+    example: 0.887
+required:
+  - id
+  - modelId
+  - modelName
+  - license
+  - btScore
+  - voteCount
+  - rank
+  - createdAt

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardHistorySort.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardHistorySort.yaml
@@ -1,0 +1,8 @@
+type: string
+description: The field to sort historical entries by.
+enum:
+  - created_at
+  - bt_score
+  - rank
+default: created_at
+example: created_at

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardModelHistoryPage.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardModelHistoryPage.yaml
@@ -1,0 +1,23 @@
+type: object
+description: A page of historical leaderboard entries for a specific model.
+allOf:
+  - $ref: PageMetadata.yaml
+  - type: object
+    properties:
+      modelId:
+        type: string
+        description: Identifier for the model
+        example: 'model_456'
+      modelName:
+        type: string
+        description: Display name of the model
+        example: 'GPT-4o'
+      history:
+        description: A list of historical leaderboard entries.
+        type: array
+        items:
+          $ref: HistoricalLeaderboardEntry.yaml
+    required:
+      - modelId
+      - modelName
+      - history

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardModelHistoryQuery.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardModelHistoryQuery.yaml
@@ -1,0 +1,34 @@
+type: object
+description: A query for retrieving historical leaderboard data for a model.
+properties:
+  pageNumber:
+    description: The page number.
+    type: integer
+    format: int32
+    default: 0
+    minimum: 0
+    example: 0
+  pageSize:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    default: 100
+    minimum: 1
+    maximum: 1000
+    example: 50
+  sort:
+    $ref: LeaderboardHistorySort.yaml
+  direction:
+    $ref: SortDirection.yaml
+  fromDate:
+    description: Include only entries created on or after this date.
+    type: string
+    format: date
+    nullable: true
+    example: '2025-08-01'
+  toDate:
+    description: Include only entries created on or before this date.
+    type: string
+    format: date
+    nullable: true
+    example: '2025-08-16'

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardPage.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardPage.yaml
@@ -1,0 +1,24 @@
+type: object
+description: A page of leaderboard entries.
+allOf:
+  - $ref: PageMetadata.yaml
+  - type: object
+    properties:
+      lastUpdated:
+        type: string
+        format: date-time
+        description: When this leaderboard was last updated
+        example: '2025-08-16T14:30:00Z'
+      snapshotId:
+        type: string
+        description: Identifier for this snapshot/timepoint
+        example: 'snapshot_2025-08-16_14-30'
+      entries:
+        description: A list of leaderboard entries.
+        type: array
+        items:
+          $ref: LeaderboardEntry.yaml
+    required:
+      - lastUpdated
+      - snapshotId
+      - entries

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardSearchQuery.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardSearchQuery.yaml
@@ -1,0 +1,32 @@
+type: object
+description: A leaderboard search query with pagination and filtering options.
+properties:
+  pageNumber:
+    description: The page number.
+    type: integer
+    format: int32
+    default: 0
+    minimum: 0
+    example: 0
+  pageSize:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    default: 100
+    minimum: 1
+    maximum: 1000
+    example: 25
+  sort:
+    $ref: LeaderboardSort.yaml
+  direction:
+    $ref: SortDirection.yaml
+  search:
+    description: Search by model name (case-insensitive partial match).
+    type: string
+    nullable: true
+    example: 'gpt'
+  snapshotId:
+    description: Get a specific historical snapshot instead of latest.
+    type: string
+    nullable: true
+    example: 'snapshot_2025-08-15_10-00'

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshot.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshot.yaml
@@ -1,0 +1,25 @@
+type: object
+description: A snapshot representing the state of a leaderboard at a specific point in time.
+properties:
+  id:
+    type: string
+    description: Unique identifier for this snapshot
+    example: 'snapshot_2025-08-16_14-30'
+  createdAt:
+    type: string
+    format: date-time
+    description: When this snapshot was created
+    example: '2025-08-16T14:30:00Z'
+  entryCount:
+    type: integer
+    description: Number of models in this snapshot
+    example: 50
+  description:
+    type: string
+    nullable: true
+    description: Optional description of this snapshot
+    example: 'Weekly evaluation run'
+required:
+  - id
+  - createdAt
+  - entryCount

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshotPage.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshotPage.yaml
@@ -1,0 +1,13 @@
+type: object
+description: A page of leaderboard snapshots.
+allOf:
+  - $ref: PageMetadata.yaml
+  - type: object
+    properties:
+      snapshots:
+        description: A list of leaderboard snapshots.
+        type: array
+        items:
+          $ref: LeaderboardSnapshot.yaml
+    required:
+      - snapshots

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshotQuery.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshotQuery.yaml
@@ -1,0 +1,22 @@
+type: object
+description: A query for retrieving leaderboard snapshots.
+properties:
+  pageNumber:
+    description: The page number.
+    type: integer
+    format: int32
+    default: 0
+    minimum: 0
+    example: 0
+  pageSize:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    default: 100
+    minimum: 1
+    maximum: 1000
+    example: 20
+  sort:
+    $ref: LeaderboardSnapshotSort.yaml
+  direction:
+    $ref: SortDirection.yaml

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshotSort.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardSnapshotSort.yaml
@@ -1,0 +1,6 @@
+type: string
+description: The field to sort snapshots by.
+enum:
+  - created_at
+default: created_at
+example: created_at

--- a/libs/bixarena/api-description/src/components/schemas/LeaderboardSort.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/LeaderboardSort.yaml
@@ -1,0 +1,10 @@
+type: string
+description: The field to sort leaderboard entries by.
+enum:
+  - rank
+  - bt_score
+  - vote_count
+  - created_at
+  - model_name
+default: rank
+example: bt_score

--- a/libs/bixarena/api-description/src/components/schemas/PageMetadata.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/PageMetadata.yaml
@@ -1,0 +1,38 @@
+type: object
+description: The metadata of a page.
+properties:
+  number:
+    description: The page number.
+    type: integer
+    format: int32
+    example: 99
+  size:
+    description: The number of items in a single page.
+    type: integer
+    format: int32
+    example: 99
+  totalElements:
+    description: Total number of elements in the result set.
+    type: integer
+    format: int64
+    example: 99
+  totalPages:
+    description: Total number of pages in the result set.
+    type: integer
+    format: int32
+    example: 99
+  hasNext:
+    description: Returns if there is a next page.
+    type: boolean
+    example: true
+  hasPrevious:
+    description: Returns if there is a previous page.
+    type: boolean
+    example: true
+required:
+  - number
+  - size
+  - totalElements
+  - totalPages
+  - hasNext
+  - hasPrevious

--- a/libs/bixarena/api-description/src/components/schemas/SortDirection.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/SortDirection.yaml
@@ -1,0 +1,7 @@
+type: string
+description: The direction to sort results.
+enum:
+  - asc
+  - desc
+default: asc
+example: desc

--- a/libs/bixarena/api-description/src/paths/README.md
+++ b/libs/bixarena/api-description/src/paths/README.md
@@ -1,0 +1,107 @@
+# Paths
+
+Organize your path definitions within this folder. You will reference your paths from your main `openapi.yaml` entrypoint file.
+
+It may help you to adopt some conventions:
+
+- path separator token (e.g. `@`) or subfolders
+- path parameter (e.g. `{example}`)
+- file-per-path or file-per-operation
+
+There are different benefits and drawbacks to each decision.
+
+You can adopt any organization you wish. We have some tips for organizing paths based on common practices.
+
+## Each path in a separate file
+
+Use a predefined "path separator" and keep all of your path files in the top level of the `paths` folder.
+
+```
+# todo: insert tree view of paths folder
+```
+
+Redocly recommends using the `@` character for this case.
+
+In addition, Redocly recommends placing path parameters within `{}` curly braces if you adopt this style.
+
+#### Motivations
+
+- Quickly see a list of all paths. Many people think in terms of the "number" of "endpoints" (paths), and not the "number" of "operations" (paths \* http methods).
+
+- Only the "file-per-path" option is semantically correct with the OpenAPI Specification 3.0.2. However, Redocly's openapi-cli will build valid bundles for any of the other options too.
+
+#### Drawbacks
+
+- This may require multiple definitions per http method within a single file.
+- It requires settling on a path separator (that is allowed to be used in filenames) and sticking to that convention.
+
+## Each operation in a separate file
+
+You may also place each operation in a separate file.
+
+In this case, if you want all paths at the top-level, you can concatenate the http method to the path name. Similar to the above option, you can
+
+### Files at top-level of `paths`
+
+You may name your files with some concatenation for the http method. For example, following a convention such as: `<path with allowed separator>-<http-method>.yaml`.
+
+#### Motivations
+
+- Quickly see all operations without needing to navigate subfolders.
+
+#### Drawbacks
+
+- Adopting an unusual path separator convention, instead of using subfolders.
+
+### Use subfolders to mirror API path structure
+
+Example:
+
+```
+GET /customers
+
+/paths/customers/get.yaml
+```
+
+In this case, the path id defined within subfolders which mirror the API URL structure.
+
+Example with path parameter:
+
+```
+GET /customers/{id}
+
+/paths/customers/{id}/get.yaml
+```
+
+#### Motivations
+
+It matches the URL structure.
+
+It is pretty easy to reference:
+
+```yaml
+paths:
+  '/customers/{id}':
+    get:
+      $ref: ./paths/customers/{id}/get.yaml
+    put:
+      $ref: ./paths/customers/{id}/put.yaml
+```
+
+#### Drawbacks
+
+If you have a lot of nested folders, it may be confusing to reference your schemas.
+
+Example
+
+```
+file: /paths/customers/{id}/timeline/{messageId}/get.yaml
+
+# excerpt of file
+    headers:
+      Rate-Limit-Remaining:
+        $ref: ../../../../../components/headers/Rate-Limit-Remaining.yaml
+
+```
+
+Notice the `../../../../../` in the ref which requires some attention to formulate correctly. While openapi-cli has a linter which suggests possible refs when there is a mistake, this is still a net drawback for APIs with deep paths.

--- a/libs/bixarena/api-description/src/paths/leaderboards.yaml
+++ b/libs/bixarena/api-description/src/paths/leaderboards.yaml
@@ -1,0 +1,40 @@
+get:
+  tags:
+    - Leaderboard
+  summary: List all available leaderboards
+  description: Get a list of all available leaderboards with their metadata
+  operationId: listLeaderboards
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Unique identifier for the leaderboard
+                  example: 'open-source'
+                name:
+                  type: string
+                  description: Display name for the leaderboard
+                  example: 'Open Source Models'
+                description:
+                  type: string
+                  description: Description of what this leaderboard measures
+                  example: 'Performance ranking of open-source AI models'
+                lastUpdated:
+                  type: string
+                  format: date-time
+                  description: When this leaderboard was last updated
+                  example: '2025-08-16T14:30:00Z'
+              required:
+                - id
+                - name
+                - description
+                - lastUpdated
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml

--- a/libs/bixarena/api-description/src/paths/leaderboards@{leaderboardId}.yaml
+++ b/libs/bixarena/api-description/src/paths/leaderboards@{leaderboardId}.yaml
@@ -1,0 +1,23 @@
+get:
+  tags:
+    - Leaderboard
+  summary: Get leaderboard entries
+  description: Get paginated leaderboard entries for a specific leaderboard
+  operationId: getLeaderboard
+  x-audience: [public]
+  parameters:
+    - $ref: ../components/parameters/path/leaderboardId.yaml
+    - $ref: ../components/parameters/query/leaderboardSearchQuery.yaml
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LeaderboardPage.yaml
+    '400':
+      $ref: ../components/responses/BadRequest.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml

--- a/libs/bixarena/api-description/src/paths/leaderboards@{leaderboardId}@history@{modelId}.yaml
+++ b/libs/bixarena/api-description/src/paths/leaderboards@{leaderboardId}@history@{modelId}.yaml
@@ -1,0 +1,24 @@
+get:
+  tags:
+    - Leaderboard
+  summary: Get model performance history
+  description: Get historical performance data for a specific model in a leaderboard
+  operationId: getModelHistory
+  x-audience: [public]
+  parameters:
+    - $ref: ../components/parameters/path/leaderboardId.yaml
+    - $ref: ../components/parameters/path/modelId.yaml
+    - $ref: ../components/parameters/query/leaderboardModelHistoryQuery.yaml
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LeaderboardModelHistoryPage.yaml
+    '400':
+      $ref: ../components/responses/BadRequest.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml

--- a/libs/bixarena/api-description/src/paths/leaderboards@{leaderboardId}@snapshots.yaml
+++ b/libs/bixarena/api-description/src/paths/leaderboards@{leaderboardId}@snapshots.yaml
@@ -1,0 +1,23 @@
+get:
+  tags:
+    - Leaderboard
+  summary: Get leaderboard snapshots
+  description: Get a paginated list of available snapshots for a leaderboard
+  operationId: getLeaderboardSnapshots
+  x-audience: [public]
+  parameters:
+    - $ref: ../components/parameters/path/leaderboardId.yaml
+    - $ref: ../components/parameters/query/leaderboardSnapshotQuery.yaml
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LeaderboardSnapshotPage.yaml
+    '400':
+      $ref: ../components/responses/BadRequest.yaml
+    '404':
+      $ref: ../components/responses/NotFound.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -15,6 +15,8 @@ apis:
     root: libs/amp-als/api-description/openapi/openapi.yaml
   agora-api-description:
     root: libs/agora/api-description/openapi/openapi.yaml
+  bixarena-api-description:
+    root: libs/bixarena/api-description/openapi/openapi.yaml
   model-ad-api-description:
     root: libs/model-ad/api-description/openapi/openapi.yaml
   openchallenges-api-description:


### PR DESCRIPTION
## Description

Create the initial BixArena OpenAPI description with endpoints for the leaderboards

## Related Issue

- [SMR-402](https://sagebionetworks.jira.com/browse/SMR-402)

## Changelog

- Create the `bixarena-api-description` project based off `agora-api-description`.
- Create endpoints for accessing different leaderboards (e.g. "open-source", "comercial", "general").
- Create endpoints for accessing different snapshots of a leaderboard.
- Create endpoints for accessing the performance of a model over time.

## Preview

<!-- Demonstrate the feature or bug fix implemented in this PR. For example, -->
<!-- - a screencast that illustrates a new UI feature (e.g. using https://gifcap.dev) -->
<!-- - a request example and its response from a new/updated REST API endpoint -->
