### PR TITLE
fix(explorers): skip nx cloud for e2e tests (SMR-463)

### DIFF
--- a/.github/workflows/e2e-explorer.yaml
+++ b/.github/workflows/e2e-explorer.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Run Explorer e2e tests
         env:
-          cmd: 'CI=true nx run ${{ inputs.explorer }}-app:e2e'
+          cmd: 'CI=true nx run ${{ inputs.explorer }}-app:e2e --no-cloud'
         run: |
           devcontainer exec --workspace-folder ../sage-monorepo bash -c ". ./dev-env.sh \
               && ${cmd}"


### PR DESCRIPTION
## Description

Explorer e2e GitHub Actions jobs have been failing with a "Nx Cloud: Workspace is unable to be authorized. Exiting run." error. The failing step uniquely sets the `CI=true` environment variable, which is used to prevent Playwright reports from opening on test failures in CI environments. Since the e2e workflow doesn't set `NX_CLOUD_ACCESS_TOKEN` to authenticate with Nx Cloud, we will disable Nx Cloud for the explorer e2e tests for now. 

## Related Issue

[SMR-463](https://sagebionetworks.jira.com/browse/SMR-463)

## Changelog

- Disables Nx Cloud for explorer e2e tests

## Preview

Start Model-AD: `model-ad-build-images && model-ad-docker-start`

Run e2e tests without disabling Nx Cloud to see the current failure state: 

```
$ CI=true nx run model-ad-app:e2e

 NX   Nx Cloud: Workspace is unable to be authorized. Exiting run.
 
You are not logged into Nx Cloud. You will have limited access to Nx Cloud features such as the remote cache. To log into your workspace, run "nx-cloud login".
```

Run e2e tests with Nx Cloud disabled to see the tests pass: 

```
$ CI=true nx run model-ad-app:e2e --no-cloud

 NX   Nx Cloud manually disabled

Nx will continue running, but nothing will be written or read from the remote cache.
Run details will also not be available in the Nx Cloud UI.

If this wasn't intentional, check for the NX_NO_CLOUD environment variable or the --no-cloud flag.


 NX   Ensuring Playwright is installed.
...
 NX   Successfully ran target e2e for project model-ad-app
```

[SMR-463]: https://sagebionetworks.jira.com/browse/SMR-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ