### PR TITLE
chore(deps): update all es targets to `es2024` (SMR-284)

### DIFF
--- a/apps/agora/app/tsconfig.spec.json
+++ b/apps/agora/app/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/apps/openchallenges/app/tsconfig.json
+++ b/apps/openchallenges/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/apps/openchallenges/app/tsconfig.spec.json
+++ b/apps/openchallenges/app/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/amp-als/api-client-angular/tsconfig.json
+++ b/libs/amp-als/api-client-angular/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/amp-als/api-client-angular/tsconfig.lib.json
+++ b/libs/amp-als/api-client-angular/tsconfig.lib.json
@@ -6,7 +6,7 @@
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
-    "target": "ES2022",
+    "target": "es2024",
     "useDefineForClassFields": false,
     "moduleResolution": "bundler"
   },

--- a/libs/amp-als/api-client-angular/tsconfig.lib.prod.json
+++ b/libs/amp-als/api-client-angular/tsconfig.lib.prod.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
     "declarationMap": false,
-    "target": "ES2022",
+    "target": "es2024",
     "useDefineForClassFields": false,
     "moduleResolution": "bundler"
   },

--- a/libs/explorers/charts-angular/tsconfig.json
+++ b/libs/explorers/charts-angular/tsconfig.json
@@ -14,7 +14,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/explorers/charts/tsconfig.json
+++ b/libs/explorers/charts/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/openchallenges/about/tsconfig.json
+++ b/libs/openchallenges/about/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/api-client-angular/tsconfig.json
+++ b/libs/openchallenges/api-client-angular/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/openchallenges/api-client-angular/tsconfig.spec.json
+++ b/libs/openchallenges/api-client-angular/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/openchallenges/challenge-search/tsconfig.json
+++ b/libs/openchallenges/challenge-search/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/challenge/tsconfig.json
+++ b/libs/openchallenges/challenge/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/config/tsconfig.json
+++ b/libs/openchallenges/config/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/home/tsconfig.json
+++ b/libs/openchallenges/home/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/not-found/tsconfig.json
+++ b/libs/openchallenges/not-found/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/org-profile/tsconfig.json
+++ b/libs/openchallenges/org-profile/tsconfig.json
@@ -18,7 +18,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/org-search/tsconfig.json
+++ b/libs/openchallenges/org-search/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/openchallenges/ui/tsconfig.json
+++ b/libs/openchallenges/ui/tsconfig.json
@@ -17,7 +17,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/results-visualization-framework/ui/tsconfig.json
+++ b/libs/results-visualization-framework/ui/tsconfig.json
@@ -20,7 +20,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "es2020"
+    "target": "es2024"
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,

--- a/libs/sandbox/angular-lib/tsconfig.json
+++ b/libs/sandbox/angular-lib/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/sandbox/angular-lib/tsconfig.spec.json
+++ b/libs/sandbox/angular-lib/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/libs/shared/typescript/util/tsconfig.json
+++ b/libs/shared/typescript/util/tsconfig.json
@@ -11,7 +11,7 @@
     }
   ],
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/synapse/api-client-angular/tsconfig.json
+++ b/libs/synapse/api-client-angular/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2024",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/synapse/api-client-angular/tsconfig.spec.json
+++ b/libs/synapse/api-client-angular/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2024",
     "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],

--- a/tools/tsconfig.tools.json
+++ b/tools/tsconfig.tools.json
@@ -4,7 +4,7 @@
     "outDir": "../dist/out-tsc/tools",
     "rootDir": ".",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2024",
     "types": ["node"],
     "importHelpers": false
   },


### PR DESCRIPTION
## Description

Update all es targets to `es2024`.

## Related Issue

- [SMR-284](https://sagebionetworks.jira.com/browse/SMR-284)

## Changelog

Update all es targets to `es2024`.


[SMR-284]: https://sagebionetworks.jira.com/browse/SMR-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ