### PR TITLE
chore: replace OpenAPI extension `x-audience` by `x-internal`

### DIFF
--- a/libs/agora/api-description/openapi/api-next-service.openapi.yaml
+++ b/libs/agora/api-description/openapi/api-next-service.openapi.yaml
@@ -16,8 +16,7 @@ servers:
 tags:
   - name: Health Check
     description: Operations about health checks.
-    x-audience:
-      - internal
+    x-internal: true
 paths:
   /next/health-check:
     get:

--- a/libs/agora/api-description/redocly.yaml
+++ b/libs/agora/api-description/redocly.yaml
@@ -33,28 +33,14 @@ apis:
   api-public:
     root: ./src/api.openapi.yaml
     decorators:
-      filter-in:
-        property: x-audience
-        value: [public]
+      remove-x-internal: on
   api-service:
     root: ./src/api.openapi.yaml
-    decorators:
-      filter-in:
-        property: x-audience
-        value: [public, internal]
-        matchStrategy: any
 
   # Next API
   api-next-public:
     root: ./src/api-next.openapi.yaml
     decorators:
-      filter-in:
-        property: x-audience
-        value: [public]
+      remove-x-internal: on
   api-next-service:
     root: ./src/api-next.openapi.yaml
-    decorators:
-      filter-in:
-        property: x-audience
-        value: [public, internal]
-        matchStrategy: any

--- a/libs/agora/api-description/src/api-next.openapi.yaml
+++ b/libs/agora/api-description/src/api-next.openapi.yaml
@@ -16,7 +16,7 @@ servers:
 tags:
   - name: Health Check
     description: Operations about health checks.
-    x-audience: [internal]
+    x-internal: true
 paths:
   # We prefix all the paths with the segment "next/" to prevent conflicts with the primary API
   /next/health-check:

--- a/libs/bixarena/api-description/openapi/api-public.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-public.openapi.yaml
@@ -40,8 +40,6 @@ paths:
       summary: Get leaderboard entries
       description: Get paginated leaderboard entries for a specific leaderboard
       operationId: getLeaderboard
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/leaderboardSearchQuery'
@@ -65,8 +63,6 @@ paths:
       summary: Get model performance history
       description: Get historical performance data for a specific model in a leaderboard
       operationId: getModelHistory
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/modelId'
@@ -91,8 +87,6 @@ paths:
       summary: Get leaderboard snapshots
       description: Get a paginated list of available snapshots for a leaderboard
       operationId: getLeaderboardSnapshots
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/leaderboardSnapshotQuery'

--- a/libs/bixarena/api-description/openapi/api-service.openapi.yaml
+++ b/libs/bixarena/api-description/openapi/api-service.openapi.yaml
@@ -40,8 +40,6 @@ paths:
       summary: Get leaderboard entries
       description: Get paginated leaderboard entries for a specific leaderboard
       operationId: getLeaderboard
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/leaderboardSearchQuery'
@@ -65,8 +63,6 @@ paths:
       summary: Get model performance history
       description: Get historical performance data for a specific model in a leaderboard
       operationId: getModelHistory
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/modelId'
@@ -91,8 +87,6 @@ paths:
       summary: Get leaderboard snapshots
       description: Get a paginated list of available snapshots for a leaderboard
       operationId: getLeaderboardSnapshots
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/leaderboardSnapshotQuery'

--- a/libs/bixarena/api-description/openapi/openapi.yaml
+++ b/libs/bixarena/api-description/openapi/openapi.yaml
@@ -40,8 +40,6 @@ paths:
       summary: Get leaderboard entries
       description: Get paginated leaderboard entries for a specific leaderboard
       operationId: getLeaderboard
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/leaderboardSearchQuery'
@@ -65,8 +63,6 @@ paths:
       summary: Get model performance history
       description: Get historical performance data for a specific model in a leaderboard
       operationId: getModelHistory
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/modelId'
@@ -91,8 +87,6 @@ paths:
       summary: Get leaderboard snapshots
       description: Get a paginated list of available snapshots for a leaderboard
       operationId: getLeaderboardSnapshots
-      x-audience:
-        - public
       parameters:
         - $ref: '#/components/parameters/leaderboardId'
         - $ref: '#/components/parameters/leaderboardSnapshotQuery'

--- a/libs/bixarena/api-description/redocly.yaml
+++ b/libs/bixarena/api-description/redocly.yaml
@@ -32,13 +32,6 @@ apis:
   api-public:
     root: ./src/api.openapi.yaml
     decorators:
-      filter-in:
-        property: x-audience
-        value: [public]
+      remove-x-internal: on
   api-service:
     root: ./src/api.openapi.yaml
-    decorators:
-      filter-in:
-        property: x-audience
-        value: [public, internal]
-        matchStrategy: any

--- a/libs/bixarena/api-description/src/paths/leaderboards/{leaderboardId}.yaml
+++ b/libs/bixarena/api-description/src/paths/leaderboards/{leaderboardId}.yaml
@@ -4,7 +4,6 @@ get:
   summary: Get leaderboard entries
   description: Get paginated leaderboard entries for a specific leaderboard
   operationId: getLeaderboard
-  x-audience: [public]
   parameters:
     - $ref: ../../components/parameters/path/leaderboardId.yaml
     - $ref: ../../components/parameters/query/leaderboardSearchQuery.yaml

--- a/libs/bixarena/api-description/src/paths/leaderboards/{leaderboardId}/history/{modelId}.yaml
+++ b/libs/bixarena/api-description/src/paths/leaderboards/{leaderboardId}/history/{modelId}.yaml
@@ -4,7 +4,6 @@ get:
   summary: Get model performance history
   description: Get historical performance data for a specific model in a leaderboard
   operationId: getModelHistory
-  x-audience: [public]
   parameters:
     - $ref: ../../../../components/parameters/path/leaderboardId.yaml
     - $ref: ../../../../components/parameters/path/modelId.yaml

--- a/libs/bixarena/api-description/src/paths/leaderboards/{leaderboardId}/snapshots.yaml
+++ b/libs/bixarena/api-description/src/paths/leaderboards/{leaderboardId}/snapshots.yaml
@@ -4,7 +4,6 @@ get:
   summary: Get leaderboard snapshots
   description: Get a paginated list of available snapshots for a leaderboard
   operationId: getLeaderboardSnapshots
-  x-audience: [public]
   parameters:
     - $ref: ../../../components/parameters/path/leaderboardId.yaml
     - $ref: ../../../components/parameters/query/leaderboardSnapshotQuery.yaml


### PR DESCRIPTION
## Description

<!-- Please include a brief summary of the changes and the related issue. Itemize
the changes in the section Changelog (see below). -->

## Related Issue

- [SMR-465](https://sagebionetworks.jira.com/browse/SMR-465)

## Changelog

- Replace OpenAPI vendor extension `x-audience: string[]` to `x-internal: boolean`.
- Remove `x-audience: [public]` to simplify OpenAPI files because it's the same as not including this annotation.
- Update Redocly config files to remove nodes annotated with `x-internal: true`.