### PR TITLE
chore: remove VS Code extension `nrwl.angular-console`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -228,7 +228,6 @@
         "mtxr.sqltools-driver-pg",
         "mtxr.sqltools",
         "njpwerner.autodocstring",
-        "nrwl.angular-console",
         "Orta.vscode-jest",
         "pranaygp.vscode-css-peek",
         "Redocly.openapi-vs-code",


### PR DESCRIPTION
## Description

Remove VS Code extension `nrwl.angular-console` that may include malicious code at this time. We are still monitoring the situation.

See https://sagebionetworks.jira.com/browse/IT-4585 for more details.