### PR TITLE
chore(agora): remove unused x-java-class-annotations from OpenAPI files (SMR-385)

### DIFF
--- a/libs/agora/api-description/openapi/api-public.openapi.yaml
+++ b/libs/agora/api-description/openapi/api-public.openapi.yaml
@@ -312,9 +312,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     BioDomain:
       type: object
       description: BioDomain

--- a/libs/agora/api-description/openapi/api-service.openapi.yaml
+++ b/libs/agora/api-description/openapi/api-service.openapi.yaml
@@ -312,9 +312,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     BioDomain:
       type: object
       description: BioDomain

--- a/libs/agora/api-description/openapi/gene-public.openapi.yaml
+++ b/libs/agora/api-description/openapi/gene-public.openapi.yaml
@@ -260,9 +260,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
   responses:
     NotFound:
       description: The specified resource was not found

--- a/libs/agora/api-description/openapi/gene-service.openapi.yaml
+++ b/libs/agora/api-description/openapi/gene-service.openapi.yaml
@@ -465,9 +465,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     TargetNomination:
       type: object
       description: TargetNomination

--- a/libs/agora/api-description/openapi/openapi.yaml
+++ b/libs/agora/api-description/openapi/openapi.yaml
@@ -312,9 +312,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     BioDomain:
       type: object
       description: BioDomain

--- a/libs/agora/api-description/src/components/schemas/BasicError.yaml
+++ b/libs/agora/api-description/src/components/schemas/BasicError.yaml
@@ -21,6 +21,3 @@ properties:
 required:
   - title
   - status
-x-java-class-annotations:
-  - '@lombok.AllArgsConstructor'
-  - '@lombok.Builder'


### PR DESCRIPTION
## Description

Remove unused x-java-class-annotations from OpenAPI files.

## Related Issue

- [SMR-385](https://sagebionetworks.jira.com/browse/SMR-385)

## Changelog

- Remove unused x-java-class-annotations from OpenAPI files.
- Generate the API clients (`nx run-many -p agora-* -t generate`).

[SMR-385]: https://sagebionetworks.jira.com/browse/SMR-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ