### PR TITLE
fix(model-ad): fix bug preventing display of all boxplots (MG-387, MG-392)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -128,7 +128,12 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
   });
 
   domFiles = computed(() => {
-    if (this.boxplotGrids().length === 0) return [];
+    if (
+      this.boxplotGrids().length === 0 ||
+      this.boxplotGrids().length !== this.evidenceTypes().length
+    ) {
+      return [];
+    }
 
     return this.evidenceTypes().map((evidenceType: string, index: number) => {
       return {


### PR DESCRIPTION
## Description

Model details boxplots were not displayed when a tissue was selected that included more evidence types than the previous tissue because the code attempted to access the `nativeElement` before the new boxplot elements had been added to the DOM.

The same bug is also preventing the boxplots from updating when changing the tissue type.

## Related Issue

- [MG-387](https://sagebionetworks.jira.com/browse/MG-387)
- [MG-392](https://sagebionetworks.jira.com/browse/MG-392)

## Changelog

- Fixes bug preventing the display of model details boxplots

## Preview

All evidence types shown: 

https://github.com/user-attachments/assets/497e3165-f692-4d73-9ad5-7f41b5c788ee

Boxplots are updated when tissue is changed: 

https://github.com/user-attachments/assets/8b28ac71-0ce0-4259-906f-368f73fd08ef


[MG-387]: https://sagebionetworks.jira.com/browse/MG-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MG-392]: https://sagebionetworks.jira.com/browse/MG-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ