### PR TITLE
feat(model-ad): allow search results to be selected with mouse or keyboard (MG-361)

### DIFF
--- a/apps/model-ad/app/e2e/helpers.ts
+++ b/apps/model-ad/app/e2e/helpers.ts
@@ -13,5 +13,6 @@ export const searchAndGetSearchListItems = async (
   await responsePromise;
 
   const searchList = page.getByRole('list').filter({ hasText: query });
-  return searchList.getByRole('listitem');
+  const searchListItems = searchList.getByRole('listitem');
+  return { input, searchListItems };
 };

--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -63,7 +63,7 @@ test.describe('model details', () => {
     await page.waitForURL(`${initialModelPath}/pathology`);
     await expect(page.getByRole('heading', { level: 2, name: 'Pathology' })).toBeVisible();
 
-    const searchListItems = await searchAndGetSearchListItems(nextModel, page);
+    const { searchListItems } = await searchAndGetSearchListItems(nextModel, page);
     await searchListItems.first().click();
 
     await page.waitForURL(`/models/${nextModel}`);

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
@@ -46,9 +46,18 @@
 
         @if (!error && results.length) {
           <ul class="search-results-list">
-            @for (result of results; track result) {
-              <li>
-                <button type="button" (click)="goToResult(result.id)" class="result-button">
+            @for (result of results; track result; let i = $index) {
+              <li
+                [class.selected]="selectedResultIndex === i"
+                (mouseenter)="onResultHover(i)"
+                (mouseleave)="onResultMouseLeave()"
+              >
+                <button
+                  type="button"
+                  (click)="goToResult(result.id)"
+                  class="result-button"
+                  [attr.aria-selected]="selectedResultIndex === i"
+                >
                   <span
                     class="result-name"
                     [innerHtml]="formatAndHighlightResultsForDisplay(result) | sanitizeHtml"

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
@@ -158,7 +158,7 @@
         li {
           cursor: pointer;
 
-          &:hover {
+          &.selected {
             background-color: var(--color-action-primary);
             color: white;
           }


### PR DESCRIPTION
## Description

The user should be able to navigate and select a search result using the mouse or the keyboard.

## Related Issue

[MG-361](https://sagebionetworks.jira.com/browse/MG-361)

## Changelog

- Allow the user to navigate and select a search result using the keyboard

## Preview

`model-ad-build-images && model-ad-docker-start`

Using the mouse: 

https://github.com/user-attachments/assets/684ace3f-fa01-4df4-8b37-b56001e9410a

Using the keyboard: 

https://github.com/user-attachments/assets/bf375b90-f26f-4aea-8b62-0b63d039f498

[MG-361]: https://sagebionetworks.jira.com/browse/MG-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ