### PR TITLE
fix(bixarena): update qwen3 model with a free version

### DIFF
--- a/apps/bixarena/app/model_config.template.json
+++ b/apps/bixarena/app/model_config.template.json
@@ -13,7 +13,7 @@
     "api_key": "${OPENAI_API_KEY}",
     "anony_only": false
   },
-  "qwen3-235b-a22b-2507": {
+  "qwen3-235b-a22b": {
     "model_name": "qwen/qwen3-235b-a22b:free",
     "api_base": "https://openrouter.ai/api/v1",
     "api_type": "openai",

--- a/apps/bixarena/app/model_config.template.json
+++ b/apps/bixarena/app/model_config.template.json
@@ -14,7 +14,7 @@
     "anony_only": false
   },
   "qwen3-235b-a22b-2507": {
-    "model_name": "qwen/qwen3-235b-a22b-2507:free",
+    "model_name": "qwen/qwen3-235b-a22b:free",
     "api_base": "https://openrouter.ai/api/v1",
     "api_type": "openai",
     "api_key": "${OPENAI_API_KEY}",


### PR DESCRIPTION
## Description

The model [qwen/qwen3-235b-a22b-2507](https://openrouter.ai/qwen/qwen3-235b-a22b-2507) no longer offers a free version, so requests to it will fail. This PR replaces it with the free Qwen3 variant: [qwen/qwen3-235b-a22b:free](https://openrouter.ai/qwen/qwen3-235b-a22b:free).

## Related Issue


## Changelog

- Replace `qwen/qwen3-235b-a22b-2507` with the available free model `qwen/qwen3-235b-a22b:free`.

## Preview

```console
 curl -X POST "https://openrouter.ai/api/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "HTTP-Referer: http://localhost:7860" \
  -H "X-Title: BixArena" \
  -d '{
    "model": "qwen/qwen3-235b-a22b:free",
    "messages": [
      {
        "role": "user", 
        "content": "Hello, can you introduce yourself?"
      }
    ],
    "max_tokens": 100,
    "temperature": 0.7
  }'

{"id":"gen-1755667723-LGHpH4DA7jS5Ring4NTV","provider":"Chutes","model":"qwen/qwen3-235b-a22b:free","object":"chat.completion","created":1755667723,"choices":[{"logprobs":null,"finish_reason":"length","native_finish_reason":"length","index":0,"message":{"role":"assistant","content":"","refusal":null,"reasoning":"\nLet me think about how to introduce myself properly. First, I need to establish my identity as Qwen3 while maintaining a friendly and approachable tone. This introduction should cover several key aspects: core capabilities, specialized skills, and personality traits. I should focus on making the information clear and relevant to the user's needs.\n\nThe user might be looking for a model that can handle both technical tasks and casual conversations. I should mention specific abilities like multilingual support and reasoning skills, but also emphasize"}}],"usage":{"prompt_tokens":16,"completion_tokens":100,"total_tokens":116}}
```