### PR TITLE
fix(agora): specify shared loading icon colors for agora, remove unnecessary explorers styles import (AG-1860)

### DIFF
--- a/apps/agora/app/src/app/app.component.ts
+++ b/apps/agora/app/src/app/app.component.ts
@@ -1,20 +1,21 @@
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterModule } from '@angular/router';
+import { Dataversion, DataversionService } from '@sagebionetworks/agora/api-client-angular';
+import { AGORA_LOADING_ICON_COLORS, ConfigService } from '@sagebionetworks/agora/config';
+import { HeaderComponent } from '@sagebionetworks/agora/ui';
+import { footerLinks } from '@sagebionetworks/agora/util';
+import { LOADING_ICON_COLORS } from '@sagebionetworks/explorers/constants';
 import {
   GitHubService,
   MetaTagService,
   PlatformService,
 } from '@sagebionetworks/explorers/services';
-import { HeaderComponent } from '@sagebionetworks/agora/ui';
 import { FooterComponent } from '@sagebionetworks/explorers/ui';
-import { DataversionService, Dataversion } from '@sagebionetworks/agora/api-client-angular';
-import { ConfigService } from '@sagebionetworks/agora/config';
-import { footerLinks } from '@sagebionetworks/agora/util';
 import {
   CONFIG_SERVICE_TOKEN,
-  GoogleTagManagerComponent,
   createGoogleTagManagerIdProvider,
+  GoogleTagManagerComponent,
   isGoogleTagManagerIdSet,
 } from '@sagebionetworks/shared/google-tag-manager';
 import { ToastModule } from 'primeng/toast';
@@ -28,6 +29,10 @@ import { ToastModule } from 'primeng/toast';
     {
       provide: CONFIG_SERVICE_TOKEN,
       useFactory: () => inject(ConfigService),
+    },
+    {
+      provide: LOADING_ICON_COLORS,
+      useValue: AGORA_LOADING_ICON_COLORS,
     },
     createGoogleTagManagerIdProvider(),
   ],

--- a/libs/agora/config/src/lib/constants.ts
+++ b/libs/agora/config/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { LoadingIconColors } from '@sagebionetworks/explorers/models';
+
 export const HELP_URL = 'https://help.adknowledgeportal.org/apd/Agora-Resources.2646671361.html';
 
 export const SUPPORT_EMAIL = 'agora@sagebionetworks.org';
@@ -13,3 +15,10 @@ export const ROUTE_PATHS = {
   NOT_FOUND: 'not-found',
   ERROR: 'error',
 } as const;
+
+// Use color-secondary to match agora-loading-icon
+export const AGORA_LOADING_ICON_COLORS: LoadingIconColors = {
+  colorInnermost: '#8b8ad1',
+  colorCentral: '#8b8ad1',
+  colorOutermost: '#8b8ad1',
+};

--- a/libs/explorers/util/src/lib/loading-icon/loading-icon.component.scss
+++ b/libs/explorers/util/src/lib/loading-icon/loading-icon.component.scss
@@ -1,5 +1,3 @@
-@use 'explorers/styles/src/lib/variables';
-
 .loading-icon {
   position: relative;
   width: 175px;


### PR DESCRIPTION
## Description

Specify shared loading icon colors for Agora and remove unnecessary explorers styles import to fix bug where explorers action-primary color overrode Agora's action-primary color.

## Related Issue

- [AG-1860](https://sagebionetworks.jira.com/browse/AG-1860)

## Changelog

- Specifies colors for shared loading icon in Agora
- Removes unnecessary explorers style import from loading icon component

## Preview

`agora-build-images && agora-docker-start`

The search input search result hover color is not purple after loading terms of service page: 

https://github.com/user-attachments/assets/821c09cb-cf1d-4c46-9dac-cf319112f771

[AG-1860]: https://sagebionetworks.jira.com/browse/AG-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ