### PR TITLE
fix(model-ad): remove frontend search query sanitization in favor of backend query escaping

### DIFF
--- a/apps/model-ad/app/e2e/search.spec.ts
+++ b/apps/model-ad/app/e2e/search.spec.ts
@@ -206,4 +206,21 @@ test.describe('search', () => {
       await expect(searchListItems.nth(i)).toBeInViewport();
     }
   });
+
+  test('can search for model with special characters', async ({ page }) => {
+    const modelQuery = 'load1.';
+    const modelName = 'LOAD1.Abca7A1527G';
+
+    await page.goto('/');
+
+    const { searchListItems } = await searchAndGetSearchListItems(modelQuery, page);
+
+    const searchListItem = searchListItems.first();
+    await expect(searchListItem).toHaveText(modelName);
+
+    await searchListItem.click();
+
+    await page.waitForURL(`/models/${modelName}`);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(modelName);
+  });
 });

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.spec.ts
@@ -317,4 +317,15 @@ describe('SearchInputComponent', () => {
     expect(screen.getByLabelText('dummy_id')).toBeInTheDocument();
     expect(screen.getByLabelText('dummy_id_2')).toBeInTheDocument();
   });
+
+  it('should not trim search with special characters', async () => {
+    const { user } = await setup();
+    const input = getInput();
+
+    const specialCharQuery = 'gene-name_1234:();,.\'*&"@#=!$';
+    await user.type(input, specialCharQuery);
+
+    await waitForSpinner();
+    expect(input).toHaveValue(specialCharQuery);
+  });
 });

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -119,16 +119,14 @@ export class SearchInputComponent implements AfterViewInit {
     this.error = '';
     this.selectedResultIndex = -1;
 
-    // Allow model names with special characters - backend handles sanitization
-    this.query = query = query.replace(/[^a-z0-9\-_()/*: ]/gi, '');
-
-    // If query is empty after sanitization, hide results and return
+    // If query is empty, hide results and return
     if (query.length === 0) {
       this.showResults = false;
       this.isLoading = false;
       return EMPTY;
     }
 
+    // No frontend sanitization - backend handles all input escaping and security validation
     if (query.length > 0 && query.length < 3) {
       this.error = this.errorMessages['notValidSearch'];
     } else {


### PR DESCRIPTION
## Description

Currently, the frontend performs sanitization to remove special characters from the search query. However, some special characters are valid, e.g. a period is a character in a model name. The backend already performs regex escaping, so the frontend sanitization is unnecessarily restrictive and prevents users from searching for characters in valid model names. We will remove the frontend sanitization in favor of the backend query handling.

## Related Issue

[MG-408](https://sagebionetworks.jira.com/browse/MG-408)

## Changelog

- Remove frontend search query sanitization in favor of backend query handling

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/af0e6678-fac9-436b-b7ab-e9bed5065ead

[MG-408]: https://sagebionetworks.jira.com/browse/MG-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ