### PR TITLE
feat(model-ad): matched control(s) value(s) in hero link to JAX (MG-397)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.html
@@ -32,7 +32,14 @@
     </div>
 
     <h4>Matched Controls</h4>
-    <p>{{ model().matched_controls.join(', ') }}</p>
+    <p>
+      @for (matched_control of model().matched_controls; track matched_control; let last = $last) {
+        <a [href]="this.MATCHED_CONTROLS_URLS[matched_control]" target="_blank">{{
+          matched_control
+        }}</a
+        >{{ !last ? ', ' : '' }}
+      }
+    </p>
 
     <hr />
 
@@ -47,7 +54,7 @@
 
     <p>
       JAX Stock Number:
-      <a [href]="`https://www.jax.org/strain/${ model().jax_id }`" target="_blank">{{
+      <a [href]="`${this.JAX_STRAIN_URL}/${ model().jax_id }`" target="_blank">{{
         model().jax_id
       }}</a>
     </p>

--- a/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-hero/model-details-hero.component.ts
@@ -11,6 +11,14 @@ import sanitizeHtml from 'sanitize-html';
   styleUrls: ['./model-details-hero.component.scss'],
 })
 export class ModelDetailsHeroComponent {
+  readonly JAX_STRAIN_URL = 'https://www.jax.org/strain';
+
+  readonly MATCHED_CONTROLS_URLS: Record<string, string> = {
+    B6129: `${this.JAX_STRAIN_URL}/101045`,
+    '5xFAD': `${this.JAX_STRAIN_URL}/008730`,
+    'C57BL/6J': `${this.JAX_STRAIN_URL}/000664`,
+  };
+
   model = input.required<Model>();
 
   sanitizeHtml = sanitizeHtml;


### PR DESCRIPTION
## Description

Link matched control values to JAX in model details hero.

## Related Issue

[MG-397](https://sagebionetworks.jira.com/browse/MG-397)

## Changelog

- Link matched control values to JAX in model details hero

## Preview

`model-ad-build-images && model-ad-docker-start`
`http://localhost:8000/models/Abca7*V1599M`

dev (before) | this PR (after)
:---: | :---: 
<img width="297" height="184" alt="image" src="https://github.com/user-attachments/assets/e7b7fcd9-b9e9-4d4c-907f-27beffdd69c7" /> | <img width="328" height="182" alt="image" src="https://github.com/user-attachments/assets/9981fa26-8506-48d9-a5fd-f5bdbfd67089" />

Demonstration of links: 

https://github.com/user-attachments/assets/9d17f9c9-f784-4194-8a8c-6fbeea850cf7

[MG-397]: https://sagebionetworks.jira.com/browse/MG-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ