### PR TITLE
fix(model-ad): use name instead of model for indexes (MG-322)

### DIFF
--- a/apps/model-ad/data/src/data/collections-indexes.json
+++ b/apps/model-ad/data/src/data/collections-indexes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "model_details",
-    "indexes": [{ "model": 1 }]
+    "indexes": [{ "name": 1 }]
   },
   {
     "name": "ui_config",
@@ -9,10 +9,10 @@
   },
   {
     "name": "model_overview",
-    "indexes": [{ "model": 1 }]
+    "indexes": [{ "name": 1 }]
   },
   {
     "name": "disease_correlation",
-    "indexes": [{ "model": 1 }]
+    "indexes": [{ "name": 1 }]
   }
 ]


### PR DESCRIPTION
## Description

We recently released mv70 in [MG-322](https://sagebionetworks.jira.com/browse/MG-322), which included renaming model to name across collections. We should rename the indexes to match the new field name.

## Related Issue

- [MG-322](https://sagebionetworks.jira.com/browse/MG-322)

## Changelog

- Use `name` instead of `model` in model-ad-data indexes


[MG-322]: https://sagebionetworks.jira.com/browse/MG-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-322]: https://sagebionetworks.jira.com/browse/MG-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ