### PR TITLE
chore(model-ad): bump model-ad-data to mv84 and align models with updated data structure (MG-362)

### DIFF
--- a/apps/model-ad/api/src/models/modelOverviewComparisonTool.ts
+++ b/apps/model-ad/api/src/models/modelOverviewComparisonTool.ts
@@ -10,7 +10,7 @@ const ModelOverviewSchema = new Schema<ModelOverview>(
   {
     name: { type: String, required: true },
     model_type: { type: String, required: true },
-    matched_controls: { type: String, required: true },
+    matched_controls: { type: [String], required: true },
     gene_expression: { type: ModelOverviewLinkSchema, required: false },
     disease_correlation: { type: ModelOverviewLinkSchema, required: false },
     biomarkers: { type: ModelOverviewLinkSchema, required: false },

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="70"
+DATA_VERSION="83"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/apps/model-ad/data/.env.example
+++ b/apps/model-ad/data/.env.example
@@ -7,5 +7,5 @@ DB_HOST="model-ad-mongo" # must match mongo service name
 
 # specifies data release manifest
 DATA_FILE="syn63540270"
-DATA_VERSION="83"
+DATA_VERSION="84"
 SYNAPSE_AUTH_TOKEN="model-ad-service-user-pat-here"

--- a/libs/model-ad/api-client-angular/src/lib/model/modelOverview.ts
+++ b/libs/model-ad/api-client-angular/src/lib/model/modelOverview.ts
@@ -22,9 +22,9 @@ export interface ModelOverview {
    */
   model_type: string;
   /**
-   * A comma-delimited list of matched control models
+   * List of matched control models
    */
-  matched_controls: string;
+  matched_controls: Array<string>;
   gene_expression?: ModelOverviewLink;
   disease_correlation?: ModelOverviewLink;
   biomarkers?: ModelOverviewLink;

--- a/libs/model-ad/api-client-angular/src/lib/model/modelOverview.ts
+++ b/libs/model-ad/api-client-angular/src/lib/model/modelOverview.ts
@@ -25,13 +25,13 @@ export interface ModelOverview {
    * A comma-delimited list of matched control models
    */
   matched_controls: string;
-  gene_expression?: ModelOverviewLink | null;
-  disease_correlation?: ModelOverviewLink | null;
-  biomarkers?: ModelOverviewLink | null;
-  pathology?: ModelOverviewLink | null;
-  study_data: ModelOverviewLink | null;
-  jax_strain: ModelOverviewLink | null;
-  center: ModelOverviewLink | null;
+  gene_expression?: ModelOverviewLink;
+  disease_correlation?: ModelOverviewLink;
+  biomarkers?: ModelOverviewLink;
+  pathology?: ModelOverviewLink;
+  study_data: ModelOverviewLink;
+  jax_strain: ModelOverviewLink;
+  center: ModelOverviewLink;
   /**
    * List of modified genes in the model
    */

--- a/libs/model-ad/api-description/openapi/api-public.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-public.openapi.yaml
@@ -443,8 +443,10 @@ components:
           type: string
           description: Model type (e.g., Late Onset AD, Familial AD)
         matched_controls:
-          type: string
-          description: A comma-delimited list of matched control models
+          type: array
+          items:
+            type: string
+          description: List of matched control models
         gene_expression:
           $ref: '#/components/schemas/ModelOverviewLink'
           nullable: true

--- a/libs/model-ad/api-description/openapi/api-public.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-public.openapi.yaml
@@ -432,17 +432,6 @@ components:
         link_url:
           type: string
           description: URL for the related resource
-      oneOf:
-        - required:
-            - link_text
-          not:
-            required:
-              - link_url
-        - required:
-            - link_url
-          not:
-            required:
-              - link_text
     ModelOverview:
       type: object
       description: Model Overview object for comparison tools

--- a/libs/model-ad/api-description/openapi/api-service.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-service.openapi.yaml
@@ -443,8 +443,10 @@ components:
           type: string
           description: Model type (e.g., Late Onset AD, Familial AD)
         matched_controls:
-          type: string
-          description: A comma-delimited list of matched control models
+          type: array
+          items:
+            type: string
+          description: List of matched control models
         gene_expression:
           $ref: '#/components/schemas/ModelOverviewLink'
           nullable: true

--- a/libs/model-ad/api-description/openapi/api-service.openapi.yaml
+++ b/libs/model-ad/api-description/openapi/api-service.openapi.yaml
@@ -432,17 +432,6 @@ components:
         link_url:
           type: string
           description: URL for the related resource
-      oneOf:
-        - required:
-            - link_text
-          not:
-            required:
-              - link_url
-        - required:
-            - link_url
-          not:
-            required:
-              - link_text
     ModelOverview:
       type: object
       description: Model Overview object for comparison tools

--- a/libs/model-ad/api-description/openapi/openapi.yaml
+++ b/libs/model-ad/api-description/openapi/openapi.yaml
@@ -443,8 +443,10 @@ components:
           type: string
           description: Model type (e.g., Late Onset AD, Familial AD)
         matched_controls:
-          type: string
-          description: A comma-delimited list of matched control models
+          type: array
+          items:
+            type: string
+          description: List of matched control models
         gene_expression:
           $ref: '#/components/schemas/ModelOverviewLink'
           nullable: true

--- a/libs/model-ad/api-description/openapi/openapi.yaml
+++ b/libs/model-ad/api-description/openapi/openapi.yaml
@@ -432,17 +432,6 @@ components:
         link_url:
           type: string
           description: URL for the related resource
-      oneOf:
-        - required:
-            - link_text
-          not:
-            required:
-              - link_url
-        - required:
-            - link_url
-          not:
-            required:
-              - link_text
     ModelOverview:
       type: object
       description: Model Overview object for comparison tools

--- a/libs/model-ad/api-description/src/components/schemas/ModelOverview.yaml
+++ b/libs/model-ad/api-description/src/components/schemas/ModelOverview.yaml
@@ -8,8 +8,10 @@ properties:
     type: string
     description: Model type (e.g., Late Onset AD, Familial AD)
   matched_controls:
-    type: string
-    description: A comma-delimited list of matched control models
+    type: array
+    items:
+      type: string
+    description: List of matched control models
   gene_expression:
     $ref: './ModelOverviewLink.yaml'
     nullable: true

--- a/libs/model-ad/api-description/src/components/schemas/ModelOverviewLink.yaml
+++ b/libs/model-ad/api-description/src/components/schemas/ModelOverviewLink.yaml
@@ -7,10 +7,3 @@ properties:
   link_url:
     type: string
     description: URL for the related resource
-oneOf:
-  - required: [link_text]
-    not:
-      required: [link_url]
-  - required: [link_url]
-    not:
-      required: [link_text]

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/components/model-overview-main-table/model-overview-main-table.component.html
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/components/model-overview-main-table/model-overview-main-table.component.html
@@ -4,7 +4,7 @@
       <td></td>
       <td>{{ modelData.name }}</td>
       <td>{{ modelData.model_type }}</td>
-      <td>{{ modelData.matched_controls }}</td>
+      <td>{{ modelData.matched_controls | commaSeparate }}</td>
       <td>
         <explorers-comparison-tool-table-link
           [linkText]="modelData.gene_expression?.link_text || 'Results'"

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/components/model-overview-main-table/model-overview-main-table.component.ts
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/components/model-overview-main-table/model-overview-main-table.component.ts
@@ -1,13 +1,14 @@
-import { Component, ViewChild, input, inject } from '@angular/core';
+import { Component, ViewChild, inject, input } from '@angular/core';
+import { ComparisonToolTableLinkComponent } from '@sagebionetworks/explorers/comparison-tools';
 import { ComparisonToolService } from '@sagebionetworks/explorers/services';
+import { CommaSeparatePipe } from '@sagebionetworks/explorers/util';
 import { ModelOverview } from '@sagebionetworks/model-ad/api-client-angular';
 import { Table, TableModule } from 'primeng/table';
 import { TooltipModule } from 'primeng/tooltip';
-import { ComparisonToolTableLinkComponent } from '@sagebionetworks/explorers/comparison-tools';
 
 @Component({
   selector: 'model-ad-model-overview-main-table',
-  imports: [TableModule, TooltipModule, ComparisonToolTableLinkComponent],
+  imports: [TableModule, TooltipModule, ComparisonToolTableLinkComponent, CommaSeparatePipe],
   templateUrl: './model-overview-main-table.component.html',
   styleUrls: ['./model-overview-main-table.component.scss'],
 })


### PR DESCRIPTION
## Description

Bump model-ad-data to mv84 and align models with updated data structure. 

> [!NOTE]
> The "no data" boxplot placeholder styling will be handled in [MG-317](https://sagebionetworks.jira.com/browse/MG-317).

## Related Issue

- [MG-362](https://sagebionetworks.jira.com/browse/MG-362)
- [MG-356](https://sagebionetworks.jira.com/browse/MG-356)
- [MG-329](https://sagebionetworks.jira.com/browse/MG-329)

## Changelog

- Bumps model-ad-data to mv84
- Remove mutual exclusivity from model overview link schema; `link_text` and `link_url` are not mutually exclusive in mv83 (see [MG-356](https://sagebionetworks.jira.com/browse/MG-356))
- Change model overview `matched_controls` from a string to a list to align with mv84 (see [MG-329](https://sagebionetworks.jira.com/browse/MG-329))

## Preview

`model-ad-build-images && model-ad-docker-start`

feature | current dev site | this feature branch
:---: | :---: | :---: 
model overview - display of the matched controls is unchanged (even though backing data changed from string to list in mv84) | <img width="1624" height="1056" alt="dev_modelOverview_matchedControls" src="https://github.com/user-attachments/assets/05c6d7df-4ad2-4fa9-bc57-da788b420896" /> | <img width="1624" height="1056" alt="MG-362_modelOverview_matchedControls" src="https://github.com/user-attachments/assets/c9b5462a-6357-4bef-94ff-0fb5b11f6b62" />
model details - no data placeholder added in mv84 | <img width="603" height="460" alt="dev_modelDetails_noData" src="https://github.com/user-attachments/assets/e341a0df-a034-4f76-b707-58dc3a95283f" /> | <img width="620" height="668" alt="MG-362_modelDetails_noData" src="https://github.com/user-attachments/assets/dde478b4-538f-4302-ab70-0d40cece8376" />

[MG-317]: https://sagebionetworks.jira.com/browse/MG-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-362]: https://sagebionetworks.jira.com/browse/MG-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-356]: https://sagebionetworks.jira.com/browse/MG-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-329]: https://sagebionetworks.jira.com/browse/MG-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-356]: https://sagebionetworks.jira.com/browse/MG-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-329]: https://sagebionetworks.jira.com/browse/MG-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ