### PR TITLE
fix(model-ad): style terms of service content (MG-296)

### DIFF
--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.scss
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.scss
@@ -27,6 +27,26 @@
 
     .terms-of-service-content {
       width: min(vars.$main-content-desktop-width, 100%);
+
+      // Override global CSS reset that removes margin
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      p,
+      ol,
+      ul {
+        margin-bottom: revert;
+      }
+
+      // Override global CSS reset that removes list styles
+      ul,
+      ol {
+        list-style: revert;
+        padding: revert;
+      }
     }
   }
 }

--- a/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.ts
+++ b/libs/explorers/shared/src/lib/components/terms-of-service/terms-of-service.component.ts
@@ -1,11 +1,11 @@
-import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, ViewEncapsulation } from '@angular/core';
 
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterModule } from '@angular/router';
 import { SynapseApiService } from '@sagebionetworks/explorers/services';
-import { MarkdownModule } from 'ngx-markdown';
 import { HeroComponent } from '@sagebionetworks/explorers/ui';
 import { LoadingIconComponent } from '@sagebionetworks/explorers/util';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MarkdownModule } from 'ngx-markdown';
 import { finalize } from 'rxjs/operators';
 
 @Component({
@@ -13,10 +13,11 @@ import { finalize } from 'rxjs/operators';
   imports: [HeroComponent, MarkdownModule, LoadingIconComponent, RouterModule],
   templateUrl: './terms-of-service.component.html',
   styleUrls: ['./terms-of-service.component.scss'],
+  encapsulation: ViewEncapsulation.None,
 })
 export class TermsOfServiceComponent implements OnInit {
   synapseService = inject(SynapseApiService);
-  private destroyRef = inject(DestroyRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   content = '';
   isLoading = true;


### PR DESCRIPTION
## Description

We should style the TOS content.

## Related Issue

[MG-296](https://sagebionetworks.jira.com/browse/MG-296)

## Changelog

- Override global CSS reset so the TOS content is styled
- Disable view encapsulation for the TOS component, so the CSS rules can properly target the dynamically generated content in the markdown component

## Preview

dev (current) | this PR (updated)
:---: | :---: 
<img width="1624" height="1056" alt="dev_tosTop" src="https://github.com/user-attachments/assets/a22d7b73-18a0-48f8-8d9a-b52c0979cbc9" /> ... <img width="1624" height="1056" alt="dev_tosMid" src="https://github.com/user-attachments/assets/a5517a6f-0158-4900-9820-a18c5fbb0319" /> | <img width="1624" height="1056" alt="MG-296_tosTop" src="https://github.com/user-attachments/assets/d5279fbe-d6a9-4c14-ad09-5236aa3c674b" /> ... <img width="1624" height="1056" alt="MG-296_tosMid" src="https://github.com/user-attachments/assets/2afef0b4-f292-4f05-b088-417c80d0c3f9" />



[MG-296]: https://sagebionetworks.jira.com/browse/MG-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ