### PR TITLE
feat(model-ad): align boxplot style with design (MG-298)

### DIFF
--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.spec.ts
@@ -29,6 +29,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
       [showLegend]="showLegend"
       [pointOpacity]="pointOpacity"
       [noDataStyle]="noDataStyle"
+      [chartStyle]="chartStyle"
     ></div>`,
   })
   class TestComponent {
@@ -48,6 +49,7 @@ const renderTestComponent = async (props: BoxplotProps) => {
     showLegend = props.showLegend;
     pointOpacity = props.pointOpacity;
     noDataStyle = props.noDataStyle;
+    chartStyle = props.chartStyle;
   }
 
   return await render(TestComponent, {

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.stories.ts
@@ -19,7 +19,7 @@ const meta: Meta<BoxplotDirective> = {
   },
   render: (args: BoxplotProps) => ({
     props: args,
-    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle"></div>`,
+    template: `<div sageBoxplot [points]="points" [summaries]="summaries" [title]="title" [xAxisTitle]="xAxisTitle" [xAxisLabelFormatter]="xAxisLabelFormatter" [xAxisCategories]="xAxisCategories" [yAxisTitle]="yAxisTitle" [yAxisMin]="yAxisMin" [yAxisMax]="yAxisMax" [xAxisLabelTooltipFormatter]="xAxisLabelTooltipFormatter" [pointTooltipFormatter]="pointTooltipFormatter" [pointCategoryColors]="pointCategoryColors" [pointCategoryShapes]="pointCategoryShapes" [showLegend]="showLegend" [pointOpacity]="pointOpacity" [noDataStyle]="noDataStyle" [chartStyle]="chartStyle"></div>`,
   }),
 };
 export default meta;
@@ -68,5 +68,6 @@ export const DynamicSummary: Story = {
     showLegend: true,
     pointOpacity: 0.5,
     noDataStyle: 'grayBackground',
+    chartStyle: 'grayGrid',
   },
 };

--- a/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
+++ b/libs/explorers/charts-angular/src/lib/boxplot/boxplot.directive.ts
@@ -34,6 +34,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
   @Input() showLegend: undefined | boolean;
   @Input() pointOpacity: undefined | number;
   @Input() noDataStyle: undefined | 'textOnly' | 'grayBackground';
+  @Input() chartStyle: undefined | 'minimal' | 'grayGrid';
 
   ngOnInit() {
     this.boxplot = new BoxplotChart(this.el.nativeElement, this.getBoxplotProps());
@@ -65,6 +66,7 @@ export class BoxplotDirective implements OnChanges, OnInit, OnDestroy {
       showLegend: this.showLegend,
       pointOpacity: this.pointOpacity,
       noDataStyle: this.noDataStyle,
+      chartStyle: this.chartStyle,
     };
   }
 }

--- a/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
+++ b/libs/explorers/charts/src/lib/boxplot-chart/boxplot-chart.ts
@@ -23,6 +23,7 @@ const titleTextStyle = {
 const boxplotStyle = {
   borderColor: '#bcc0ca',
   borderWidth: 2,
+  color: 'transparent',
 };
 
 const yAxisPadding = 0.2;
@@ -148,6 +149,7 @@ export class BoxplotChart {
     yAxisTitle: BoxplotProps['yAxisTitle'],
     yAxisMin: BoxplotProps['yAxisMin'],
     yAxisMax: BoxplotProps['yAxisMax'],
+    chartStyle: BoxplotProps['chartStyle'],
   ) {
     const yAxisOptions: EChartsOption['yAxis'] = {
       type: 'value',
@@ -165,7 +167,7 @@ export class BoxplotChart {
         showMaxLabel: yAxisMax == null,
       },
       splitLine: {
-        show: false,
+        show: chartStyle === 'grayGrid',
       },
       min: yAxisMin ? yAxisMin - yAxisPadding : undefined,
       max: yAxisMax ? yAxisMax + yAxisPadding : undefined,
@@ -194,6 +196,7 @@ export class BoxplotChart {
 
     const showLegend = boxplotProps.showLegend || false;
     const noDataStyle = boxplotProps.noDataStyle || 'textOnly';
+    const chartStyle = boxplotProps.chartStyle || 'minimal';
 
     const noPoints = points.length === 0;
     const noSummaries = summaries == null || summaries.length === 0;
@@ -283,6 +286,20 @@ export class BoxplotChart {
       tooltip: {
         show: false,
       },
+      markArea:
+        chartStyle === 'grayGrid'
+          ? {
+              itemStyle: {
+                color: '#AEB5BC',
+                opacity: 0.1,
+              },
+              data: xAxisCategories.map((pc, idx) => {
+                const spacing = 0.4;
+                const pcIndex = idx + 1;
+                return [{ xAxis: pcIndex - spacing }, { xAxis: pcIndex + spacing }];
+              }),
+            }
+          : undefined,
     };
     if (summaries) {
       seriesOpts.push({
@@ -374,7 +391,7 @@ export class BoxplotChart {
       },
       dataset: datasetOpts,
       xAxis: this.getXAxisOptions(xAxisCategories, xAxisLabelFormatter, xAxisLabelTooltipFormatter),
-      yAxis: this.getYAxisOptions(yAxisTitle, yAxisMin, yAxisMax),
+      yAxis: this.getYAxisOptions(yAxisTitle, yAxisMin, yAxisMax, chartStyle),
       tooltip: {
         confine: true,
         position: 'top',

--- a/libs/explorers/charts/src/lib/models/boxplot.ts
+++ b/libs/explorers/charts/src/lib/models/boxplot.ts
@@ -65,4 +65,5 @@ export interface BoxplotProps {
   showLegend?: boolean;
   pointOpacity?: number;
   noDataStyle?: 'textOnly' | 'grayBackground';
+  chartStyle?: 'minimal' | 'grayGrid';
 }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.html
@@ -12,4 +12,5 @@
   [showLegend]="showLegend()"
   [pointOpacity]="0.5"
   [noDataStyle]="'grayBackground'"
+  [chartStyle]="'grayGrid'"
 ></div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -50,11 +50,13 @@ export class ModelDetailsBoxplotComponent {
   yAxisTitle = computed(() => this.modelData().units);
 
   createTooltipText(individual: IndividualData, units: string): string {
-    return `${individual.sex}\n${individual.value} ${units}\nIndividual ID: ${individual.individual_id}`;
+    const color = this.pointCategoryColors[individual.sex] || 'black';
+    const tooltipMarker = `<span style="display: inline-block; width: 10px; height: 10px; background-color: ${color}; margin-right: 4px;"></span>`;
+    return `${tooltipMarker}${individual.sex}\n${individual.value} ${units}\nIndividual ID: ${individual.individual_id}`;
   }
 
   pointTooltipFormatter = (pt: CategoryPoint, params: CallbackDataParams) => {
-    return `<div style="text-align: left;">${params.marker} ${pt.text ?? pt.value.toString()}</div>`;
+    return `<div style="text-align: left;">${pt.text ?? pt.value.toString()}</div>`;
   };
 
   xAxisLabelFormatter = (value: string) => {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplot/model-details-boxplot.component.ts
@@ -54,7 +54,7 @@ export class ModelDetailsBoxplotComponent {
   }
 
   pointTooltipFormatter = (pt: CategoryPoint, params: CallbackDataParams) => {
-    return `${params.marker} ${pt.text ?? pt.value.toString()}`;
+    return `<div style="text-align: left;">${params.marker} ${pt.text ?? pt.value.toString()}</div>`;
   };
 
   xAxisLabelFormatter = (value: string) => {


### PR DESCRIPTION
## Description

We would like to align the model details boxplots style with the design.

## Related Issue

[MG-298](https://sagebionetworks.jira.com/browse/MG-298)

## Changelog

- Adds boxplot `chartStyle` options -- `minimal` to maintain style for Agora and `grayGrid` for the Model-AD design with grid lines and gray background behind boxes
- Left-aligns text and updates marker to a square in model details boxplot tooltips

## Preview

### Model-AD 

`model-ad-build-images && model-ad-docker-start`

This PR updates the chart and tooltip style to align more closely with the design:

dev (current) | this PR (updated) 
:---: | :---: 
<img width="1360" height="461" alt="MG-298_dev" src="https://github.com/user-attachments/assets/3505a5d8-e2ca-41f9-9fe2-b998c0082707" /> | <img width="1322" height="474" alt="MG-298_pr" src="https://github.com/user-attachments/assets/6e9a4644-ca95-4c14-9eeb-9da9f2e19706" />

### Agora

This PR does not change the styling of the Agora boxplot:

`agora-build-images && agora-docker-start`

dev (current) | this PR (updated) 
:---: | :---:
<img width="1454" height="611" alt="MG-298_agora_dev" src="https://github.com/user-attachments/assets/4c59fbe7-59a6-4ad5-8cb8-83a38d9c08ca" /> | <img width="1485" height="612" alt="MG-298_agora_pr" src="https://github.com/user-attachments/assets/972ceeb1-3dfa-4c46-bfe7-3069823893b2" />

[MG-298]: https://sagebionetworks.jira.com/browse/MG-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ