### PR TITLE
fix(model-ad): conditionally display omics tab, fallback to default tab when invalid or disabled tab in URL (MG-282, MG-415)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -14,7 +14,7 @@ test.describe('model details', () => {
     await expect(page.getByRole('heading', { level: 1, name: 'APOE4' })).toBeVisible();
   });
 
-  test('default tab is omics', async ({ page }) => {
+  test('default tab is omics for model with omics data', async ({ page }) => {
     await page.goto('/models/APOE4');
     await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
   });
@@ -92,6 +92,47 @@ test.describe('model details', () => {
     ).not.toBeInViewport();
     await page.evaluate(() => window.pageYOffset === 0);
   });
+
+  test('disabled tab in url defaults to first available tab and does not scroll', async ({
+    page,
+  }) => {
+    const model = 'LOAD1';
+    await page.goto(`/models/${model}/pathology`);
+    await expect(page.getByRole('heading', { level: 1, name: model })).toBeInViewport();
+    await page.evaluate(() => window.pageYOffset === 0);
+    await page.waitForURL(`/models/${model}`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
+  });
+
+  test('invalid tab in url defaults to first available tab and does not scroll', async ({
+    page,
+  }) => {
+    const model = '3xTg-AD';
+    await page.goto(`/models/${model}/does-not-exist`);
+    await expect(page.getByRole('heading', { level: 1, name: model })).toBeInViewport();
+    await page.evaluate(() => window.pageYOffset === 0);
+    await page.waitForURL(`/models/${model}`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
+  });
+
+  test.skip(
+    'omics tab is not shown when omics data is unavailable',
+    {
+      annotation: {
+        type: 'skip',
+        description: 'enable when model without omics data is available',
+      },
+    },
+    async ({ page }) => {
+      const modelWithoutOmics = 'APOECh';
+      await page.goto(`/models/${modelWithoutOmics}`);
+      await expect(page.getByRole('heading', { level: 1, name: modelWithoutOmics })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Omics' })).toHaveCount(0);
+      await expect(
+        page.getByRole('heading', { level: 2, name: 'Model-Specific Resources' }),
+      ).toBeVisible();
+    },
+  );
 });
 
 test.describe('model details - omics', () => {

--- a/libs/explorers/services/src/lib/helper.service.ts
+++ b/libs/explorers/services/src/lib/helper.service.ts
@@ -74,6 +74,24 @@ export class HelperService {
     }
   }
 
+  findPanelByName(panels: Panel[], panelName: string): Panel | undefined {
+    const topLevelPanel = panels.find((p) => p.name === panelName);
+    if (topLevelPanel) {
+      return topLevelPanel;
+    }
+
+    for (const panel of panels) {
+      if (panel.children) {
+        const childPanel = panel.children.find((child) => child.name === panelName);
+        if (childPanel) {
+          return childPanel;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
   getUrlParam(name: string) {
     if (typeof window === 'undefined') return null;
 


### PR DESCRIPTION
## Description

We would like to hide the omics tab from the model details page when there is no omics data. We would also like to gracefully handle the case where the URL contains a tab that does not exist or is disabled for the current model.

## Related Issue

- [MG-282](https://sagebionetworks.jira.com/browse/MG-282)
- [MG-415](https://sagebionetworks.jira.com/browse/MG-415)

## Changelog

- Adds conditional disabling of the Omics tab
- Implements fallback logic to redirect users from invalid/disabled tabs to the first available tab and update the URL
- Changes the default activePanel from 'omics' to empty string to ensure proper fallback behavior instead of assuming omics is always available
- Moves URL parsing from ngOnInit to inside the HTTP response handler so panel validation occurs after model data is loaded

## Preview

Start the app: `model-ad-build-images && model-ad-docker-start`
Connect to the model-ad-mongo db
Add a test model without omics data: 

```
// Get an existing model
let testModel = db.model_details.findOne({ name: "LOAD1" });

// Remove the _id field so MongoDB will generate a new one
delete testModel._id;

// Update the specific fields
testModel.name = "MG-282-test";
testModel.gene_expression = null;
testModel.disease_correlation = null;

// Insert the new model
db.model_details.insertOne(testModel);
```

Navigate to the test model without omics data: 

- Defaults to first tab with data: "Resources"
- Does not scroll
- URL is unchanged

https://github.com/user-attachments/assets/4f6a2961-0c76-478b-b21b-b7ded805b8fc

Navigate to a tab that is disabled for a model:

- Defaults to first tab with data: "Omics"
- Does not scroll
- URL corrected to remove the incorrect tab

https://github.com/user-attachments/assets/9d967da4-64c4-4230-8d45-8af0f15134d6

[MG-282]: https://sagebionetworks.jira.com/browse/MG-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-415]: https://sagebionetworks.jira.com/browse/MG-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ