### PR TITLE
fix(model-ad): clean up section link fragments (MG-414)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -283,7 +283,7 @@ test.describe('model details - boxplots selector - table of contents', () => {
     page,
   }) => {
     const model = 'Abca7*V1599M';
-    const fragment = 'soluble-a-beta-40';
+    const fragment = 'soluble-abeta40';
     const section = 'Soluble Aβ40';
     await page.goto(`/models/${model}/biomarkers#${fragment}`);
     await expect(page.getByRole('heading', { level: 1, name: model })).toBeVisible();
@@ -314,7 +314,7 @@ test.describe('model details - boxplots selector - table of contents', () => {
     const section = 'NfL';
     const fragment = 'nfl';
 
-    await page.goto(`${basePath}#soluble-a-beta-40`);
+    await page.goto(`${basePath}#soluble-abeta40`);
     await expect(page.getByRole('heading', { level: 1, name: model })).toBeVisible();
 
     const nflButton = page.getByRole('button', { name: section, exact: true });
@@ -363,7 +363,7 @@ test.describe('model details - boxplots selector - share links - initial load', 
   }) => {
     const tissueFilter = 'Hippocampus';
     const sexFilter = 'Male';
-    await page.goto(`${basePath}?tissue=${tissueFilter}&sex=${sexFilter}#soluble-a-beta-42`);
+    await page.goto(`${basePath}?tissue=${tissueFilter}&sex=${sexFilter}#soluble-abeta42`);
     await expect(page.getByRole('combobox', { name: tissueFilter })).toBeVisible();
     await expect(page.getByRole('combobox', { name: sexFilter })).toBeVisible();
     await expect(
@@ -374,7 +374,7 @@ test.describe('model details - boxplots selector - share links - initial load', 
   test('falls back to default filters when query parameters are invalid', async ({ page }) => {
     const invalidTissue = 'InvalidTissue';
     const invalidSex = 'InvalidSex';
-    const fragment = '#soluble-a-beta-42';
+    const fragment = '#soluble-abeta42';
     await page.goto(`${basePath}?tissue=${invalidTissue}&sex=${invalidSex}${fragment}`);
     await expect(page.getByRole('combobox', { name: tissueDefault })).toBeVisible();
     await expect(page.getByRole('combobox', { name: sexDefault })).toBeVisible();
@@ -416,14 +416,14 @@ test.describe('model details - boxplots selector - share links - updates', () =>
     const pathWithParams = `${basePath}?tissue=Hippocampus&sex=Male`;
     await page.goto(pathWithParams);
     await page.getByRole('button', { name: 'Soluble Aβ42', exact: true }).click();
-    await page.waitForURL(`${pathWithParams}#soluble-a-beta-42`);
+    await page.waitForURL(`${pathWithParams}#soluble-abeta42`);
   });
 
   test('preserves fragment that remains valid when query parameters are updated', async ({
     page,
   }) => {
     const tissueChosen = 'Hippocampus';
-    const fragment = '#soluble-a-beta-42';
+    const fragment = '#soluble-abeta42';
     await page.goto(`${basePath}${fragment}`);
     await page.getByRole('combobox', { name: tissueDefault }).click();
     await page.getByRole('option', { name: tissueChosen }).click();
@@ -448,7 +448,7 @@ test.describe('model details - boxplots selector - share links - link button', (
     page,
     context,
   }) => {
-    const path = `${basePath}#soluble-a-beta-42`;
+    const path = `${basePath}#soluble-abeta42`;
     await context.grantPermissions(['clipboard-read']);
 
     await page.goto(path);

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -113,8 +113,11 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
   it('should convert evidence type to anchor id', async () => {
     const { component } = await setup();
     expect(component.generateAnchorId('Amyloid Beta')).toBe('amyloid-beta');
-    expect(component.generateAnchorId('A&beta;42')).toBe('a-beta-42');
+    expect(component.generateAnchorId('Insoluble A&beta;42')).toBe('insoluble-abeta42');
     expect(component.generateAnchorId('Tau-pS396')).toBe('tau-ps396');
+    expect(component.generateAnchorId('Astrocyte Cell Density (GFAP)')).toBe(
+      'astrocyte-cell-density-gfap',
+    );
   });
 
   it('should decode HTML entities correctly', async () => {

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -202,7 +202,8 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
   generateAnchorId(evidenceType: string): string {
     return evidenceType
       .toLowerCase()
-      .replace(/[^a-z0-9]/g, '-')
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
       .replace(/-+/g, '-');
   }
 


### PR DESCRIPTION
## Description

We would like to clean up the model details section link fragments.

## Related Issue

- [MG-414](https://sagebionetworks.jira.com/browse/MG-414)

## Changelog

- Cleans up section link fragments

## Preview

`model-ad-build-images && model-ad-docker-start`

Note the updated fragments in the URL:

https://github.com/user-attachments/assets/fc80029d-0bce-4901-b5b4-d24ef24d8d3d

[MG-414]: https://sagebionetworks.jira.com/browse/MG-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ