### PR TITLE
fix(model-ad): wrap boxplots grid to enable complete image downloads (MG-407)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -106,11 +106,15 @@
           />
         </div>
 
-        <model-ad-model-details-boxplots-grid
-          [modelDataList]="getSelectedModelDataForEvidenceType(evidenceType)"
-          [genotypeOrder]="genotypeOrder()"
-          [sexes]="selectedSexOption().value"
-        />
+        <!-- Wrapper handles full-width positioning while keeping grid in normal document flow 
+         so the full grid is captured in the download image -->
+        <div class="boxplots-grid-wrapper">
+          <model-ad-model-details-boxplots-grid
+            [modelDataList]="getSelectedModelDataForEvidenceType(evidenceType)"
+            [genotypeOrder]="genotypeOrder()"
+            [sexes]="selectedSexOption().value"
+          />
+        </div>
         @if (!last) {
           <hr class="boxplots-separator" />
         }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -104,14 +104,18 @@
     }
   }
 
-  model-ad-model-details-boxplots-grid {
+  .boxplots-grid-wrapper {
     width: 100vw;
     max-width: 2500px;
-    display: block;
     position: relative;
     left: 50%;
     transform: translateX(-50%);
     padding: 0 15%;
+
+    model-ad-model-details-boxplots-grid {
+      display: block;
+      width: 100%;
+    }
   }
 
   .boxplots-separator {


### PR DESCRIPTION
## Description

The boxplots download should include all boxplots. We recently updated the boxplots grid to allow the boxplots to rearrange to 1, 2, or 3 plots per row, but the styling caused issues with the DOM capture library. This PR adds a wrapper div around the grid, so the grid remains in the normal document flow for proper DOM capture while maintaining the existing functionality.

## Related Issue

- [MG-407](https://sagebionetworks.jira.com/browse/MG-407)

## Changelog

- Fixes issue where only partial plots were captured in downloads
- Add wrapper div around model-details-boxplots-grid component
- Move full-width positioning styles from grid component to wrapper
- Keep grid component in normal document flow for proper DOM capture

## Preview

`model-ad-build-images && model-ad-docker-build`

Downloaded image contains all plots: 

<img width="1765" height="449" alt="Abca7_V1599M_Insoluble_Abeta40_Cerebral_Cortex_Female_Male" src="https://github.com/user-attachments/assets/aa6ca938-6eb4-48e7-a582-b32165062ee8" />

Maintains rearrangement behavior: 

https://github.com/user-attachments/assets/be1c5786-314e-44eb-aef4-94e0ef547b95

[MG-407]: https://sagebionetworks.jira.com/browse/MG-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ