### PR TITLE
fix(synapse): specify base branch in workflow that updates the API

### DIFF
--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -87,6 +87,7 @@ jobs:
           branch: synapse/update-synapse-api
           title: 'chore(synapse): update Synapse API description and its clients'
           commit-message: 'chore(synapse): update Synapse API description and its clients'
+          base: 'main'
           body: |
             ## Description
 


### PR DESCRIPTION
## Description

Specify base branch in workflow that updates the Synapse API. The workflow previously failed because the current branch, which `peter-evans/create-pull-request@v7` use as the base branch by default, was the same as `branch`.