### PR TITLE
feat(model-ad): highlight search query in search results, modernize search input to use signals, fix display of long search results (MG-360)

### DIFF
--- a/apps/model-ad/api/src/components/modelSearch.ts
+++ b/apps/model-ad/api/src/components/modelSearch.ts
@@ -18,7 +18,8 @@ export async function searchModels(query: string) {
     return cachedResult;
   }
 
-  const queryTrimmed = escapeRegexChars(query.trim());
+  // Do not trim query - space is an allowed search character
+  const queryEscaped = escapeRegexChars(query);
   const result: SearchResult[] = await ModelCollection.aggregate([
     {
       $addFields: {
@@ -28,7 +29,7 @@ export async function searchModels(query: string) {
               filtered_aliases: {
                 $filter: {
                   input: '$aliases',
-                  cond: { $regexMatch: { input: '$$this', regex: queryTrimmed, options: 'i' } },
+                  cond: { $regexMatch: { input: '$$this', regex: queryEscaped, options: 'i' } },
                 },
               },
             },
@@ -36,7 +37,7 @@ export async function searchModels(query: string) {
               $switch: {
                 branches: [
                   {
-                    case: { $regexMatch: { input: '$name', regex: queryTrimmed, options: 'i' } },
+                    case: { $regexMatch: { input: '$name', regex: queryEscaped, options: 'i' } },
                     then: { precedence: 1, match_field: 'name', match_value: '$name' },
                   },
                   {
@@ -48,11 +49,11 @@ export async function searchModels(query: string) {
                     },
                   },
                   {
-                    case: { $regexMatch: { input: '$jax_id', regex: queryTrimmed, options: 'i' } },
+                    case: { $regexMatch: { input: '$jax_id', regex: queryEscaped, options: 'i' } },
                     then: { precedence: 3, match_field: 'jax_id', match_value: '$jax_id' },
                   },
                   {
-                    case: { $regexMatch: { input: '$rrid', regex: queryTrimmed, options: 'i' } },
+                    case: { $regexMatch: { input: '$rrid', regex: queryEscaped, options: 'i' } },
                     then: { precedence: 4, match_field: 'rrid', match_value: '$rrid' },
                   },
                 ],

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
@@ -1,4 +1,4 @@
-<div #root [class]="`search ${hasThickBorder() && 'search-thick-border'} `">
+<div #root [class]="`search ${hasThickBorder() ? 'search-thick-border' : ''}`">
   <div class="search-bar">
     <div class="search-bar-icon">
       @if (isLoading) {
@@ -50,7 +50,7 @@
               <li (click)="goToResult(result.id)">
                 <span
                   class="result-name"
-                  [innerHtml]="formatResultForDisplay()(result) | sanitizeHtml"
+                  [innerHtml]="formatAndHighlightResultsForDisplay(result) | sanitizeHtml"
                 ></span>
               </li>
             }

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
@@ -25,7 +25,7 @@
     />
     @if (query) {
       <div class="search-bar-close">
-        <button (click)="clearInput()">
+        <button (click)="clearInput()" [attr.aria-label]="'Clear'">
           <fa-icon [icon]="faXmark" />
         </button>
       </div>
@@ -47,11 +47,14 @@
         @if (!error && results.length) {
           <ul class="search-results-list">
             @for (result of results; track result) {
-              <li (click)="goToResult(result.id)">
-                <span
-                  class="result-name"
-                  [innerHtml]="formatAndHighlightResultsForDisplay(result) | sanitizeHtml"
-                ></span>
+              <li>
+                <button type="button" (click)="goToResult(result.id)" class="result-button">
+                  <span
+                    class="result-name"
+                    [innerHtml]="formatAndHighlightResultsForDisplay(result) | sanitizeHtml"
+                    [attr.aria-label]="formatResultForDisplay()(result)"
+                  ></span>
+                </button>
               </li>
             }
           </ul>

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
@@ -162,6 +162,17 @@
             background-color: var(--color-action-primary);
             color: white;
           }
+
+          .result-button {
+            @include mixins.reset-button;
+
+            text-align: left;
+            width: 100%;
+
+            &:hover {
+              cursor: pointer;
+            }
+          }
         }
       }
     }

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
@@ -143,11 +143,13 @@
       margin: 0;
       max-height: 247px;
       border-top: none;
-      overflow-y: auto;
+      overflow: hidden auto;
 
       li {
         padding: 11px 20px;
         transition: var(--transition-duration);
+        word-wrap: break-word;
+        overflow-wrap: break-word;
       }
 
       &.search-results-list {

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
@@ -29,7 +29,7 @@ async function waitForSpinner() {
 
 async function setup() {
   const user = userEvent.setup();
-  const component = render(SearchInputComponent, {
+  const component = await render(SearchInputComponent, {
     providers: [
       provideHttpClient(),
       provideRouter([]),
@@ -45,7 +45,8 @@ async function setup() {
       checkQueryForErrors: mockCheckQueryForErrors,
     },
   });
-  return { user, component };
+  const { container } = component;
+  return { user, component, container };
 }
 
 describe('SearchInputComponent', () => {
@@ -88,6 +89,18 @@ describe('SearchInputComponent', () => {
     await screen.findByText('No results match your search string.');
   });
 
+  it('should highlight search query with mark', async () => {
+    const { container, user } = await setup();
+
+    const input = getInput();
+    await user.type(input, 'dummy');
+    await waitForSpinner();
+
+    const markedResults = container.querySelectorAll('mark');
+    expect(markedResults).toHaveLength(2);
+    expect(markedResults[1].textContent).toBe('dummy');
+  });
+
   it('should display results when search is successful', async () => {
     const { user } = await setup();
     const input = getInput();
@@ -96,8 +109,9 @@ describe('SearchInputComponent', () => {
     await waitForSpinner();
 
     expect(input).toHaveValue('dummy');
-    await screen.findByText('dummy_id');
-    await screen.findByText('dummy_id_2');
+    // search for the text that is not surrounded by <mark>
+    await screen.findByText('_id');
+    await screen.findByText('_id_2');
   });
 
   it('should navigate to result when clicked', async () => {
@@ -107,7 +121,8 @@ describe('SearchInputComponent', () => {
     await user.type(input, 'dummy');
     await waitForSpinner();
 
-    await user.click(screen.getByText('dummy_id'));
+    // search for text that is not surrounded by <mark>
+    await user.click(screen.getByText('_id'));
     expect(mockNavigateToResult).toHaveBeenCalledWith('dummy_id');
 
     expect(getInput()).toHaveValue('');

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
@@ -109,9 +109,8 @@ describe('SearchInputComponent', () => {
     await waitForSpinner();
 
     expect(input).toHaveValue('dummy');
-    // search for the text that is not surrounded by <mark>
-    await screen.findByText('_id');
-    await screen.findByText('_id_2');
+    await screen.findByLabelText('dummy_id');
+    await screen.findByLabelText('dummy_id_2');
   });
 
   it('should navigate to result when clicked', async () => {
@@ -121,8 +120,7 @@ describe('SearchInputComponent', () => {
     await user.type(input, 'dummy');
     await waitForSpinner();
 
-    // search for text that is not surrounded by <mark>
-    await user.click(screen.getByText('_id'));
+    await user.click(screen.getByLabelText('dummy_id'));
     expect(mockNavigateToResult).toHaveBeenCalledWith('dummy_id');
 
     expect(getInput()).toHaveValue('');
@@ -135,7 +133,7 @@ describe('SearchInputComponent', () => {
     await user.type(input, 'dummy');
     await waitForSpinner();
 
-    const clearButton = screen.getByRole('button');
+    const clearButton = screen.getByRole('button', { name: 'Clear' });
     await user.click(clearButton);
 
     expect(getInput()).toHaveValue('');

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -26,6 +26,7 @@ import {
   of,
   switchMap,
 } from 'rxjs';
+import sanitizeHtml from 'sanitize-html';
 import { SvgImageComponent } from '../svg-image/svg-image.component';
 
 @Component({
@@ -168,14 +169,14 @@ export class SearchInputComponent implements AfterViewInit {
 
   highlightMatches(text: string, query: string): string {
     if (!text || !query || query.length < 1) {
-      return text;
+      return sanitizeHtml(text);
     }
 
     // Escape special regex characters in the query
     const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(`(${escapedQuery})`, 'gi');
 
-    return text.replace(regex, '<mark>$1</mark>');
+    return sanitizeHtml(text).replace(regex, '<mark>$1</mark>');
   }
 
   formatAndHighlightResultsForDisplay(result: SearchResult): string {

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -3,12 +3,11 @@ import {
   Component,
   DestroyRef,
   ElementRef,
-  EventEmitter,
   HostListener,
   inject,
   input,
-  Output,
-  ViewChild,
+  output,
+  viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
@@ -40,7 +39,7 @@ export class SearchInputComponent implements AfterViewInit {
   router = inject(Router);
   destroyRef = inject(DestroyRef);
 
-  @Output() searchNavigated = new EventEmitter();
+  searchNavigated = output();
 
   searchPlaceholder = input.required<string>();
   searchImagePath = input<string | undefined>();
@@ -70,8 +69,8 @@ export class SearchInputComponent implements AfterViewInit {
     unknown: 'An unknown error occurred, please try again.',
   };
 
-  @ViewChild('root') root!: ElementRef;
-  @ViewChild('input') input!: ElementRef<HTMLInputElement>;
+  root = viewChild.required<ElementRef>('root');
+  input = viewChild.required<ElementRef<HTMLInputElement>>('input');
 
   @HostListener('document:click', ['$event'])
   onClick(event: Event) {
@@ -79,7 +78,7 @@ export class SearchInputComponent implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    fromEvent(this.input.nativeElement, 'keyup')
+    fromEvent(this.input().nativeElement, 'keyup')
       .pipe(
         takeUntilDestroyed(this.destroyRef),
         debounceTime(500),
@@ -138,7 +137,7 @@ export class SearchInputComponent implements AfterViewInit {
   }
 
   goToResult(id: string) {
-    this.input.nativeElement.blur();
+    this.input().nativeElement.blur();
     this.query = '';
     this.results = [];
     this.showResults = false;
@@ -153,7 +152,7 @@ export class SearchInputComponent implements AfterViewInit {
   }
 
   clearInput() {
-    this.input.nativeElement.focus();
+    this.input().nativeElement.focus();
     this.query = '';
     this.error = '';
     this.results = [];
@@ -162,7 +161,7 @@ export class SearchInputComponent implements AfterViewInit {
 
   checkClickIsInsideComponent(event: Event) {
     // if clicked element is not part of this component, hide results
-    if (!this.root.nativeElement.contains(event.target)) {
+    if (!this.root().nativeElement.contains(event.target)) {
       this.showResults = false;
     }
   }

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -166,4 +166,21 @@ export class SearchInputComponent implements AfterViewInit {
       this.showResults = false;
     }
   }
+
+  highlightMatches(text: string, query: string): string {
+    if (!text || !query || query.length < 1) {
+      return text;
+    }
+
+    // Escape special regex characters in the query
+    const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escapedQuery})`, 'gi');
+
+    return text.replace(regex, '<mark>$1</mark>');
+  }
+
+  formatAndHighlightResultsForDisplay(result: SearchResult): string {
+    const formattedText = this.formatResultForDisplay()(result);
+    return this.highlightMatches(formattedText, this.query);
+  }
 }


### PR DESCRIPTION
## Description

Add highlighting of the search query in the search results and general improvements to the search input component.

## Related Issue

- [MG-360](https://sagebionetworks.jira.com/browse/MG-360)
- [MG-2](https://sagebionetworks.jira.com/browse/MG-2)

## Changelog

- Highlights search query in search results
- Modernizes search input component to use signals rather than decorators
- Improves accessibility of search result options by adding aria labels and buttons
- Fixes display of long search results
- Removes trimming of query on server -- space is an allowed search character

## Preview

`model-ad-build-images && model-ad-docker-start`

### Current dev site (no highlighting, long search terms are cut off)

https://github.com/user-attachments/assets/77852712-4534-41ea-9907-4b6408fae07b

### Update in this PR (highlighting, long search terms wrap): 

https://github.com/user-attachments/assets/88e17366-701f-4ea0-9736-b30470055928

[MG-360]: https://sagebionetworks.jira.com/browse/MG-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-2]: https://sagebionetworks.jira.com/browse/MG-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ