### PR TITLE
fix(sage-monorepo): detect projects built with esbuild and fix Dockerfile location for image build (SMR-430)

### DIFF
--- a/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
@@ -8,12 +8,6 @@ export async function buildImageTarget(
   projectFramework: Framework | null,
   containerImageType: ContainerImageType | null,
 ): Promise<TargetConfiguration> {
-  console.log(
-    `[buildImageTarget] ENTER - projectName: ${projectName}, projectRoot: ${projectRoot}`,
-  );
-  console.log(`[buildImageTarget] projectBuilder: ${projectBuilder}`);
-  console.log(`[buildImageTarget] projectFramework: ${projectFramework}`);
-  console.log(`[buildImageTarget] containerImageType: ${containerImageType}`);
   const dependsOn = [];
 
   // Add container image template generation if needed
@@ -58,7 +52,6 @@ export async function buildImageTarget(
     dockerfile = 'Dockerfile.generated';
   }
 
-  console.log(`[buildImageTarget] EXIT - returning configuration for ${projectName}`);
   return {
     executor: '@nx-tools/nx-container:build',
     outputs: [],

--- a/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/build-image-target.ts
@@ -8,6 +8,12 @@ export async function buildImageTarget(
   projectFramework: Framework | null,
   containerImageType: ContainerImageType | null,
 ): Promise<TargetConfiguration> {
+  console.log(
+    `[buildImageTarget] ENTER - projectName: ${projectName}, projectRoot: ${projectRoot}`,
+  );
+  console.log(`[buildImageTarget] projectBuilder: ${projectBuilder}`);
+  console.log(`[buildImageTarget] projectFramework: ${projectFramework}`);
+  console.log(`[buildImageTarget] containerImageType: ${containerImageType}`);
   const dependsOn = [];
 
   // Add container image template generation if needed
@@ -40,7 +46,9 @@ export async function buildImageTarget(
   let context = projectRoot;
   // TODO: The context must be set to '.' for Angular app. Be more specific.
   // Actually, this is also valid for `agora-api` built with Webpack.
-  if (projectBuilder === 'webpack') {
+  // TODO: Consider setting the context per project types once implemented (e.g. 'angular-app')
+  // instead of per builder.
+  if (projectBuilder === 'webpack' || projectBuilder === 'esbuild') {
     context = '.';
   }
 
@@ -50,12 +58,13 @@ export async function buildImageTarget(
     dockerfile = 'Dockerfile.generated';
   }
 
+  console.log(`[buildImageTarget] EXIT - returning configuration for ${projectName}`);
   return {
     executor: '@nx-tools/nx-container:build',
     outputs: [],
     options: {
       context,
-      file: `${context}/${dockerfile}`,
+      file: `${projectRoot}/${dockerfile}`,
     },
     cache: false,
     configurations: {

--- a/libs/sage-monorepo/nx-plugin/src/plugins/project-metadata.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/project-metadata.ts
@@ -64,14 +64,19 @@ function inferBuilder(
   }
 
   const executor = localProjectConfiguration?.targets?.['build']?.executor ?? '';
-  const webpackExecutors = [
-    '@angular-devkit/build-angular:browser',
+  const webpackExecutors = ['@angular-devkit/build-angular:browser', '@nx/webpack:webpack'];
+
+  const esbuildExecutors = [
+    '@angular-devkit/build-angular:application',
+    '@angular-devkit/build-angular:browser-esbuild',
     '@nx/angular:application',
-    '@nx/webpack:webpack',
+    '@nx/esbuild:esbuild',
   ];
 
   if (webpackExecutors.includes(executor)) {
     return 'webpack';
+  } else if (esbuildExecutors.includes(executor)) {
+    return 'esbuild';
   }
 
   return null;


### PR DESCRIPTION
## Description

The bug described in [SMR-430](https://sagebionetworks.jira.com/browse/SMR-430) occurs because the plugin references the Dockerfile using an incorrect path. Specifically, the code was resolving the path relative to the Docker context instead of the project folder, where the Dockerfile actually resides.

## Related Issue

- [SMR-430](https://sagebionetworks.jira.com/browse/SMR-430)

## Changelog

- Fix the path to the Dockerfile used when building the images.
- Detect when projects use `esbuild` as the builder (not related to the bug).

## Preview

```bash
agora-build-images
model-ad-build-images
```

[SMR-430]: https://sagebionetworks.jira.com/browse/SMR-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SMR-430]: https://sagebionetworks.jira.com/browse/SMR-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ