### PR TITLE
fix(agora): defer rendering of gene details summary charts to the browser, bump data version to align with latest release (AG-1858)

### DIFF
--- a/apps/agora/data/.env.example
+++ b/apps/agora/data/.env.example
@@ -7,6 +7,6 @@ DB_HOST="agora-mongo" # must match mongo service name
 
 # specifies data release manifest and team images folder
 DATA_FILE="syn13363290"
-DATA_VERSION="73"
+DATA_VERSION="74"
 TEAM_IMAGES_ID="syn12861877"
 SYNAPSE_AUTH_TOKEN="agora-service-user-pat-here"

--- a/libs/agora/genes/src/lib/components/gene-soe/gene-soe.component.html
+++ b/libs/agora/genes/src/lib/components/gene-soe/gene-soe.component.html
@@ -50,7 +50,9 @@
   <div class="section section-gray-100">
     <div class="section-inner">
       <div class="container-lg">
-        <agora-gene-soe-charts [gene]="gene"></agora-gene-soe-charts>
+        @defer {
+          <agora-gene-soe-charts [gene]="gene"></agora-gene-soe-charts>
+        }
       </div>
     </div>
   </div>
@@ -90,7 +92,9 @@
           </div>
         </div>
       </div>
-      <agora-gene-biodomains [gene]="gene"></agora-gene-biodomains>
+      @defer {
+        <agora-gene-biodomains [gene]="gene"></agora-gene-biodomains>
+      }
     </div>
   </div>
 }


### PR DESCRIPTION
## Description

Defers rendering of gene details summary charts to the browser to fix bug where biological domain mappings were not selectable. Suspect this bug is related to the Vite migration, where we addressed [similar issues for other charts](https://github.com/Sage-Bionetworks/sage-monorepo/pull/3243#discussion_r2181049739) in other gene details tabs.

Also bumps data version to align with latest release.

## Related Issue

- [AG-1858](https://sagebionetworks.jira.com/browse/AG-1858)

## Changelog

- Defers rendering of charts to the browser to fix bug where biological domain mappings were not selectable
- Bumps data version to align with latest release to align with latest release

## Preview

https://github.com/user-attachments/assets/3c134d48-e321-4d85-9d0d-74a769c91e6c

[AG-1858]: https://sagebionetworks.jira.com/browse/AG-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ