### PR TITLE
fix(openchallenges): add missing Nx task `openchallenges-app:create-config` (SMR-459)

### DIFF
--- a/apps/openchallenges/app/project.json
+++ b/apps/openchallenges/app/project.json
@@ -11,6 +11,13 @@
     "shared-typescript-assets"
   ],
   "targets": {
+    "create-config": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cp -n .env.example .env",
+        "cwd": "{projectRoot}"
+      }
+    },
     "build": {
       "executor": "@nx/angular:application",
       "outputs": ["{options.outputPath}"],


### PR DESCRIPTION
## Description

Add missing Nx task `openchallenges-app:create-config`.

## Related Issue

- [SMR-459](https://sagebionetworks.jira.com/browse/SMR-459)

## Changelog

- Add missing Nx task `openchallenges-app:create-config`.



[SMR-459]: https://sagebionetworks.jira.com/browse/SMR-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ