### PR TITLE
chore(model-ad): remove unused x-java-class-annotations from OpenAPI files (SMR-385)

### DIFF
--- a/libs/model-ad/api-description/openapi/api-public.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-public.openapi.yaml
@@ -156,9 +156,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     GeneticInfo:
       type: object
       description: Genetic information about a model

--- a/libs/model-ad/api-description/openapi/api-service.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-service.openapi.yaml
@@ -156,9 +156,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     GeneticInfo:
       type: object
       description: Genetic information about a model

--- a/libs/model-ad/api-description/openapi/openapi.yaml
+++ b/libs/model-ad/api-description/openapi/openapi.yaml
@@ -156,9 +156,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     GeneticInfo:
       type: object
       description: Genetic information about a model

--- a/libs/model-ad/api-description/src/components/schemas/BasicError.yaml
+++ b/libs/model-ad/api-description/src/components/schemas/BasicError.yaml
@@ -21,6 +21,3 @@ properties:
 required:
   - title
   - status
-x-java-class-annotations:
-  - '@lombok.AllArgsConstructor'
-  - '@lombok.Builder'


### PR DESCRIPTION
## Description

Remove unused x-java-class-annotations from OpenAPI files.

## Related Issue

- [SMR-385](https://sagebionetworks.jira.com/browse/SMR-385)

## Changelog

- Remove unused x-java-class-annotations from OpenAPI files.
- Generate the API clients (`nx run-many -p model-ad-* -t generate`).

[SMR-385]: https://sagebionetworks.jira.com/browse/SMR-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ