### PR TITLE
fix(model-ad): copying section links shouldn't change the current URL (MG-412)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { baseURL } from '../playwright.config';
 import { searchAndGetSearchListItems } from './helpers';
 
 test.describe('model details', () => {
@@ -443,13 +444,14 @@ test.describe('model details - boxplots selector - share links - updates', () =>
 
 test.describe('model details - boxplots selector - share links - link button', () => {
   const basePath = '/models/Abca7*V1599M/biomarkers';
-  test('clicking share link button updates fragment and copies link to clipboard', async ({
+  test('clicking share link button copies link to clipboard and does not update fragment in URL', async ({
     page,
     context,
   }) => {
+    const path = `${basePath}#soluble-a-beta-42`;
     await context.grantPermissions(['clipboard-read']);
 
-    await page.goto(`${basePath}#soluble-a-beta-42`);
+    await page.goto(path);
 
     // hover on heading, so share link appears
     const heading = page.getByRole('heading', { level: 2, name: 'Nfl' });
@@ -458,9 +460,9 @@ test.describe('model details - boxplots selector - share links - link button', (
     const button = page.getByRole('button', { name: 'Copy link to Nfl' });
     await button.click();
 
-    await page.waitForURL(`${basePath}#nfl`);
-
     const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
-    expect(clipboardContent).toEqual(page.url());
+    expect(clipboardContent).toEqual(`${baseURL}${basePath}#nfl`);
+
+    await page.waitForURL(path);
   });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -206,10 +206,13 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
       .replace(/-+/g, '-');
   }
 
-  updateUrlFragment(fragment: string | undefined): void {
+  getUpdatedUrlFragment(fragment: string | undefined): string {
     const fragmentPart = fragment ? `#${fragment}` : '';
-    const newUrl = `${window.location.pathname}${window.location.search}${fragmentPart}`;
-    this.location.replaceState(newUrl);
+    return `${window.location.pathname}${window.location.search}${fragmentPart}`;
+  }
+
+  updateUrlFragment(fragment: string | undefined): void {
+    this.location.replaceState(this.getUpdatedUrlFragment(fragment));
   }
 
   updateQueryParams(sex: string, tissue: string) {
@@ -269,8 +272,8 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit {
   }
 
   copyShareLink(evidenceType: string): void {
-    this.updateUrlFragment(this.generateAnchorId(evidenceType));
-    this.clipboard.copy(window.location.href);
+    const urlFragment = this.getUpdatedUrlFragment(this.generateAnchorId(evidenceType));
+    this.clipboard.copy(`${window.location.origin}${urlFragment}`);
     this.lastShareLinkCopied.set(evidenceType);
   }
 


### PR DESCRIPTION
## Description

Copying model details section links shouldn't change the current URL.

## Related Issue

[MG-412](https://sagebionetworks.jira.com/browse/MG-412)

## Changelog

- Copying model details section links no longer updates the current URL

## Preview

`model-ad-build-images && model-ad-docker-start`

https://github.com/user-attachments/assets/e62cb7f6-de43-4220-85fb-b8122a9b090f

[MG-412]: https://sagebionetworks.jira.com/browse/MG-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ