### PR TITLE
fix(model-ad): unstick the toc (MG-403)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -48,10 +48,6 @@
 
 .table-of-contents-container {
   box-shadow: 0 4px 4px 0 rgb(0 0 0 / 25%);
-  position: sticky;
-  top: var(--panel-nav-height);
-  z-index: 10;
-  background-color: white;
 
   .table-of-contents-title-bar {
     padding: 20px 0 25px;

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -240,14 +240,11 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
       const element = container.nativeElement.querySelector(`#${anchorId}`) as HTMLElement;
 
       if (element) {
-        const tocElement = document.querySelector('.table-of-contents-container');
-        const tocHeight = tocElement ? tocElement.getBoundingClientRect().height : 0;
-
         const panelNavHeight = this.helperService.getNumberFromCSSValue(
           getComputedStyle(document.documentElement).getPropertyValue('--panel-nav-height'),
         );
 
-        const yOffset = -(tocHeight + panelNavHeight + this.SCROLL_PADDING);
+        const yOffset = -(panelNavHeight + this.SCROLL_PADDING);
         const elementOffset = this.helperService.getOffset(element);
         const y = elementOffset.top + yOffset;
         window.scrollTo({ top: y, behavior: 'smooth' });


### PR DESCRIPTION
## Description

The model details table of contents should not be sticky.

## Related Issue

[MG-403](https://sagebionetworks.jira.com/browse/MG-403)

## Changelog

- Unstick the table of contents

## Preview

`model-ad-build-images && model-ad-docker-start`

Current (`https://dev.modeladexplorer.org/models/3xTg-AD/biomarkers`)

https://github.com/user-attachments/assets/0ff1215d-a378-4630-9171-d129c49994ef

Updated (`http://localhost:8000/models/3xTg-AD/biomarkers`)

https://github.com/user-attachments/assets/45aa9145-afc5-4e7b-a2c2-17f0054a87e0