### PR TITLE
feat(model-ad): scroll to panel content when tab specified in url, delay scroll when changing between tabs to give content time to load (MG-390)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -49,6 +49,28 @@ test.describe('model details', () => {
     await page.waitForURL(`${modelPath}/omics`);
     await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
   });
+
+  test('scrolls to panel content on initial load when tab specified in url and no hash fragment is present', async ({
+    page,
+  }) => {
+    const model = '3xTg-AD';
+    await page.goto(`/models/${model}/omics`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeInViewport();
+    await expect(page.getByRole('heading', { level: 1, name: model })).not.toBeInViewport();
+    await page.evaluate(() => window.pageYOffset !== 0);
+  });
+
+  test('does not scroll to panel content on initial load when tab not specified in url', async ({
+    page,
+  }) => {
+    const model = '3xTg-AD';
+    await page.goto(`/models/${model}`);
+    await expect(page.getByRole('heading', { level: 1, name: model })).toBeInViewport();
+    await expect(
+      page.getByRole('heading', { level: 2, name: 'Available Data' }),
+    ).not.toBeInViewport();
+    await page.evaluate(() => window.pageYOffset === 0);
+  });
 });
 
 test.describe('model details - omics', () => {

--- a/libs/explorers/services/src/lib/helper.service.ts
+++ b/libs/explorers/services/src/lib/helper.service.ts
@@ -82,6 +82,11 @@ export class HelperService {
     return urlParams.get(name);
   }
 
+  getHashFragment() {
+    // Extract hash fragment from URL (e.g. "nfl" from "#nfl")
+    return window.location.hash.slice(1);
+  }
+
   encodeParenthesesForwardSlashes(uri: string) {
     return (
       uri

--- a/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.ts
+++ b/libs/explorers/ui/src/lib/components/panel-navigation/panel-navigation.component.ts
@@ -28,6 +28,7 @@ export class PanelNavigationComponent implements AfterViewInit, AfterViewChecked
   panels = input.required<Panel[]>();
   activePanel = input.required<string>();
   activeParent = input<string>('');
+  scrollToPanelNavElementOnInitialLoad = input<boolean>(false);
   panelChange = output<Panel>();
 
   faAngleRight = faAngleRight;
@@ -80,6 +81,10 @@ export class PanelNavigationComponent implements AfterViewInit, AfterViewChecked
     setTimeout(() => {
       this.onWindowResize();
     }, 100);
+
+    if (this.scrollToPanelNavElementOnInitialLoad()) {
+      this.scrollToPanelNavElement();
+    }
   }
 
   ngAfterViewChecked() {
@@ -88,13 +93,23 @@ export class PanelNavigationComponent implements AfterViewInit, AfterViewChecked
 
   activatePanel(panel: Panel) {
     if (isPlatformBrowser(this.platformId)) {
+      this.panelChange.emit(panel);
+      this.scrollToPanelNavElement();
+    }
+  }
+
+  scrollToPanelNavElement() {
+    // Add slight delay to allow panel to render before scrolling
+    setTimeout(() => {
       const nav = document.querySelector('.panel-navigation');
       if (nav) {
-        window.scrollTo(0, this.helperService.getOffset(nav).top);
+        window.scrollTo({
+          top: this.helperService.getOffset(nav).top,
+          left: 0,
+          behavior: 'smooth',
+        });
       }
-
-      this.panelChange.emit(panel);
-    }
+    }, 100);
   }
 
   getPanelCount() {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -176,11 +176,6 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
     this.hasInitializedOptions = true;
   }
 
-  getHashFragment() {
-    // Extract hash fragment from URL (e.g. "nfl" from "#nfl")
-    return window.location.hash.slice(1);
-  }
-
   isValidHashFragment(hashFragment: string): boolean {
     return this.evidenceTypes().some(
       (evidenceType) => this.generateAnchorId(evidenceType) === hashFragment,
@@ -189,7 +184,7 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
 
   scrollToSectionOnFirstRender() {
     if (typeof window !== 'undefined' && !this.isInitialScrollDone) {
-      const hashFragment = this.getHashFragment();
+      const hashFragment = this.helperService.getHashFragment();
       if (this.isValidHashFragment(hashFragment)) {
         this.isInitialScrollDone = this.scrollToSection(hashFragment, false);
       } else {
@@ -232,7 +227,7 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
     const queryString = params.toString();
     const queryStringFormatted = queryString ? `?${queryString}` : '';
 
-    const hashFragment = this.getHashFragment();
+    const hashFragment = this.helperService.getHashFragment();
     const hash = this.isValidHashFragment(hashFragment) ? `#${hashFragment}` : '';
 
     const newUrl = `${window.location.pathname}${queryStringFormatted}${hash}`;

--- a/libs/model-ad/model-details/src/lib/model-details.component.html
+++ b/libs/model-ad/model-details/src/lib/model-details.component.html
@@ -10,6 +10,7 @@
       (panelChange)="onPanelChange($event)"
       [activePanel]="activePanel"
       [activeParent]="activeParent"
+      [scrollToPanelNavElementOnInitialLoad]="scrollToPanelNavElementOnInitialLoad"
     />
     <div class="panel-content">
       @switch (activePanel) {

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -68,6 +68,8 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   activePanel = 'omics';
   activeParent = '';
 
+  scrollToPanelNavElementOnInitialLoad = false;
+
   ngOnInit() {
     this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params: ParamMap) => {
       this.isLoading = true;
@@ -114,9 +116,11 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   }
 
   private setActivePanelAndParentFromUrl(params: ParamMap) {
+    const noHashFragment = this.helperService.getHashFragment() === '';
     if (params.get('subtab')) {
       this.activePanel = params.get('subtab') as string;
       this.activeParent = params.get('tab') as string;
+      this.scrollToPanelNavElementOnInitialLoad = noHashFragment; // selector will handle to scroll if hash fragment is present
     } else if (params.get('tab')) {
       const panel = this.panels.find((p: Panel) => p.name === params.get('tab'));
       if (panel) {
@@ -126,6 +130,7 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
         );
         this.activePanel = activePanel;
         this.activeParent = activeParent;
+        this.scrollToPanelNavElementOnInitialLoad = noHashFragment; // selector will handle scroll if hash fragment is present
       }
     }
   }


### PR DESCRIPTION
## Description

The model details page should scroll to the panel nav element when a tab is specified in the URL. If no tab is specified in the URL, then the page should not scroll.

## Related Issue

[MG-390](https://sagebionetworks.jira.com/browse/MG-390) 

## Changelog

- Scrolls to panel nav element when a tab is specified in the URL
- Delays scroll when changing between tabs to give content time to load so panel nav element is positioned correctly
- Does not scroll when URL includes a hash fragment; expect the scroll to be handled by a component within the panel content (e.g. scrolling to the Nfl section of the biomarkers plots), so we should not scroll to the panel nav element
- Moves `getHashFragment` to explorers HelperService

## Preview

`model-ad-build-images && model-ad-docker-start`

Scrolls to panel nav element when a tab is specified in the URL: 

https://github.com/user-attachments/assets/7b81b8fb-b74a-4094-a745-a4a6f47450d8

Does not scroll to panel nav element when tab is not specified in URL and keeps panel nav element at top of screen when switching tabs: 

https://github.com/user-attachments/assets/c811d186-92da-4d61-aa3a-11836d30f7a1
