### PR TITLE
fix(model-ad): reset model details variables when route is updated to ensure default tab is loaded for each model (MG-394)

### DIFF
--- a/apps/model-ad/app/e2e/helpers.ts
+++ b/apps/model-ad/app/e2e/helpers.ts
@@ -1,0 +1,17 @@
+import { Page } from '@playwright/test';
+
+export const headerSearchPlaceholder = 'Search models';
+
+export const searchAndGetSearchListItems = async (
+  query: string,
+  page: Page,
+  searchPlaceholder = headerSearchPlaceholder,
+) => {
+  const responsePromise = page.waitForResponse(`**/models/search?q=${query}`);
+  const input = page.getByPlaceholder(searchPlaceholder);
+  await input.pressSequentially(query);
+  await responsePromise;
+
+  const searchList = page.getByRole('list').filter({ hasText: query });
+  return searchList.getByRole('listitem');
+};

--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { searchAndGetSearchListItems } from './helpers';
 
 test.describe('model details', () => {
   test('invalid model results in a 404 redirect', async ({ page }) => {
@@ -47,6 +48,26 @@ test.describe('model details', () => {
     const omicsTab = page.getByRole('button', { name: 'Omics' });
     await omicsTab.click();
     await page.waitForURL(`${modelPath}/omics`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
+  });
+
+  test('correct tab is loaded when navigating to new model via search', async ({ page }) => {
+    const initialModelPath = '/models/3xTg-AD';
+    const nextModel = 'LOAD2';
+
+    await page.goto('/models/3xTg-AD');
+    await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
+
+    const pathologyTab = page.getByRole('button', { name: 'Pathology' });
+    await pathologyTab.click();
+    await page.waitForURL(`${initialModelPath}/pathology`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Pathology' })).toBeVisible();
+
+    const searchListItems = await searchAndGetSearchListItems(nextModel, page);
+    await searchListItems.first().click();
+
+    await page.waitForURL(`/models/${nextModel}`);
+    await expect(page.getByRole('heading', { level: 1, name: nextModel })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
   });
 });

--- a/apps/model-ad/app/e2e/search.spec.ts
+++ b/apps/model-ad/app/e2e/search.spec.ts
@@ -1,20 +1,5 @@
-import { expect, Page, test } from '@playwright/test';
-
-const headerSearchPlaceholder = 'Search models';
-
-const searchAndGetSearchListItems = async (
-  query: string,
-  page: Page,
-  searchPlaceholder = headerSearchPlaceholder,
-) => {
-  const responsePromise = page.waitForResponse(`**/models/search?q=${query}`);
-  const input = page.getByPlaceholder(searchPlaceholder);
-  await input.pressSequentially(query);
-  await responsePromise;
-
-  const searchList = page.getByRole('list').filter({ hasText: query });
-  return searchList.getByRole('listitem');
-};
+import { expect, test } from '@playwright/test';
+import { headerSearchPlaceholder, searchAndGetSearchListItems } from './helpers';
 
 test.describe('search', () => {
   test('can search for model and aliases then navigate to model details from search result', async ({

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -68,9 +68,16 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   activePanel = 'omics';
   activeParent = '';
 
+  reset() {
+    this.model = undefined;
+    this.activePanel = 'omics';
+    this.activeParent = '';
+    this.isLoading = true;
+  }
+
   ngOnInit() {
     this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params: ParamMap) => {
-      this.isLoading = true;
+      this.reset();
 
       // only fetch data during client hydration
       if (this.platformService.isBrowser) {


### PR DESCRIPTION
## Description

The incorrect model details tab is loaded when searching for a model from another model details page on the non-default tab. This PR resets the model details variables when the route is updated to ensure that the default tab is loaded.

## Related Issue

[MG-394](https://sagebionetworks.jira.com/browse/MG-394)

## Changelog

- Reset model details variables when route is updated to ensure default tab is loaded for each model

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/12d8ddd6-c36a-45f1-ae3a-ce72588a706c

