### PR TITLE
fix(synapse): fix GitHub workflow that updates Synapse API - Take 2 (SMR-435)

### DIFF
--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -114,16 +114,16 @@ jobs:
             git add .
 
             # Commit (git hooks will run here inside container)
-            printf '%s\n' \
-              'This is an automated update triggered by changes detected in the Synapse OpenAPI' \
-              'specification.' \
-              '' \
-              'Updated components:' \
-              '- libs/synapse/api-description/src/openapi.json (source specification)' \
-              '- libs/synapse/api-description/openapi/openapi.yaml (bundled specification)' \
-              '- Regenerated synapse-* client libraries' \
-              '' \
-              'Source: https://rest-docs.synapse.org/rest/openapi/openapispecification.json' \
+            printf "%s\n" \\
+              "This is an automated update triggered by changes detected in the Synapse OpenAPI" \\
+              "specification." \\
+              "" \\
+              "Updated components:" \\
+              "- libs/synapse/api-description/src/openapi.json (source specification)" \\
+              "- libs/synapse/api-description/openapi/openapi.yaml (bundled specification)" \\
+              "- Regenerated synapse-* client libraries" \\
+              "" \\
+              "Source: https://rest-docs.synapse.org/rest/openapi/openapispecification.json" \\
               > COMMIT_BODY.md
 
             git commit -m "chore(synapse): update Synapse API description and regenerate clients" \
@@ -134,42 +134,42 @@ jobs:
             CHANGED_FILES="$(git diff --name-only HEAD~1)"
 
             # Build PR body file (variable expansion allowed for changed files)
-            printf '%s\n' \
-              '## Description' \
-              '' \
-              'This is an automated update triggered by changes detected in the Synapse OpenAPI specification.' \
-              '' \
-              'The workflow downloads the latest OpenAPI specification from Synapse, compares it with the' \
-              'current version, and regenerates all dependent client libraries to ensure they stay in sync' \
-              'with the API.' \
-              '' \
-              '## Related Issue' \
-              '' \
-              'Automated maintenance task (no linked issue).' \
-              '' \
-              '## Changelog' \
-              '- Update `libs/synapse/api-description/openapi/openapi.json` with latest specification' \
-              '- Update `libs/synapse/api-description/openapi/openapi.yaml` with bundled specification' \
-              '- Regenerate Angular API client (`synapse-api-client-angular`)' \
-              '- Update any other synapse-* projects with generate tasks' \
-              '' \
-              '## Preview' \
-              '### Files changed:' \
-              '```' \
-              "$CHANGED_FILES" \
-              '```' \
-              '' \
-              '### ⚠️ Review checklist:' \
-              '- [ ] Verify that the API changes are expected' \
-              '- [ ] Check that generated clients compile successfully' \
-              '- [ ] Run tests to ensure compatibility' \
-              '- [ ] Review any breaking changes in the API' \
-              '' \
-              '---' \
-              "Workflow: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-              'Source: https://rest-docs.synapse.org/rest/openapi/openapispecification.json' \
-              '' \
-              'This PR was automatically created by the `update-synapse-api.yml` workflow.' \
+            printf "%s\n" \\
+              "## Description" \\
+              "" \\
+              "This is an automated update triggered by changes detected in the Synapse OpenAPI specification." \\
+              "" \\
+              "The workflow downloads the latest OpenAPI specification from Synapse, compares it with the" \\
+              "current version, and regenerates all dependent client libraries to ensure they stay in sync" \\
+              "with the API." \\
+              "" \\
+              "## Related Issue" \\
+              "" \\
+              "Automated maintenance task (no linked issue)." \\
+              "" \\
+              "## Changelog" \\
+              "- Update \`libs/synapse/api-description/openapi/openapi.json\` with latest specification" \\
+              "- Update \`libs/synapse/api-description/openapi/openapi.yaml\` with bundled specification" \\
+              "- Regenerate Angular API client (\`synapse-api-client-angular\`)" \\
+              "- Update any other synapse-* projects with generate tasks" \\
+              "" \\
+              "## Preview" \\
+              "### Files changed:" \\
+              "```" \\
+              "$CHANGED_FILES" \\
+              "```" \\
+              "" \\
+              "### ⚠️ Review checklist:" \\
+              "- [ ] Verify that the API changes are expected" \\
+              "- [ ] Check that generated clients compile successfully" \\
+              "- [ ] Run tests to ensure compatibility" \\
+              "- [ ] Review any breaking changes in the API" \\
+              "" \\
+              "---" \\
+              "Workflow: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \\
+              "Source: https://rest-docs.synapse.org/rest/openapi/openapispecification.json" \\
+              "" \\
+              "This PR was automatically created by the \`update-synapse-api.yml\` workflow." \\
               > PR_BODY.md
 
             gh pr create \


### PR DESCRIPTION
## Description

Fix GitHub workflow that updates Synapse API. The issue occurred because the workflow committed the changes outside of the dev container where the tools needed by the git hooks were not available.

## Related Issue

- [SMR-435](https://sagebionetworks.jira.com/browse/SMR-435)

## Changelog

- Fix GitHub workflow that updates Synapse API.


[SMR-435]: https://sagebionetworks.jira.com/browse/SMR-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ