### PR TITLE
feat: centralize all Caddy images and update to Caddy 2.10.2 - Take 2 (SMR-433)

### DIFF
--- a/apps/agora/apex/Dockerfile
+++ b/apps/agora/apex/Dockerfile
@@ -1,3 +1,0 @@
-FROM mirror.gcr.io/caddy:2.8.4
-
-COPY Caddyfile /etc/caddy/

--- a/apps/agora/apex/project.json
+++ b/apps/agora/apex/project.json
@@ -24,5 +24,5 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"]
+  "tags": ["type:service", "scope:backend", "container-image:caddy"]
 }

--- a/apps/bixarena/apex/Dockerfile
+++ b/apps/bixarena/apex/Dockerfile
@@ -1,8 +1,0 @@
-FROM mirror.gcr.io/caddy:2.8.4
-
-RUN apk add --no-cache curl jq
-
-HEALTHCHECK --interval=2s --timeout=3s --retries=20 --start-period=5s \
-  CMD curl --fail --silent "localhost:8111/health" | jq '.status' | grep healthy || exit 1
-
-COPY Caddyfile /etc/caddy/

--- a/apps/bixarena/apex/project.json
+++ b/apps/bixarena/apex/project.json
@@ -24,5 +24,5 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"]
+  "tags": ["type:service", "scope:backend", "container-image:caddy"]
 }

--- a/apps/model-ad/apex/Dockerfile
+++ b/apps/model-ad/apex/Dockerfile
@@ -1,3 +1,0 @@
-FROM mirror.gcr.io/caddy:2.8.4
-
-COPY Caddyfile /etc/caddy/

--- a/apps/model-ad/apex/project.json
+++ b/apps/model-ad/apex/project.json
@@ -24,5 +24,9 @@
       }
     }
   },
+<<<<<<< HEAD
   "tags": ["type:service", "scope:backend"]
+=======
+  "tags": ["type:service", "scope:backend", "container-image:caddy"]
+>>>>>>> ae4a636c (refactor: centralize all Caddy images)
 }

--- a/apps/observability/apex/Dockerfile
+++ b/apps/observability/apex/Dockerfile
@@ -1,3 +1,0 @@
-FROM mirror.gcr.io/caddy:2.8.4
-
-COPY Caddyfile /etc/caddy/

--- a/apps/observability/apex/project.json
+++ b/apps/observability/apex/project.json
@@ -24,5 +24,5 @@
       }
     }
   },
-  "tags": ["type:service", "scope:backend"]
+  "tags": ["type:service", "scope:backend", "container-image:caddy"]
 }

--- a/libs/sage-monorepo/nx-plugin/src/config/README.md
+++ b/libs/sage-monorepo/nx-plugin/src/config/README.md
@@ -88,7 +88,7 @@ Dockerfile templates are stored in:
 
 These templates support variable substitution:
 
-- `{{containerImage}}`: Replaced with the centralized container image
+- `{{baseImage}}`: Replaced with the base image
 
 ## Benefits
 

--- a/libs/sage-monorepo/nx-plugin/src/config/README.md
+++ b/libs/sage-monorepo/nx-plugin/src/config/README.md
@@ -31,13 +31,8 @@ For postgres and caddy projects, the plugin automatically creates:
 Base images are centrally configured in:
 
 ```
-libs/sage-monorepo/nx-plugin/src/config/base-images.ts
+libs/sage-monorepo/nx-plugin/src/config/container-images.ts
 ```
-
-Current configuration:
-
-- **postgres**: `mirror.gcr.io/postgres:16.9-bullseye`
-- **caddy**: `mirror.gcr.io/caddy:2.9.1`
 
 ## Usage
 
@@ -60,11 +55,11 @@ For custom projects:
 nx run bixarena-postgres:build-image
 ```
 
-### Updating Base Images
+### Updating Container Images
 
 To update a container image version:
 
-1. Edit `libs/sage-monorepo/nx-plugin/src/config/base-images.ts`
+1. Edit `libs/sage-monorepo/nx-plugin/src/config/container-images.ts`
 2. Update the version for the desired image type
 3. Rebuild the plugin: `nx build sage-monorepo-nx-plugin`
 4. Reset Nx cache: `nx reset`
@@ -77,11 +72,11 @@ View project classification:
 ```bash
 # Check project tags to see container image type
 nx show project openchallenges-postgres --json | jq '.tags'
-# Output: ["base-image:postgres", "type:db", "scope:backend"]
+# Output: ["container-image:postgres", "type:db", "scope:backend"]
 
 # Check available targets
 nx show project openchallenges-postgres --json | jq '.targets | keys'
-# Output: ["build-image", "create-config", "generate-dockerfile", "serve-detach"]
+# Output: ["container-image", "create-config", "generate-dockerfile", "serve-detach"]
 ```
 
 ## Templates
@@ -93,7 +88,7 @@ Dockerfile templates are stored in:
 
 These templates support variable substitution:
 
-- `{{baseImage}}`: Replaced with the centralized container image
+- `{{containerImage}}`: Replaced with the centralized container image
 
 ## Benefits
 

--- a/libs/sage-monorepo/nx-plugin/src/config/container-images.ts
+++ b/libs/sage-monorepo/nx-plugin/src/config/container-images.ts
@@ -18,7 +18,7 @@ export const CONTAINER_IMAGES: ContainerImagesRegistry = {
   },
   caddy: {
     name: 'caddy',
-    version: '2.9.1', // Using the newer version from amp-als
+    version: '2.10.2',
     registry: 'mirror.gcr.io',
   },
 };

--- a/libs/sage-monorepo/nx-plugin/src/config/container-images.ts
+++ b/libs/sage-monorepo/nx-plugin/src/config/container-images.ts
@@ -24,7 +24,7 @@ export const CONTAINER_IMAGES: ContainerImagesRegistry = {
 };
 
 /**
- * Get the full container image string (registry/name:version) for a given image type
+ * Get the full base container image string (registry/name:version) for a given image type
  */
 export function getContainerImageString(imageKey: keyof ContainerImagesRegistry): string {
   const config = CONTAINER_IMAGES[imageKey];

--- a/libs/sage-monorepo/nx-plugin/src/plugins/generate-dockerfile-target.ts
+++ b/libs/sage-monorepo/nx-plugin/src/plugins/generate-dockerfile-target.ts
@@ -19,7 +19,7 @@ export function generateDockerfileTarget(
     options: {
       commands: [
         {
-          command: `echo "Generating Dockerfile with container image: ${baseImage}"`,
+          command: `echo "Generating Dockerfile with base image: ${baseImage}"`,
         },
         {
           command: `sed 's|{{baseImage}}|${baseImage}|g' ${templatePath} > ${projectRoot}/Dockerfile.generated`,


### PR DESCRIPTION
## Description

Centralize all Caddy images and update to Caddy 2.10.2.

## Related Issue

- [SMR-433](https://sagebionetworks.jira.com/browse/SMR-433)

## Changelog

- Centralize all the Caddy Docker images
- Update to Caddy 2.10.2
- Fix selected term "base image" by "container image" in the README of our Nx plugin

## Preview

Changing the template of a container image or one of its variable like the `baseImage` require to build the plugin and reset Nx. This should no longer be the case when these information will be externalized from the plugin.

```bash
nx build sage-monorepo-nx-plugin
nx reset
```

The logs in the CI workflow shows the value of the variable `baseImage`:

```console
> nx run bixarena-apex:generate-dockerfile

> echo "Generating Dockerfile with container image: mirror.gcr.io/caddy:2.10.2"

Generating Dockerfile with container image: mirror.gcr.io/caddy:2.10.2

> sed 's|{{baseImage}}|mirror.gcr.io/caddy:2.10.2|g' libs/sage-monorepo/nx-plugin/src/templates/caddy.Dockerfile.template > apps/bixarena/apex/Dockerfile.generated
```

Build the Docker images of all the apex projects.

```bash
nx run-many -p *-apex -t build-image
```

Output:

```console
$ docker images
REPOSITORY                                     TAG           IMAGE ID       CREATED              SIZE
ghcr.io/sage-bionetworks/observability-apex    local         5c51b12950c7   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/observability-apex    sha-eff9260   5c51b12950c7   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/openchallenges-apex   local         a06b91f889d1   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/openchallenges-apex   sha-eff9260   a06b91f889d1   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/agora-apex            local         389bf9bc8b8e   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/agora-apex            sha-eff9260   389bf9bc8b8e   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/amp-als-apex          local         cc4eaceb4e8d   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/amp-als-apex          sha-eff9260   cc4eaceb4e8d   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/model-ad-apex         local         45893d87dedb   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/model-ad-apex         sha-eff9260   45893d87dedb   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/bixarena-apex         local         9c79f2300633   About a minute ago   53.4MB
ghcr.io/sage-bionetworks/bixarena-apex         sha-eff9260   9c79f2300633   About a minute ago   53.4MB
```

A nice feature, likely from the Nx extension for VS Code, is to get access to the list of existing project tags:

<img width="1766" height="222" alt="image" src="https://github.com/user-attachments/assets/f99dcb8c-2810-4080-84fc-ea43308b9cf9" />

<img width="1530" height="533" alt="image" src="https://github.com/user-attachments/assets/dd6508aa-b0b0-452a-aa0c-1cb339f196ca" />


## Checklist

Local testing:

- [x] OpenChallenges
- [x] Agora
- [x] Model-AD

[SMR-433]: https://sagebionetworks.jira.com/browse/SMR-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ