### PR TITLE
chore(bixarena): remove unused x-java-class-annotations from OpenAPI files (SMR-385)

### DIFF
--- a/apps/bixarena/api/src/main/resources/openapi.yaml
+++ b/apps/bixarena/api/src/main/resources/openapi.yaml
@@ -282,9 +282,6 @@ components:
         - status
         - title
       type: object
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     LeaderboardSort:
       default: rank
       description: The field to sort leaderboard entries by.

--- a/libs/bixarena/api-description/openapi/api-public.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-public.openapi.yaml
@@ -161,9 +161,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     LeaderboardSort:
       type: string
       description: The field to sort leaderboard entries by.

--- a/libs/bixarena/api-description/openapi/api-service.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-service.openapi.yaml
@@ -161,9 +161,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     LeaderboardSort:
       type: string
       description: The field to sort leaderboard entries by.

--- a/libs/bixarena/api-description/openapi/openapi.yaml
+++ b/libs/bixarena/api-description/openapi/openapi.yaml
@@ -161,9 +161,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     LeaderboardSort:
       type: string
       description: The field to sort leaderboard entries by.

--- a/libs/bixarena/api-description/src/components/schemas/BasicError.yaml
+++ b/libs/bixarena/api-description/src/components/schemas/BasicError.yaml
@@ -21,6 +21,3 @@ properties:
 required:
   - title
   - status
-x-java-class-annotations:
-  - '@lombok.AllArgsConstructor'
-  - '@lombok.Builder'


### PR DESCRIPTION
## Description

Remove unused x-java-class-annotations from OpenAPI files.

## Related Issue

- [SMR-385](https://sagebionetworks.jira.com/browse/SMR-385)

## Changelog

- Remove unused x-java-class-annotations from OpenAPI files.
- Generate the API clients (`nx run-many -p bixarena-* -t generate`).

[SMR-385]: https://sagebionetworks.jira.com/browse/SMR-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ