### PR TITLE
fix(model-ad): ensure scroll to section after same-document navigation (MG-413)

### DIFF
--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -3,10 +3,7 @@ import { baseURL } from '../playwright.config';
 import { searchAndGetSearchListItems } from './helpers';
 
 async function isPageAtTop(page: Page) {
-  return await page.evaluate(() => {
-    console.log(window.pageYOffset);
-    return window.pageYOffset === 0;
-  });
+  return await page.evaluate(() => window.pageYOffset === 0);
 }
 
 async function expectPageAtTop(page: Page) {

--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -428,7 +428,7 @@ test.describe('model details - boxplots selector - share links - same-document n
   test('scrolls to section during same-document navigation with different fragment', async ({
     page,
   }) => {
-    const anotherFragment = 'insoluble-a-beta-42';
+    const anotherFragment = 'insoluble-abeta42';
     await page.goto(`${basePath}#${validFragment}`);
     await expect(page.getByRole('heading', { level: 2, name: 'NfL' })).toBeInViewport();
     await expectPageNotAtTop(page);

--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -1,6 +1,21 @@
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { baseURL } from '../playwright.config';
 import { searchAndGetSearchListItems } from './helpers';
+
+async function isPageAtTop(page: Page) {
+  return await page.evaluate(() => {
+    console.log(window.pageYOffset);
+    return window.pageYOffset === 0;
+  });
+}
+
+async function expectPageAtTop(page: Page) {
+  expect(await isPageAtTop(page)).toBe(true);
+}
+
+async function expectPageNotAtTop(page: Page) {
+  expect(await isPageAtTop(page)).toBe(false);
+}
 
 test.describe('model details', () => {
   test('invalid model results in a 404 redirect', async ({ page }) => {
@@ -79,7 +94,7 @@ test.describe('model details', () => {
     await page.goto(`/models/${model}/omics`);
     await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeInViewport();
     await expect(page.getByRole('heading', { level: 1, name: model })).not.toBeInViewport();
-    await page.evaluate(() => window.pageYOffset !== 0);
+    await expectPageNotAtTop(page);
   });
 
   test('does not scroll to panel content on initial load when tab not specified in url', async ({
@@ -91,7 +106,7 @@ test.describe('model details', () => {
     await expect(
       page.getByRole('heading', { level: 2, name: 'Available Data' }),
     ).not.toBeInViewport();
-    await page.evaluate(() => window.pageYOffset === 0);
+    await expectPageAtTop(page);
   });
 
   test('disabled tab in url defaults to first available tab and does not scroll', async ({
@@ -100,7 +115,7 @@ test.describe('model details', () => {
     const model = 'LOAD1';
     await page.goto(`/models/${model}/pathology`);
     await expect(page.getByRole('heading', { level: 1, name: model })).toBeInViewport();
-    await page.evaluate(() => window.pageYOffset === 0);
+    await expectPageAtTop(page);
     await page.waitForURL(`/models/${model}`);
     await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
   });
@@ -111,7 +126,7 @@ test.describe('model details', () => {
     const model = '3xTg-AD';
     await page.goto(`/models/${model}/does-not-exist`);
     await expect(page.getByRole('heading', { level: 1, name: model })).toBeInViewport();
-    await page.evaluate(() => window.pageYOffset === 0);
+    await expectPageAtTop(page);
     await page.waitForURL(`/models/${model}`);
     await expect(page.getByRole('heading', { level: 2, name: 'Available Data' })).toBeVisible();
   });
@@ -387,6 +402,58 @@ test.describe('model details - boxplots selector - share links - initial load', 
     await page.goto(`${basePath}${queryParam}#${invalidFragment}`);
     await expect(page.getByRole('heading', { level: 1, name: 'Abca7*V1599M' })).toBeInViewport();
     await page.waitForURL(`${basePath}${queryParam}`);
+  });
+});
+
+test.describe('model details - boxplots selector - share links - same-document navigation', () => {
+  const modelName = 'Abca7*V1599M';
+  const basePath = `/models/${modelName}/biomarkers?sex=Male`;
+  const validFragment = 'nfl';
+
+  test('scrolls to section during same-document navigation with same fragment', async ({
+    page,
+  }) => {
+    const path = `${basePath}#${validFragment}`;
+    await page.goto(path);
+    await expect(page.getByRole('heading', { level: 2, name: 'NfL' })).toBeInViewport();
+    await expectPageNotAtTop(page);
+
+    await page.goto(path);
+
+    await expect(page).toHaveURL(`${baseURL}${path}`);
+    await expect(page.getByRole('heading', { level: 2, name: 'NfL' })).toBeInViewport();
+    await expectPageNotAtTop(page);
+  });
+
+  test('scrolls to section during same-document navigation with different fragment', async ({
+    page,
+  }) => {
+    const anotherFragment = 'insoluble-a-beta-42';
+    await page.goto(`${basePath}#${validFragment}`);
+    await expect(page.getByRole('heading', { level: 2, name: 'NfL' })).toBeInViewport();
+    await expectPageNotAtTop(page);
+
+    await page.goto(`${basePath}#${anotherFragment}`);
+
+    await expect(page).toHaveURL(`${baseURL}${basePath}#${anotherFragment}`);
+    await expect(page.getByRole('heading', { level: 2, name: 'Insoluble Aβ42' })).toBeInViewport();
+    await expectPageNotAtTop(page);
+  });
+
+  test('does not scroll and removes invalid fragment from url during same-document navigation', async ({
+    page,
+  }) => {
+    await page.goto(`${basePath}#${validFragment}`);
+    await expect(page.getByRole('heading', { level: 2, name: 'NfL' })).toBeInViewport();
+
+    const invalidFragment = 'does-not-exist';
+    await page.evaluate((fragment) => {
+      window.location.hash = fragment;
+    }, invalidFragment);
+
+    await expect(page).toHaveURL(`${baseURL}${basePath}`);
+    await expectPageAtTop(page);
+    await expect(page.getByRole('heading', { level: 1, name: modelName })).toBeInViewport();
   });
 });
 


### PR DESCRIPTION
## Description

Currently, when a model details URL contains a hash fragment, the page scrolls to the appropriate section on full page reload (e.g. Cmd + Shift + R on a Mac), but not on a same-document navigation (e.g. moving cursor to the address bar, then pressing enter) because the same-document navigation doesn’t trigger Angular component lifecycle methods which we've used to trigger the scroll. This PR adds a listener for the `popstate` event so the page will scroll after same-document navigation.

## Related Issue

[MG-413](https://sagebionetworks.jira.com/browse/MG-413)

## Changelog

- Scroll to section in model details page after same-document navigation with valid hash fragment
- Remove hash fragment from url after same-document navigation with invalid hash fragment
- Fixes expectations for scroll position in e2e tests

## Preview

`model-ad-build-images && model-ad-docker-start` 

https://github.com/user-attachments/assets/0398ee45-bd1f-47f1-bdb5-1e7d78eb966b

[MG-413]: https://sagebionetworks.jira.com/browse/MG-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ