### PR TITLE
fix(model-ad): update 'no results' message in search input (MG-409)

### DIFF
--- a/apps/model-ad/app/e2e/search.spec.ts
+++ b/apps/model-ad/app/e2e/search.spec.ts
@@ -117,7 +117,7 @@ test.describe('search', () => {
     const input = page.getByPlaceholder(headerSearchPlaceholder);
     await input.pressSequentially('this-model-does-not-exist');
     await expect(
-      page.getByRole('listitem').filter({ hasText: /no results match your search string/i }),
+      page.getByRole('listitem').filter({ hasText: /no results match your search term/i }),
     ).toBeVisible();
   });
 
@@ -137,7 +137,7 @@ test.describe('search', () => {
     await input.press('Backspace');
 
     await expect(
-      page.getByRole('listitem').filter({ hasText: /no results match your search string/i }),
+      page.getByRole('listitem').filter({ hasText: /no results match your search term/i }),
     ).toBeVisible();
   });
 

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
@@ -96,7 +96,7 @@ describe('SearchInputComponent', () => {
 
     await waitForSpinner();
 
-    await screen.findByText('No results match your search string.');
+    await screen.findByText('No results match your search term.');
   });
 
   it('should highlight search query with mark', async () => {

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -67,7 +67,7 @@ export class SearchInputComponent implements AfterViewInit {
 
   showResults = false;
   errorMessages: { [key: string]: string } = {
-    notFound: 'No results match your search string.',
+    notFound: 'No results match your search term.',
     notValidSearch: 'Please enter at least three characters.',
     unknown: 'An unknown error occurred, please try again.',
   };


### PR DESCRIPTION
## Description

We would like to update the 'no results' message in the search input.

## Related Issue

[MG-409](https://sagebionetworks.jira.com/browse/MG-409)

## Changelog

- Update 'no results' message in search input

## Preview

`model-ad-build-images && model-ad-docker-start`

<img width="1624" height="1056" alt="MG-409" src="https://github.com/user-attachments/assets/84e21197-2b2b-4246-b92c-c8dbc3da1d4d" />


[MG-409]: https://sagebionetworks.jira.com/browse/MG-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ