### PR TITLE
feat(model-ad): align style of "no data" boxplot placeholder with design, fix bug where legend is not displayed when last boxplot doesn't have data (MG-317)

### DIFF
--- a/libs/model-ad/config/src/lib/constants.ts
+++ b/libs/model-ad/config/src/lib/constants.ts
@@ -1,4 +1,5 @@
 import { LoadingIconColors } from '@sagebionetworks/explorers/models';
+import { PointStyle } from '@sagebionetworks/shared/charts';
 
 export const HELP_URL =
   'https://help.adknowledgeportal.org/apd/Model-AD+Explorer+Resources.4077682781.html';
@@ -23,3 +24,18 @@ export const ROUTE_PATHS = {
   NOT_FOUND: 'not-found',
   ERROR: 'error',
 } as const;
+
+export const MODEL_DETAILS_BOXPLOT_POINT_STYLES: PointStyle[] = [
+  {
+    label: 'Female',
+    color: '#DB00FF',
+    shape: 'triangle',
+    opacity: 0.5,
+  },
+  {
+    label: 'Male',
+    color: '#1B00B3',
+    shape: 'circle',
+    opacity: 0.5,
+  },
+];

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -11,4 +11,5 @@
   [pointCategoryShapes]="pointCategoryShapes"
   [showLegend]="showLegend()"
   [pointOpacity]="0.5"
+  [noDataStyle]="'grayBackground'"
 ></div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -2,6 +2,7 @@ import { TitleCasePipe } from '@angular/common';
 import { Component, computed, inject, input } from '@angular/core';
 import { DecodeGreekEntityPipe } from '@sagebionetworks/explorers/util';
 import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
+import { MODEL_DETAILS_BOXPLOT_POINT_STYLES } from '@sagebionetworks/model-ad/config';
 import { CategoryPoint, getTextWidth } from '@sagebionetworks/shared/charts';
 import { BoxplotDirective } from '@sagebionetworks/shared/charts-angular';
 import { CallbackDataParams } from 'echarts/types/dist/shared';
@@ -20,15 +21,13 @@ export class ModelDetailsBoxplotComponent {
   private readonly X_AXIS_LABEL_MAX_WIDTH = 100;
   private readonly X_AXIS_LABEL_FONT = "bold 14px 'DM Sans Variable', sans-serif";
 
-  pointCategoryColors = {
-    Male: '#1B00B3',
-    Female: '#DB00FF',
-  };
+  pointCategoryColors = Object.fromEntries(
+    MODEL_DETAILS_BOXPLOT_POINT_STYLES.map((style) => [style.label, style.color]),
+  );
 
-  pointCategoryShapes = {
-    Male: 'circle',
-    Female: 'triangle',
-  };
+  pointCategoryShapes = Object.fromEntries(
+    MODEL_DETAILS_BOXPLOT_POINT_STYLES.map((style) => [style.label, style.shape]),
+  );
 
   modelData = input.required<ModelData>();
   sexes = input.required<IndividualData.SexEnum[]>();

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.html
@@ -3,8 +3,9 @@
     <model-ad-model-details-boxplot
       [modelData]="modelData"
       [sexes]="sexes()"
-      [showLegend]="i === legendIndex()"
+      [showLegend]="false"
       [genotypeOrder]="genotypeOrder()"
     />
   }
 </div>
+<div class="boxplots-grid-legend" sageLegend [pointStyles]="pointStyles()"></div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
@@ -14,3 +14,8 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.boxplots-grid-legend {
+  display: flex;
+  margin-top: 30px;
+}

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.ts
@@ -1,39 +1,23 @@
-import { BreakpointObserver } from '@angular/cdk/layout';
-import { Component, computed, inject, input } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { BreakpointConfigService } from '@sagebionetworks/explorers/services';
+import { Component, computed, input } from '@angular/core';
 import { IndividualData, ModelData } from '@sagebionetworks/model-ad/api-client-angular';
+import { MODEL_DETAILS_BOXPLOT_POINT_STYLES } from '@sagebionetworks/model-ad/config';
+import { LegendDirective } from '@sagebionetworks/shared/charts-angular';
 import { ModelDetailsBoxplotComponent } from '../model-details-boxplot/model-details-boxplot.component';
 
 @Component({
   selector: 'model-ad-model-details-boxplots-grid',
-  imports: [ModelDetailsBoxplotComponent],
+  imports: [ModelDetailsBoxplotComponent, LegendDirective],
   templateUrl: './model-details-boxplots-grid.component.html',
   styleUrls: ['./model-details-boxplots-grid.component.scss'],
 })
 export class ModelDetailsBoxplotsGridComponent {
-  private readonly breakpointObserver = inject(BreakpointObserver);
-  private readonly breakpointConfigService = inject(BreakpointConfigService);
-
   modelDataList = input.required<ModelData[]>();
   genotypeOrder = input<string[] | undefined>();
   sexes = input.required<IndividualData.SexEnum[]>();
 
-  private readonly observeLargeScreen = toSignal(
-    this.breakpointObserver.observe(`(min-width: ${this.breakpointConfigService.largeBreakpoint})`),
-    { initialValue: { matches: false, breakpoints: {} } },
-  );
-
-  legendIndex = computed(() => {
-    const totalPlots = this.modelDataList().length;
-    const isLargeScreen = this.observeLargeScreen().matches ?? false;
-
-    if (!isLargeScreen) {
-      // 1-column layout: legend on last plot
-      return totalPlots - 1;
-    } else {
-      // 2-column layout: legend on leftmost of last row
-      return totalPlots % 2 === 0 ? totalPlots - 2 : totalPlots - 1;
-    }
+  pointStyles = computed(() => {
+    return MODEL_DETAILS_BOXPLOT_POINT_STYLES.filter((pointStyle) =>
+      this.sexes().includes(pointStyle.label as IndividualData.SexEnum),
+    );
   });
 }

--- a/libs/shared/typescript/charts-angular/src/index.ts
+++ b/libs/shared/typescript/charts-angular/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/boxplot';
+export * from './lib/legend';

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -28,6 +28,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [pointCategoryShapes]="pointCategoryShapes"
       [showLegend]="showLegend"
       [pointOpacity]="pointOpacity"
+      [noDataStyle]="noDataStyle"
     ></div>`,
   })
   class TestComponent {
@@ -46,6 +47,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
     pointCategoryShapes = props.pointCategoryShapes;
     showLegend = props.showLegend;
     pointOpacity = props.pointOpacity;
+    noDataStyle = props.noDataStyle;
   }
 
   return await render(TestComponent, {

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -18,7 +18,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisCategoryToTooltipText]="xAxisCategoryToTooltipText" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle"></div>`,
   }),
 };
 export default meta;
@@ -63,5 +63,6 @@ export const DynamicSummary: Story = {
     pointCategoryShapes: { Male: 'circle', Female: 'triangle' },
     showLegend: true,
     pointOpacity: 0.5,
+    noDataStyle: 'grayBackground',
   },
 };

--- a/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -33,6 +33,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() pointCategoryShapes: undefined | Record<string, string>;
   @Input() showLegend: undefined | boolean;
   @Input() pointOpacity: undefined | number;
+  @Input() noDataStyle: undefined | 'textOnly' | 'grayBackground';
 
   ngOnInit() {
     this.boxplot = new BoxplotChart(this.el.nativeElement, this.getBoxplotProps());
@@ -63,6 +64,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       pointCategoryShapes: this.pointCategoryShapes,
       showLegend: this.showLegend,
       pointOpacity: this.pointOpacity,
+      noDataStyle: this.noDataStyle,
     };
   }
 }

--- a/libs/shared/typescript/charts-angular/src/lib/legend/index.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/legend/index.ts
@@ -1,0 +1,1 @@
+export * from './legend.directive';

--- a/libs/shared/typescript/charts-angular/src/lib/legend/legend.directive.spec.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/legend/legend.directive.spec.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { LegendProps, mockPointStyles } from '@sagebionetworks/shared/charts';
+import { render } from '@testing-library/angular';
+import { LegendDirective } from './legend.directive';
+
+const renderTestComponent = async (props: LegendProps) => {
+  @Component({
+    imports: [LegendDirective],
+    template: `<div sageLegend [pointStyles]="pointStyles"></div>`,
+  })
+  class TestComponent {
+    pointStyles = props.pointStyles;
+  }
+
+  return await render(TestComponent, {
+    imports: [LegendDirective],
+  });
+};
+
+describe('LegendDirective', () => {
+  it('should create with empty array', async () => {
+    const { fixture } = await renderTestComponent({ pointStyles: [] });
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should create with data', async () => {
+    const { fixture } = await renderTestComponent({ pointStyles: mockPointStyles });
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});

--- a/libs/shared/typescript/charts-angular/src/lib/legend/legend.directive.stories.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/legend/legend.directive.stories.ts
@@ -1,0 +1,26 @@
+import { LegendProps, mockPointStyles } from '@sagebionetworks/shared/charts';
+import { Meta, StoryObj } from '@storybook/angular';
+import { LegendDirective } from './legend.directive';
+
+const meta: Meta<LegendDirective> = {
+  component: LegendDirective,
+  title: 'directives/sageLegend',
+  render: (args: LegendProps) => ({
+    props: args,
+    template: `<div sageLegend [pointStyles]="pointStyles"></div>`,
+  }),
+};
+export default meta;
+type Story = StoryObj<LegendDirective>;
+
+export const NoData: Story = {
+  args: {
+    pointStyles: [],
+  },
+};
+
+export const Demo: Story = {
+  args: {
+    pointStyles: mockPointStyles,
+  },
+};

--- a/libs/shared/typescript/charts-angular/src/lib/legend/legend.directive.ts
+++ b/libs/shared/typescript/charts-angular/src/lib/legend/legend.directive.ts
@@ -1,0 +1,32 @@
+import { Directive, ElementRef, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { LegendChart, LegendProps, PointStyle } from '@sagebionetworks/shared/charts';
+
+@Directive({
+  selector: '[sageLegend]',
+  standalone: true,
+})
+export class LegendDirective implements OnChanges, OnInit, OnDestroy {
+  private readonly el = inject(ElementRef);
+
+  legend: LegendChart | undefined;
+
+  @Input({ required: true }) pointStyles: PointStyle[] = [];
+
+  ngOnInit() {
+    this.legend = new LegendChart(this.el.nativeElement, this.getLegendProps());
+  }
+
+  ngOnChanges(): void {
+    this.legend?.setOptions(this.getLegendProps());
+  }
+
+  ngOnDestroy() {
+    this.legend?.destroy();
+  }
+
+  private getLegendProps(): LegendProps {
+    return {
+      pointStyles: this.pointStyles,
+    };
+  }
+}

--- a/libs/shared/typescript/charts/src/index.ts
+++ b/libs/shared/typescript/charts/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/boxplot-chart';
+export * from './lib/legend-chart';
 export * from './lib/mocks';
 export * from './lib/models';
 export * from './lib/utils';

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -1,4 +1,5 @@
 import { DatasetComponentOption, ECharts, EChartsOption, SeriesOption } from 'echarts';
+import { DEFAULT_POINT_SIZE } from '../constants';
 import { BoxplotProps, CategoryPoint } from '../models';
 import {
   addXAxisValueToBoxplotSummaries,
@@ -26,7 +27,6 @@ const boxplotStyle = {
 
 const yAxisPadding = 0.2;
 const defaultPointShape = 'circle';
-const defaultPointSize = 18;
 const defaultPointColor = '#8b8ad1';
 const defaultPointOpacity = 0.8;
 
@@ -96,7 +96,7 @@ export class BoxplotChart {
       points,
       xAxisCategories,
       pointCategories,
-      0.1,
+      0.3,
       0.02,
     );
     const dataForStaticBoxplotSummaries = summaries
@@ -194,7 +194,7 @@ export class BoxplotChart {
           x: 'xAxisValue',
           y: 'value',
         },
-        symbolSize: defaultPointSize,
+        symbolSize: DEFAULT_POINT_SIZE,
         symbol:
           id === 'points'
             ? defaultPointShape
@@ -262,8 +262,8 @@ export class BoxplotChart {
         orient: 'horizontal',
         left: 'left',
         top: 'bottom',
-        itemHeight: defaultPointSize,
-        itemWidth: defaultPointSize,
+        itemHeight: DEFAULT_POINT_SIZE,
+        itemWidth: DEFAULT_POINT_SIZE,
         selectedMode: false,
       },
       grid: {

--- a/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -74,12 +74,13 @@ export class BoxplotChart {
     } = boxplotProps;
 
     const showLegend = boxplotProps.showLegend || false;
+    const noDataStyle = boxplotProps.noDataStyle || 'textOnly';
 
     const noPoints = points.length === 0;
     const noSummaries = summaries == null || summaries.length === 0;
 
     if (noPoints && noSummaries) {
-      setNoDataOption(this.chart);
+      setNoDataOption(this.chart, noDataStyle);
       return;
     }
 

--- a/libs/shared/typescript/charts/src/lib/constants.ts
+++ b/libs/shared/typescript/charts/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_POINT_SIZE = 18;

--- a/libs/shared/typescript/charts/src/lib/legend-chart/index.ts
+++ b/libs/shared/typescript/charts/src/lib/legend-chart/index.ts
@@ -1,0 +1,1 @@
+export * from './legend-chart';

--- a/libs/shared/typescript/charts/src/lib/legend-chart/legend-chart.ts
+++ b/libs/shared/typescript/charts/src/lib/legend-chart/legend-chart.ts
@@ -1,0 +1,52 @@
+import { ECharts, EChartsOption } from 'echarts';
+import { DEFAULT_POINT_SIZE } from '../constants';
+import { LegendProps } from '../models';
+import { initChart } from '../utils';
+
+export class LegendChart {
+  private readonly INITIAL_CHART_HEIGHT = '25px';
+  chart: ECharts | undefined;
+
+  constructor(chartDom: HTMLDivElement | HTMLCanvasElement, legendProps: LegendProps) {
+    this.chart = initChart(chartDom, this.INITIAL_CHART_HEIGHT);
+    this.setOptions(legendProps);
+  }
+
+  destroy() {
+    this.chart?.dispose();
+  }
+
+  setOptions(legendProps: LegendProps) {
+    if (!this.chart) return;
+
+    const { pointStyles } = legendProps;
+
+    const option: EChartsOption = {
+      legend: {
+        data: pointStyles.map((item) => item.label),
+        orient: 'horizontal',
+        left: 'left',
+        top: 'bottom',
+        itemHeight: DEFAULT_POINT_SIZE,
+        itemWidth: DEFAULT_POINT_SIZE,
+        selectedMode: false,
+      },
+      xAxis: { show: false },
+      yAxis: { show: false },
+      series: pointStyles.map((item) => ({
+        name: item.label,
+        type: 'scatter',
+        symbol: item.shape,
+        data: [[0, 0]], // single dummy point
+        itemStyle: {
+          color: item.color,
+          opacity: item.opacity,
+        },
+        symbolSize: DEFAULT_POINT_SIZE,
+      })),
+    };
+
+    // notMerge must be set to true to override any existing options set on the chart
+    this.chart.setOption(option, true);
+  }
+}

--- a/libs/shared/typescript/charts/src/lib/mocks/index.ts
+++ b/libs/shared/typescript/charts/src/lib/mocks/index.ts
@@ -1,1 +1,2 @@
 export * from './mock-boxplot-data';
+export * from './mock-point-styles';

--- a/libs/shared/typescript/charts/src/lib/mocks/mock-point-styles.ts
+++ b/libs/shared/typescript/charts/src/lib/mocks/mock-point-styles.ts
@@ -1,0 +1,16 @@
+import { PointStyle } from '../models';
+
+export const mockPointStyles: PointStyle[] = [
+  {
+    label: 'Female',
+    color: '#DB00FF',
+    shape: 'triangle',
+    opacity: 0.5,
+  },
+  {
+    label: 'Male',
+    color: '#1B00B3',
+    shape: 'circle',
+    opacity: 0.5,
+  },
+];

--- a/libs/shared/typescript/charts/src/lib/models/boxplot.ts
+++ b/libs/shared/typescript/charts/src/lib/models/boxplot.ts
@@ -67,4 +67,5 @@ export interface BoxplotProps {
   pointCategoryShapes?: Record<string, string>;
   showLegend?: boolean;
   pointOpacity?: number;
+  noDataStyle?: 'textOnly' | 'grayBackground';
 }

--- a/libs/shared/typescript/charts/src/lib/models/index.ts
+++ b/libs/shared/typescript/charts/src/lib/models/index.ts
@@ -5,10 +5,13 @@ import type {
   CategoryBoxplotSummary,
   CategoryPoint,
 } from './boxplot';
+import type { LegendProps, PointStyle } from './legend';
 export {
   BoxplotProps,
   CategoryAsValueBoxplotSummary,
   CategoryAsValuePoint,
   CategoryBoxplotSummary,
   CategoryPoint,
+  LegendProps,
+  PointStyle,
 };

--- a/libs/shared/typescript/charts/src/lib/models/legend.ts
+++ b/libs/shared/typescript/charts/src/lib/models/legend.ts
@@ -1,0 +1,10 @@
+export interface PointStyle {
+  label: string;
+  color: string;
+  shape: string;
+  opacity: number;
+}
+
+export interface LegendProps {
+  pointStyles: PointStyle[];
+}

--- a/libs/shared/typescript/charts/src/lib/utils/chart-utils.ts
+++ b/libs/shared/typescript/charts/src/lib/utils/chart-utils.ts
@@ -29,14 +29,28 @@ export function resizeChartOnWindowResize(
   resizeObserver.observe(chartDom);
 }
 
-export function setNoDataOption(chart: ECharts) {
-  const noDataOptions: EChartsOption = {
-    title: {
+export function setNoDataOption(chart: ECharts, noDataStyle: 'textOnly' | 'grayBackground') {
+  const noDataStyleOptions = {
+    textOnly: {
       text: 'No data is currently available.',
+      textColor: 'rgb(174, 181, 188)',
+      backgroundColor: 'transparent',
+    },
+    grayBackground: {
+      text: 'Data unavailable',
+      textColor: '#4A5056',
+      backgroundColor: '#DFE2E6',
+    },
+  };
+
+  const noDataOptions: EChartsOption = {
+    backgroundColor: noDataStyleOptions[noDataStyle].backgroundColor,
+    title: {
+      text: noDataStyleOptions[noDataStyle].text,
       left: 'center',
       top: 'middle',
       textStyle: {
-        color: 'rgb(174, 181, 188)',
+        color: noDataStyleOptions[noDataStyle].textColor,
         fontStyle: 'italic',
         fontWeight: 400,
         fontSize: 18,
@@ -45,7 +59,7 @@ export function setNoDataOption(chart: ECharts) {
     aria: {
       enabled: true,
       label: {
-        description: 'No data is currently available.',
+        description: noDataStyleOptions[noDataStyle].text,
       },
     },
   };

--- a/libs/shared/typescript/charts/src/lib/utils/chart-utils.ts
+++ b/libs/shared/typescript/charts/src/lib/utils/chart-utils.ts
@@ -2,16 +2,19 @@ import * as echarts from 'echarts';
 import { ECharts, EChartsOption } from 'echarts';
 
 // Chart must have initial height to be visible
-export function ensureChartDomHasHeight(chartDom: HTMLDivElement | HTMLCanvasElement) {
+export function ensureChartDomHasHeight(
+  chartDom: HTMLDivElement | HTMLCanvasElement,
+  initialHeight = '350px',
+) {
   const computedHeight = window.getComputedStyle(chartDom, null).getPropertyValue('height');
   const inlineHeight = chartDom.style.height;
   if (!computedHeight || computedHeight === '0px' || !inlineHeight || inlineHeight === '0px') {
-    chartDom.style.height = '350px';
+    chartDom.style.height = initialHeight;
   }
 }
 
-export function initChart(chartDom: HTMLDivElement | HTMLCanvasElement) {
-  ensureChartDomHasHeight(chartDom);
+export function initChart(chartDom: HTMLDivElement | HTMLCanvasElement, initialHeight = '350px') {
+  ensureChartDomHasHeight(chartDom, initialHeight);
   const chart = echarts.init(chartDom);
   resizeChartOnWindowResize(chartDom, chart);
   return chart;


### PR DESCRIPTION
## Description

The Model-AD model details data was recently updated to include placeholders for ages that don't have data, but should still be displayed in the boxplots grid. Here, we align the style of the "no data" boxplot placeholder with the design. We also fix a bug where the legend is not displayed when the last boxplot doesn't have data by creating a new legend component that is displayed in a separate row below the boxplots.

## Related Issue

[MG-317](https://sagebionetworks.jira.com/browse/MG-317)

## Changelog

- Adds style options for "no data" boxplot placeholder -- `textOnly` to maintain style for Agora and `grayBackground` for the Model-AD design
- Adds new legend chart that only displays a scatterplot legend
- Moves the boxplots grid legend from the last plot in the grid to a separate row to fix bug where legend is not displayed when the last plot doesn't have data
- Increases the offset between Female and Male categories to increase visual separation between the points on the plots and align with the design
- Moves the boxplot point style definition to constants

## Preview

`model-ad-build-images && model-ad-docker-start`
`https://dev.modeladexplorer.org/models/Abca7*V1599M/biomarkers` | `http://localhost:8000/models/Abca7*V1599M/biomarkers` 
:---: | :---:
<img width="614" height="776" alt="dev_dataUnavailable_noLegend" src="https://github.com/user-attachments/assets/7c15451c-c914-4d00-8dcf-ccde5ef308f3" /> | <img width="668" height="772" alt="MG-317_dataUnavailable_newLegend" src="https://github.com/user-attachments/assets/ed22df40-3ad4-457c-8557-8592c4cb2c15" />