### PR TITLE
chore(amp-als,synapse): remove unused x-java-class-annotations from OpenAPI files (SMR-385)

### DIFF
--- a/apps/amp-als/dataset-service/src/main/resources/openapi.yaml
+++ b/apps/amp-als/dataset-service/src/main/resources/openapi.yaml
@@ -321,8 +321,6 @@ components:
             updatedAt: 2022-07-04T22:19:11Z
         totalElements: 99
       type: object
-      x-java-class-annotations:
-        - '@lombok.Builder'
     BasicError:
       description: Problem details (tools.ietf.org/html/rfc7807)
       properties:
@@ -343,6 +341,3 @@ components:
         - status
         - title
       type: object
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'

--- a/apps/amp-als/user-service/src/main/resources/openapi.yaml
+++ b/apps/amp-als/user-service/src/main/resources/openapi.yaml
@@ -87,6 +87,3 @@ components:
         - status
         - title
       type: object
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'

--- a/libs/amp-als/api-description/openapi/dataset-public.openapi.yaml
+++ b/libs/amp-als/api-description/openapi/dataset-public.openapi.yaml
@@ -201,8 +201,6 @@ components:
                 $ref: '#/components/schemas/Dataset'
           required:
             - datasets
-      x-java-class-annotations:
-        - '@lombok.Builder'
     BasicError:
       type: object
       description: Problem details (tools.ietf.org/html/rfc7807)
@@ -222,9 +220,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
   parameters:
     datasetSearchQuery:
       name: datasetSearchQuery

--- a/libs/amp-als/api-description/openapi/dataset-service.openapi.yaml
+++ b/libs/amp-als/api-description/openapi/dataset-service.openapi.yaml
@@ -201,8 +201,6 @@ components:
                 $ref: '#/components/schemas/Dataset'
           required:
             - datasets
-      x-java-class-annotations:
-        - '@lombok.Builder'
     BasicError:
       type: object
       description: Problem details (tools.ietf.org/html/rfc7807)
@@ -222,9 +220,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
   parameters:
     datasetSearchQuery:
       name: datasetSearchQuery

--- a/libs/amp-als/api-description/openapi/openapi.yaml
+++ b/libs/amp-als/api-description/openapi/openapi.yaml
@@ -222,8 +222,6 @@ components:
                 $ref: '#/components/schemas/Dataset'
           required:
             - datasets
-      x-java-class-annotations:
-        - '@lombok.Builder'
     BasicError:
       type: object
       description: Problem details (tools.ietf.org/html/rfc7807)
@@ -243,9 +241,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
     HealthCheck:
       type: object
       description: Represents the health of a service

--- a/libs/amp-als/api-description/openapi/user-public.openapi.yaml
+++ b/libs/amp-als/api-description/openapi/user-public.openapi.yaml
@@ -67,9 +67,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
   responses:
     InternalServerError:
       description: The request cannot be fulfilled due to an unexpected server error

--- a/libs/amp-als/api-description/openapi/user-service.openapi.yaml
+++ b/libs/amp-als/api-description/openapi/user-service.openapi.yaml
@@ -67,9 +67,6 @@ components:
       required:
         - title
         - status
-      x-java-class-annotations:
-        - '@lombok.AllArgsConstructor'
-        - '@lombok.Builder'
   responses:
     InternalServerError:
       description: The request cannot be fulfilled due to an unexpected server error

--- a/libs/amp-als/api-description/src/components/schemas/BasicError.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/BasicError.yaml
@@ -17,6 +17,3 @@ properties:
 required:
   - title
   - status
-x-java-class-annotations:
-  - '@lombok.AllArgsConstructor'
-  - '@lombok.Builder'

--- a/libs/amp-als/api-description/src/components/schemas/DatasetsPage.yaml
+++ b/libs/amp-als/api-description/src/components/schemas/DatasetsPage.yaml
@@ -11,5 +11,3 @@ allOf:
           $ref: Dataset.yaml
     required:
       - datasets
-x-java-class-annotations:
-  - '@lombok.Builder'

--- a/libs/synapse/api-description/src/components/schemas/BasicError.yaml
+++ b/libs/synapse/api-description/src/components/schemas/BasicError.yaml
@@ -17,5 +17,3 @@ properties:
 required:
   - title
   - status
-x-java-class-annotations:
-  - '@lombok.Builder'


### PR DESCRIPTION
## Description

Remove unused x-java-class-annotations from OpenAPI files.

## Related Issue

- [SMR-385](https://sagebionetworks.jira.com/browse/SMR-385)

## Changelog

- Remove unused x-java-class-annotations from OpenAPI files.
- Generate the API clients.

[SMR-385]: https://sagebionetworks.jira.com/browse/SMR-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ