### PR TITLE
feat(model-ad): add tooltips to share link and copy link to clipboard on click (MG-364)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -359,12 +359,24 @@ test.describe('model details - boxplots selector - share links - updates', () =>
 
 test.describe('model details - boxplots selector - share links - link button', () => {
   const basePath = '/models/Abca7*V1599M/biomarkers';
-  test('clicking share link button updates fragment', async ({ page }) => {
+  test('clicking share link button updates fragment and copies link to clipboard', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read']);
+
     await page.goto(`${basePath}#soluble-a-beta-42`);
 
-    const button = page.getByRole('button', { name: 'Update URL to link to Nfl' });
+    // hover on heading, so share link appears
+    const heading = page.getByRole('heading', { level: 2, name: 'Nfl' });
+    await heading.hover();
+
+    const button = page.getByRole('button', { name: 'Copy link to Nfl' });
     await button.click();
 
     await page.waitForURL(`${basePath}#nfl`);
+
+    const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardContent).toEqual(page.url());
   });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -67,24 +67,36 @@
 
   <div class="boxplots-container" #boxplotsContainer>
     @for (evidenceType of evidenceTypes(); track evidenceType; let last = $last) {
-      <div class="boxplots-evidence-type" [id]="generateAnchorId(evidenceType)">
+      <div
+        class="boxplots-evidence-type"
+        [id]="generateAnchorId(evidenceType)"
+        (mouseenter)="activeShareLink.set(evidenceType)"
+        (mouseleave)="activeShareLink.set('')"
+      >
         <div class="boxplots-evidence-type-title-bar">
           <div class="boxplots-evidence-type-title">
             <h2>{{ evidenceType | decodeGreekEntity }}</h2>
-            <button
-              type="button"
-              (click)="scrollToSection(generateAnchorId(evidenceType))"
-              [attr.aria-describedby]="generateAnchorId(evidenceType)"
-              [attr.aria-label]="`Update URL to link to ${evidenceType | decodeGreekEntity }`"
-            >
-              <explorers-svg-icon
-                imagePath="/explorers-assets/icons/link.svg"
-                altText="link"
-                color="#878E95"
-                [height]="12"
-                [width]="24"
-              />
-            </button>
+            @if (activeShareLink() === evidenceType) {
+              <button
+                type="button"
+                (click)="copyShareLink(evidenceType)"
+                [attr.aria-describedby]="generateAnchorId(evidenceType)"
+                [attr.aria-label]="`Copy link to ${evidenceType | decodeGreekEntity }`"
+                [pTooltip]="getShareLinkTooltipText(evidenceType)"
+                (mouseenter)="showTooltip()"
+                (mouseleave)="hideTooltip()"
+                [autoHide]="false"
+                [tooltipEvent]="'focus'"
+              >
+                <explorers-svg-icon
+                  imagePath="/explorers-assets/icons/link.svg"
+                  altText="link"
+                  color="#878E95"
+                  [height]="12"
+                  [width]="24"
+                />
+              </button>
+            }
           </div>
           <explorers-download-dom-image
             [target]="getBoxplotsGridTargetByEvidenceType(evidenceType)"

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -1,3 +1,4 @@
+import { Clipboard } from '@angular/cdk/clipboard';
 import { Location } from '@angular/common';
 import {
   afterNextRender,
@@ -26,6 +27,7 @@ import {
 } from '@sagebionetworks/explorers/util';
 import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
 import { SelectModule } from 'primeng/select';
+import { Tooltip, TooltipModule } from 'primeng/tooltip';
 import { ModelDetailsBoxplotsGridComponent } from '../model-details-boxplots-grid/model-details-boxplots-grid.component';
 
 @Component({
@@ -39,6 +41,8 @@ import { ModelDetailsBoxplotsGridComponent } from '../model-details-boxplots-gri
     DecodeGreekEntityPipe,
     DownloadDomImageComponent,
     DownloadDomImagesZipComponent,
+    TooltipModule,
+    Tooltip,
   ],
   templateUrl: './model-details-boxplots-selector.component.html',
   styleUrls: ['./model-details-boxplots-selector.component.scss'],
@@ -46,7 +50,9 @@ import { ModelDetailsBoxplotsGridComponent } from '../model-details-boxplots-gri
 export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
   private readonly helperService = inject(HelperService);
   private readonly location = inject(Location);
+  private readonly clipboard = inject(Clipboard);
 
+  tooltip = viewChild(Tooltip);
   boxplotsContainer = viewChild('boxplotsContainer', { read: ElementRef });
   boxplotGrids = viewChildren(ModelDetailsBoxplotsGridComponent, { read: ElementRef });
 
@@ -75,6 +81,9 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
   private readonly SCROLL_PADDING = 15;
   isInitialScrollDone = false;
   hasInitializedOptions = false;
+
+  activeShareLink = signal('');
+  lastShareLinkCopied = signal('');
 
   constructor() {
     effect(() => {
@@ -258,6 +267,26 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
       }
     }
     return false;
+  }
+
+  getShareLinkTooltipText(evidenceType: string): string {
+    return this.lastShareLinkCopied() === evidenceType
+      ? 'URL copied to clipboard'
+      : 'Copy the URL to this section';
+  }
+
+  showTooltip() {
+    this.tooltip()?.show();
+  }
+
+  hideTooltip() {
+    this.tooltip()?.hide();
+  }
+
+  copyShareLink(evidenceType: string): void {
+    this.updateUrlFragment(this.generateAnchorId(evidenceType));
+    this.clipboard.copy(window.location.href);
+    this.lastShareLinkCopied.set(evidenceType);
   }
 
   decodeHtmlEntities(text: string): string {


### PR DESCRIPTION
## Description

Updates the model details share links functionality.

## Related Issue

- [MG-364](https://sagebionetworks.jira.com/browse/MG-364)

## Changelog

- Copy share link to clipboard on click
- Remove scroll to section header on share link click
- Add tooltip on share link hover
- Only show share link in current section, hide other share links

## Preview

`model-ad-build-images && model-ad-docker-start`
`http://localhost:4200/models/Abca7*V1599M/biomarkers`

https://github.com/user-attachments/assets/aeefc88d-54f8-40eb-bfc1-8328a6e28bd6

[MG-364]: https://sagebionetworks.jira.com/browse/MG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ