### PR TITLE
fix(explorers): handle paginated response from GitHub tags service (MG-418)

### DIFF
--- a/libs/agora/gene-comparison-tool/jest.config.ts
+++ b/libs/agora/gene-comparison-tool/jest.config.ts
@@ -15,7 +15,9 @@ export default {
     ],
   },
   testEnvironment: 'jest-fixed-jsdom',
-  transformIgnorePatterns: ['node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|until-async))'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|until-async|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   moduleNameMapper: {
     d3: '<rootDir>/../../../node_modules/d3/dist/d3.min.js',
     '^d3-(.*)$': '<rootDir>/../../../node_modules/d3-$1/dist/d3-$1.min.js',

--- a/libs/agora/genes/jest.config.ts
+++ b/libs/agora/genes/jest.config.ts
@@ -16,7 +16,9 @@ export default {
   },
   maxWorkers: '50%',
   testEnvironment: 'jest-fixed-jsdom',
-  transformIgnorePatterns: ['node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|until-async))'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|until-async|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   moduleNameMapper: {
     d3: '<rootDir>/../../../node_modules/d3/dist/d3.min.js',
     '^d3-(.*)$': '<rootDir>/../../../node_modules/d3-$1/dist/d3-$1.min.js',

--- a/libs/agora/home/jest.config.ts
+++ b/libs/agora/home/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   moduleNameMapper: {
     d3: '<rootDir>/../../../node_modules/d3/dist/d3.min.js',
     '^d3-(.*)$': '<rootDir>/../../../node_modules/d3-$1/dist/d3-$1.min.js',

--- a/libs/agora/nominated-targets/jest.config.ts
+++ b/libs/agora/nominated-targets/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   moduleNameMapper: {
     d3: '<rootDir>/../../../node_modules/d3/dist/d3.min.js',
     '^d3-(.*)$': '<rootDir>/../../../node_modules/d3-$1/dist/d3-$1.min.js',

--- a/libs/agora/ui/jest.config.ts
+++ b/libs/agora/ui/jest.config.ts
@@ -15,7 +15,9 @@ export default {
     ],
   },
   testEnvironment: 'jest-fixed-jsdom',
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   moduleNameMapper: {
     d3: '<rootDir>/../../../node_modules/d3/dist/d3.min.js',
     '^d3-(.*)$': '<rootDir>/../../../node_modules/d3-$1/dist/d3-$1.min.js',

--- a/libs/explorers/comparison-tools/jest.config.ts
+++ b/libs/explorers/comparison-tools/jest.config.ts
@@ -15,7 +15,9 @@ export default {
     ],
   },
   testEnvironment: 'jest-fixed-jsdom',
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/explorers/services/src/lib/version.service.ts
+++ b/libs/explorers/services/src/lib/version.service.ts
@@ -51,33 +51,28 @@ export class VersionService {
     }
   }
 
-  getSiteVersion(
+  async getSiteVersion(
     config: VersionConfig,
     onSuccess: (siteVersion: string) => void,
     onError?: (error: any) => void,
-  ): void {
+  ): Promise<void> {
     if (this.platformService.isBrowser) {
-      this.gitHubService
-        .getCommitSHA(config.tagName)
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe({
-          next: (sha) => {
-            const siteVersion = this.formatSiteVersion(sha, config);
-            onSuccess(siteVersion);
-          },
-          error: (error) => {
-            console.error('Error loading commit SHA:', error);
-            const fallbackVersion = this.formatSiteVersion('', config);
-            if (fallbackVersion) {
-              onSuccess(fallbackVersion);
-            } else {
-              console.error('Error loading appVersion');
-              if (onError) {
-                onError(error);
-              }
-            }
-          },
-        });
+      try {
+        const sha = await this.gitHubService.getCommitSHA(config.tagName);
+        const siteVersion = this.formatSiteVersion(sha, config);
+        onSuccess(siteVersion);
+      } catch (error) {
+        console.error('Error loading commit SHA:', error);
+        const fallbackVersion = this.formatSiteVersion('', config);
+        if (fallbackVersion) {
+          onSuccess(fallbackVersion);
+        } else {
+          console.error('Error loading appVersion');
+          if (onError) {
+            onError(error);
+          }
+        }
+      }
     }
   }
 

--- a/libs/explorers/shared/jest.config.ts
+++ b/libs/explorers/shared/jest.config.ts
@@ -15,7 +15,9 @@ export default {
     ],
   },
   testEnvironment: 'jest-fixed-jsdom',
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/explorers/ui/jest.config.ts
+++ b/libs/explorers/ui/jest.config.ts
@@ -15,7 +15,9 @@ export default {
     ],
   },
   testEnvironment: 'jest-fixed-jsdom',
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/explorers/util/jest.config.ts
+++ b/libs/explorers/util/jest.config.ts
@@ -15,7 +15,9 @@ export default {
     ],
   },
   testEnvironment: 'jest-fixed-jsdom',
-  transformIgnorePatterns: ['node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|until-async))'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|until-async|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/model-ad/disease-correlation-comparison-tool/jest.config.ts
+++ b/libs/model-ad/disease-correlation-comparison-tool/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/model-ad/gene-expression-comparison-tool/jest.config.ts
+++ b/libs/model-ad/gene-expression-comparison-tool/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/model-ad/home/jest.config.ts
+++ b/libs/model-ad/home/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/model-ad/model-details/jest.config.ts
+++ b/libs/model-ad/model-details/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/model-ad/model-overview-comparison-tool/jest.config.ts
+++ b/libs/model-ad/model-overview-comparison-tool/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',

--- a/libs/model-ad/ui/jest.config.ts
+++ b/libs/model-ad/ui/jest.config.ts
@@ -14,7 +14,9 @@ export default {
       },
     ],
   },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$|@octokit/.*|universal-user-agent|before-after-hook))',
+  ],
   snapshotSerializers: [
     'jest-preset-angular/build/serializers/no-ng-attributes',
     'jest-preset-angular/build/serializers/ng-snapshot',


### PR DESCRIPTION
## Description

The [explorers github tags service](https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/libs/explorers/services/src/lib/github.service.ts) currently returns the first page of tags. However, the tag of interest may not be on the first page. We should iterate through each page until the tag of interest is found or the last page is reached.

## Related Issue

[MG-418](https://sagebionetworks.jira.com/browse/MG-418)

## Changelog

- Handles paginated response from GitHub tags service

## Preview

Set `APP_VERSION="4.1.0-rc2"` and `TAG_NAME="agora/v4.1.0-rc2"` in `apps/agora/app/.env`
Build and run the app: `agora-build-images && agora-docker-start`

current (prod) | updated (this PR) 
:---: | :---: 
<img width="424" height="84" alt="MG-418_siteVersion_prod" src="https://github.com/user-attachments/assets/8e6e8872-670a-4ba6-a43f-d276b37ff693" /> | <img width="443" height="82" alt="MG-418_siteVersion_PR" src="https://github.com/user-attachments/assets/d899cbed-a8a3-4dc2-92fd-82d9604f76f6" />


[MG-418]: https://sagebionetworks.jira.com/browse/MG-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ