### PR TITLE
feat: add Docker Compose `extra_hosts` to OC, Agora and Model-AD apexes (SMR-384)

### DIFF
--- a/apps/agora/app/project.json
+++ b/apps/agora/app/project.json
@@ -88,7 +88,8 @@
     "serve": {
       "executor": "@nx/angular:dev-server",
       "options": {
-        "proxyConfig": "{projectRoot}/src/proxy.conf.json"
+        "host": "0.0.0.0",
+        "port": 4200
       },
       "configurations": {
         "production": {

--- a/apps/agora/app/src/proxy.conf.json
+++ b/apps/agora/app/src/proxy.conf.json
@@ -1,6 +1,0 @@
-{
-  "/v1": {
-    "target": "http://localhost:3333",
-    "secure": false
-  }
-}

--- a/apps/model-ad/app/project.json
+++ b/apps/model-ad/app/project.json
@@ -93,7 +93,8 @@
     "serve": {
       "executor": "@nx/angular:dev-server",
       "options": {
-        "proxyConfig": "{projectRoot}/src/proxy.conf.json"
+        "host": "0.0.0.0",
+        "port": 4200
       },
       "configurations": {
         "production": {

--- a/apps/model-ad/app/src/proxy.conf.json
+++ b/apps/model-ad/app/src/proxy.conf.json
@@ -1,6 +1,0 @@
-{
-  "/v1": {
-    "target": "http://localhost:3333",
-    "secure": false
-  }
-}

--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -77,7 +77,7 @@
     "serve": {
       "executor": "@nx/angular:dev-server",
       "options": {
-        "host": "127.0.0.1",
+        "host": "0.0.0.0",
         "port": 4200
       },
       "configurations": {

--- a/docker/agora/services/apex.yml
+++ b/docker/agora/services/apex.yml
@@ -23,6 +23,10 @@ services:
         condition: service_healthy
       agora-app:
         condition: service_healthy
+    extra_hosts:
+      - 'agora-api-docs:host-gateway'
+      - 'agora-api:host-gateway'
+      - 'agora-app:host-gateway'
     deploy:
       resources:
         limits:

--- a/docker/model-ad/services/apex.yml
+++ b/docker/model-ad/services/apex.yml
@@ -23,6 +23,10 @@ services:
         condition: service_healthy
       model-ad-app:
         condition: service_healthy
+      extra_hosts:
+        - 'model-ad-api-docs:host-gateway'
+        - 'model-ad-api:host-gateway'
+        - 'model-ad-app:host-gateway'
     deploy:
       resources:
         limits:

--- a/docker/model-ad/services/apex.yml
+++ b/docker/model-ad/services/apex.yml
@@ -23,10 +23,10 @@ services:
         condition: service_healthy
       model-ad-app:
         condition: service_healthy
-      extra_hosts:
-        - 'model-ad-api-docs:host-gateway'
-        - 'model-ad-api:host-gateway'
-        - 'model-ad-app:host-gateway'
+    extra_hosts:
+      - 'model-ad-api-docs:host-gateway'
+      - 'model-ad-api:host-gateway'
+      - 'model-ad-app:host-gateway'
     deploy:
       resources:
         limits:

--- a/docker/openchallenges/services/apex.yml
+++ b/docker/openchallenges/services/apex.yml
@@ -18,6 +18,10 @@ services:
         condition: service_started
       openchallenges-mcp-server:
         condition: service_started
+    extra_hosts:
+      - 'openchallenges-api-gateway:host-gateway'
+      - 'openchallenges-app:host-gateway'
+      - 'openchallenges-mcp-server:host-gateway'
     deploy:
       resources:
         limits:

--- a/tools/configure-hostnames.sh
+++ b/tools/configure-hostnames.sh
@@ -5,6 +5,7 @@
 # list of hostnames (defined in alphabetical order)
 declare -a hostnames=(
   "127.0.0.1 agora-api"
+  "127.0.0.1 agora-app"
   "127.0.0.1 agora-mongo"
   "127.0.0.1 amp-als-apex"
   "127.0.0.1 amp-als-dataset-service"
@@ -15,6 +16,7 @@ declare -a hostnames=(
   "127.0.0.1 iatlas-api"
   "127.0.0.1 iatlas-postgres"
   "127.0.0.1 model-ad-api"
+  "127.0.0.1 model-ad-app"
   "127.0.0.1 model-ad-mongo"
   "127.0.0.1 observability-apex"
   "127.0.0.1 observability-grafana"


### PR DESCRIPTION
## Description

Introducing Docker Compose `extra_hosts` to OC and Agora apexes to enable swapping upstream apps (e.g., API server, Angular app) between their containers and their development servers.

## The Problem

Consider the following case where the Agora stack is deployed locally with Docker Compose.

1. Build the Docker images and deploy the stack with Docker Compose
    ```bash
    agora-build-images
    nx serve-detach agora-apex
    ```
2. Access the web app via the Caddy reverse proxy at `http://localhost:8000`.
3. Stop or remove the `agora-app` container.
    ```bash
    nx stop agora-app
    ```
4. Start the web app development server.
    ```bash
    nx serve agora-app
    ````
5. Accessing the web app via the reverse proxy fails. ❌

Currently, developers must access the web app directly at `localhost:4200` during active development. The same limitation applies to other apps upstream of the Caddy server, such as the Agora API server. For example, if an app in the stack is configured to reach the API server through the Caddy server, the API server becomes inaccessible when its container is stopped and its development server is started. This setup reduces flexibility and can feel unintuitive.

## The Solution

The proposed solution is to specify `extra_hosts` in the Docker Compose file for the Caddy server (apex). This provides a fallback resolution for app hostnames such as `agora-app` and `agora-api`, which are used in the Caddy configuration and throughout our product stacks.

When deploying a stack locally with Docker Compose, these hostnames are normally resolved by Docker’s internal DNS server. However, if an upstream container is stopped, attempts to access its hostname from another container result in a 502 Bad Gateway error.

By specifying `extra_hosts` as shown below, the `/etc/hosts` file inside the apex container will include additional entries that resolve app hostnames to the host machine, where development servers are running. For this to work, the development servers must listen on `0.0.0.0` rather than the loopback interface (`127.0.0.1`), ensuring they are reachable from within the stack containers.

```yaml
# docker/agora/services/apex.yml
...
    depends_on:
      agora-api-docs:
        condition: service_healthy
      agora-api:
        condition: service_healthy
      agora-app:
        condition: service_healthy
    extra_hosts:
      - 'agora-api-docs:host-gateway'
      - 'agora-api:host-gateway'
      - 'agora-app:host-gateway
```

The `/etc/hosts` file after specifying `extra_hosts`:

```console
$ docker exec agora-apex cat /etc/hosts
127.0.0.1       localhost
::1     localhost ip6-localhost ip6-loopback
fe00::  ip6-localnet
ff00::  ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
172.18.0.1      agora-app              # New
172.18.0.1      agora-api-docs      # New
172.18.0.1      agora-api               # New
172.19.0.6      5aef72a3042e
```

Finally, the use of `extra_hosts` can be extended to the Docker Compose files of any apps of a stack. For example, this property could be specified in the Docker Compose file of an API server to access a database started locally on the host instead of one running inside a container.

## Related Issue

- [SMR-384](https://sagebionetworks.jira.com/browse/SMR-384)

## Changelog

- Add Docker Compose `extra_host`s to Agora and OC apexes.
- Update `openchallenges-app` and `agora-app` to listen to `0.0.0.0`.
- Apply the changes to Model-AD.
- Add `agora-app` and `model-ad-app` to the host `/etc/hosts` via `tools/configure-hostnames.sh`.

[SMR-384]: https://sagebionetworks.jira.com/browse/SMR-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ