### PR TITLE
fix(model-ad): allow model details boxplots container to stretch wider than the section (MG-330)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-grid/model-details-boxplots-grid.component.scss
@@ -1,18 +1,8 @@
-@use 'styles/src/lib/variables' as vars;
-@use 'styles/src/lib/mixins';
-
-:host {
-  --lg-breakpoint: vars.$lg-breakpoint;
-}
-
 .boxplots-grid {
   display: grid;
   gap: 30px 50px;
-  grid-template-columns: minmax(0, 1fr);
-
-  @include mixins.respond-to('large') {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  grid-template-columns: repeat(auto-fit, minmax(495px, 1fr));
+  justify-content: center;
 }
 
 .boxplots-grid-legend {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -107,6 +107,16 @@
     }
   }
 
+  model-ad-model-details-boxplots-grid {
+    width: 100vw;
+    max-width: 2500px;
+    display: block;
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 0 15%;
+  }
+
   .boxplots-separator {
     margin-top: 80px;
     margin-bottom: 80px;


### PR DESCRIPTION
## Description

Allow the model details boxplots container to stretch wider than the section width, so the plots will transition to a 3x1 grid when the page is very wide.

## Related Issue

[MG-330](https://sagebionetworks.jira.com/browse/MG-330)

## Changelog

- Allow model details boxplots container to stretch wider than the section width

## Preview

`model-ad-build-images && model-ad-docker-start`
`http://localhost:8000/models/Abca7*V1599M/biomarkers`

https://github.com/user-attachments/assets/afd78808-2d35-4cd3-b023-9e6d9dd442e1

[MG-330]: https://sagebionetworks.jira.com/browse/MG-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ