### PR TITLE
feat(sage-monorepo): cache build tasks of OpenAPI projects using Nx

### DIFF
--- a/libs/agora/api-description/project.json
+++ b/libs/agora/api-description/project.json
@@ -4,8 +4,9 @@
   "sourceRoot": "libs/agora/api-description/src",
   "projectType": "library",
   "targets": {
-    "build-individuals": {
+    "build-individual-openapi": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly bundle api-public --output openapi/api-public.openapi.yaml",
@@ -18,6 +19,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly join openapi/*-public.openapi.yaml --output openapi/openapi.yaml",
@@ -26,7 +28,7 @@
         "cwd": "{projectRoot}",
         "parallel": false
       },
-      "dependsOn": ["build-individuals"]
+      "dependsOn": ["build-individual-openapi"]
     },
     "lint": {
       "executor": "nx:run-commands",

--- a/libs/amp-als/api-description/project.json
+++ b/libs/amp-als/api-description/project.json
@@ -4,8 +4,9 @@
   "sourceRoot": "libs/amp-als/api-description/src",
   "projectType": "library",
   "targets": {
-    "build-individuals": {
+    "build-individual-openapi": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly bundle dataset-service --output openapi/dataset-service.openapi.yaml",
@@ -18,6 +19,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly join openapi/*-public.openapi.yaml --output openapi/openapi.yaml",
@@ -26,7 +28,7 @@
         "cwd": "{projectRoot}",
         "parallel": false
       },
-      "dependsOn": ["build-individuals"]
+      "dependsOn": ["build-individual-openapi"]
     },
     "lint": {
       "executor": "nx:run-commands",

--- a/libs/bixarena/api-description/project.json
+++ b/libs/bixarena/api-description/project.json
@@ -4,8 +4,9 @@
   "sourceRoot": "libs/bixarena/api-description/src",
   "projectType": "library",
   "targets": {
-    "build-individuals": {
+    "build-individual-openapi": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly bundle api-public --output openapi/api-public.openapi.yaml",
@@ -16,12 +17,13 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": ["redocly bundle bixarena-public --output openapi/openapi.yaml"],
         "cwd": "{projectRoot}",
         "parallel": false
       },
-      "dependsOn": ["build-individuals"]
+      "dependsOn": ["build-individual-openapi"]
     },
     "lint": {
       "executor": "nx:run-commands",

--- a/libs/model-ad/api-description/project.json
+++ b/libs/model-ad/api-description/project.json
@@ -4,8 +4,9 @@
   "sourceRoot": "libs/model-ad/api-description/src",
   "projectType": "library",
   "targets": {
-    "build-individuals": {
+    "build-individual-openapi": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly bundle api-public --output openapi/api-public.openapi.yaml",
@@ -16,12 +17,13 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": ["redocly bundle model-ad-public --output openapi/openapi.yaml"],
         "cwd": "{projectRoot}",
         "parallel": false
       },
-      "dependsOn": ["build-individuals"]
+      "dependsOn": ["build-individual-openapi"]
     },
     "lint": {
       "executor": "nx:run-commands",

--- a/libs/openchallenges/api-description/project.json
+++ b/libs/openchallenges/api-description/project.json
@@ -4,8 +4,9 @@
   "sourceRoot": "libs/openchallenges/api-description/src",
   "projectType": "library",
   "targets": {
-    "build-individuals": {
+    "build-individual-openapi": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly bundle auth-service --output openapi/auth-service.openapi.yaml",
@@ -23,6 +24,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/openapi"],
       "options": {
         "commands": [
           "redocly join openapi/*-public.openapi.yaml --output openapi/openapi.yaml",
@@ -31,7 +33,7 @@
         "cwd": "{projectRoot}",
         "parallel": false
       },
-      "dependsOn": ["build-individuals"]
+      "dependsOn": ["build-individual-openapi"]
     },
     "lint": {
       "executor": "nx:run-commands",

--- a/nx.json
+++ b/nx.json
@@ -174,6 +174,10 @@
         "{projectRoot}/tsconfig.storybook.json"
       ]
     },
+    "build-individual-openapi": {
+      "cache": true,
+      "inputs": ["default"]
+    },
     "@nx/webpack:webpack": {
       "cache": true,
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Description

Cache build tasks of OpenAPI projects using Nx.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #(issue)

## Changelog

- Rename the task `build-individuals` to `build-individual-openapi`.
- Make the task `build-individual-openapi` cacheable in `nx.json`.
- Set `outputs` for the `build` and `build-individual-openapi` tasks.

## Preview

### Previously

The `build` and `build-individuals` tasks were not cached.

### Now

Clear the cache:

```bash
nx reset
```

Run the task a first time:

```console
$ nx build agora-api-description
...

 NX   Successfully ran target build for project agora-api-description and 1 task it depends on (10s)
```

Subsequent runs without changing any input files:

```console
$ nx build agora-api-description
...

 NX   Successfully ran target build for project agora-api-description and 1 task it depends on (436ms)
```