### PR TITLE
fix(model-ad): move allen institute card to resources (MG-396)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-omics/model-details-omics.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-omics/model-details-omics.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, computed, input } from '@angular/core';
 import { ResourceCardsComponent } from '@sagebionetworks/explorers/ui';
 
@@ -23,12 +22,6 @@ export class ModelDetailsOmicsComponent {
       description: 'View Disease Correlation results for this model in the comparison tool.',
       title: 'Disease Correlation',
       link: `/comparison/correlation?model=${this.modelName()}`,
-    },
-    {
-      imagePath: '/model-ad-assets/images/allen-institute-logo.svg',
-      description: "View Gene Expression results for this model on the Allen Institute's site.",
-      // TODO: update to finalized link, see MG-252
-      link: 'https://alleninstitute.org/division/brain-science/',
     },
   ]);
 }

--- a/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-resources/model-details-resources.component.ts
@@ -47,6 +47,11 @@ export class ModelDetailsResourcesComponent {
       link: 'https://agora.adknowledgeportal.org/',
     },
     {
+      imagePath: '/model-ad-assets/images/allen-institute-logo.svg',
+      description: 'Explore mouse brain resources in the Allen Brain Atlas.',
+      link: 'https://mouse.brain-map.org/ ',
+    },
+    {
       imagePath: '/model-ad-assets/images/model-ad-logo.svg',
       description: 'Learn about the MODEL-AD program.',
       link: 'https://www.model-ad.org/',


### PR DESCRIPTION
## Description

We would like to move the Allen Institute card to the resources page.

## Related Issue

[MG-396](https://sagebionetworks.jira.com/browse/MG-396)

## Changelog

- Moves Allen Institute card from 'Omics to Resources

## Preview

`model-ad-build-images && model-ad-docker-start`

tab | dev (current) | this PR (updated) 
:---: | :---: | :---:
'Omics | <img width="1624" height="1056" alt="dev_omics" src="https://github.com/user-attachments/assets/70336742-6fea-4966-863d-6d57edc44354" /> | <img width="1624" height="1056" alt="MG-396_omics" src="https://github.com/user-attachments/assets/16a38fc1-523f-4116-b14e-5524102b14cb" />
Resources | <img width="1624" height="1056" alt="dev_resources" src="https://github.com/user-attachments/assets/652c4407-5589-4fa1-8f59-eac8fd3d11c7" /> | <img width="1624" height="1056" alt="MG-396_resources" src="https://github.com/user-attachments/assets/ad914d08-67ad-46e5-aa94-9739bb90f99f" />