### PR TITLE
feat(explorers): extend search-input to allow subtext beneath result text

### DIFF
--- a/libs/explorers/testing/src/lib/mocks/search-result-mocks.ts
+++ b/libs/explorers/testing/src/lib/mocks/search-result-mocks.ts
@@ -40,3 +40,7 @@ export function mockCheckQueryForErrors(query: string): string {
   }
   return '';
 }
+
+export function mockFormatResultSubtextForDisplay(result: SearchResult): string | undefined {
+  return result.match_value;
+}

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.html
@@ -57,12 +57,19 @@
                   (click)="goToResult(result.id)"
                   class="result-button"
                   [attr.aria-selected]="selectedResultIndex === i"
+                  [attr.aria-label]="formatResultForDisplay()(result)"
                 >
                   <span
                     class="result-name"
                     [innerHtml]="formatAndHighlightResultsForDisplay(result) | sanitizeHtml"
-                    [attr.aria-label]="formatResultForDisplay()(result)"
                   ></span>
+                  @if (formatResultSubtextForDisplay()(result)) {
+                    <br />
+                    <span
+                      class="result-subtext"
+                      [innerHtml]="`&nbsp;${formatAndHighlightResultsSubtextForDisplay(result)}` | sanitizeHtml"
+                    ></span>
+                  }
                 </button>
               </li>
             }

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.scss
@@ -172,6 +172,10 @@
             &:hover {
               cursor: pointer;
             }
+
+            .result-subtext {
+              color: var(--color-gray-500);
+            }
           }
         }
       }

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.stories.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.stories.ts
@@ -2,6 +2,7 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { provideRouter } from '@angular/router';
 import {
   mockCheckQueryForErrors,
+  mockFormatResultSubtextForDisplay,
   mockGetSearchResults,
   mockNavigateToResult,
 } from '@sagebionetworks/explorers/testing';
@@ -21,6 +22,7 @@ const meta: Meta<SearchInputComponent> = {
     navigateToResult: { control: false },
     getSearchResults: { control: false },
     checkQueryForErrors: { control: false },
+    formatResultSubtextForDisplay: { control: false },
   },
 };
 export default meta;
@@ -41,6 +43,7 @@ export const HomeSearchInput: Story = {
     searchImagePath: '/explorers-assets/images/gene-search-icon.svg',
     searchImageAltText: 'gene search icon',
     hasThickBorder: true,
+    formatResultSubtextForDisplay: mockFormatResultSubtextForDisplay,
     navigateToResult: mockNavigateToResult,
     getSearchResults: mockGetSearchResults,
     checkQueryForErrors: mockCheckQueryForErrors,

--- a/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
+++ b/libs/explorers/ui/src/lib/components/search-input/search-input.component.ts
@@ -54,6 +54,9 @@ export class SearchInputComponent implements AfterViewInit {
   formatResultForDisplay = input<(result: SearchResult) => string>(
     (result: SearchResult) => result.id,
   );
+  formatResultSubtextForDisplay = input<(result: SearchResult) => string | undefined>(
+    (result: SearchResult) => undefined,
+  );
 
   faMagnifyingGlass = faMagnifyingGlass;
   faSpinner = faSpinner;
@@ -230,6 +233,11 @@ export class SearchInputComponent implements AfterViewInit {
   formatAndHighlightResultsForDisplay(result: SearchResult): string {
     const formattedText = this.formatResultForDisplay()(result);
     return this.highlightMatches(formattedText, this.query);
+  }
+
+  formatAndHighlightResultsSubtextForDisplay(result: SearchResult): string | undefined {
+    const subtext = this.formatResultSubtextForDisplay()(result);
+    return subtext ? this.highlightMatches(subtext, this.query) : undefined;
   }
 
   onResultHover(index: number) {


### PR DESCRIPTION
## Description

The shared `search-input` currently supports displaying one block of text per search result. However, Agora displays subtext below the text of each search result in a grey color. We need to extend the `search-input` to allow Agora to provide subtext for each search result. 

Note: the goal of this PR is to replicate the functionality and design of the current Agora search. 

## Related Issue

[AG-1878](https://sagebionetworks.jira.com/browse/AG-1878)

## Changelog

- Extend search-input to allow subtext beneath result text

## Preview

`nx storybook explorers-storybook` 

current Agora search | explorers search component
:----: | :----: 
<img width="225" height="184" alt="image" src="https://github.com/user-attachments/assets/93007cbd-7e06-4e28-a9ec-ac0b6af79f7a" /> |  <img width="307" height="257" alt="AG-1878_subtextHighlight" src="https://github.com/user-attachments/assets/96fe0d67-30e7-4256-81f0-ce72549f1078" /> 

[AG-1878]: https://sagebionetworks.jira.com/browse/AG-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ