### PR TITLE
fix(explorers): fix csrApiUrl for explorers to use extra_host feature (SMR-473)

### DIFF
--- a/apps/agora/app/src/config/config.json
+++ b/apps/agora/app/src/config/config.json
@@ -1,7 +1,7 @@
 {
   "apiDocsUrl": "http://localhost:8000/api-docs",
   "appVersion": "edge",
-  "csrApiUrl": "http://localhost:4200/v1",
+  "csrApiUrl": "http://localhost:8000/api/v1",
   "ssrApiUrl": "http://agora-api:3333/v1",
   "tagName": "edge",
   "googleTagManagerId": ""

--- a/apps/model-ad/app/src/config/config.json
+++ b/apps/model-ad/app/src/config/config.json
@@ -1,7 +1,7 @@
 {
   "apiDocsUrl": "http://localhost:8000/api-docs",
   "appVersion": "1.0.0-beta",
-  "csrApiUrl": "http://localhost:4200/v1",
+  "csrApiUrl": "http://localhost:8000/api/v1",
   "dataUpdatedOn": "yyyy-mm-dd",
   "environment": "development",
   "googleTagManagerId": "",


### PR DESCRIPTION
## Description

Fix `csrApiUrl` for explorers to use extra_host feature.

## Related Issue

[SMR-473](https://sagebionetworks.jira.com/browse/SMR-473)

## Changelog

- Update `csrApiUrl` for model-ad-app and explorers-app to work with extra_host feature

## Preview

`model-ad-build-images && model-ad-docker-start && docker rm -f model-ad-app && nx serve model-ad-app`
Navigate to a page that makes an API call to model-ad-api, e.g. `http://localhost:8000/models/3xTg-AD`
Page should load: 
<img width="1624" height="1056" alt="SMR-473" src="https://github.com/user-attachments/assets/3de772ad-31a7-4270-ba01-9cd5bfd0db32" />

[SMR-473]: https://sagebionetworks.jira.com/browse/SMR-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ