### PR TITLE
fix(synapse): use alternative method to run the dev container to update Synapse API (SMR-435)

### DIFF
--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -3,7 +3,7 @@ name: Update Synapse API description and generated artifacts
 on:
   push:
     branches:
-      - synapse/update-synapse-api-test # trigger workflow when changes are pushed to this maintenance branch
+      - synapse/update-synapse-api-workflow-test # trigger workflow when changes are pushed to this maintenance branch
   schedule:
     # Run daily at 9 AM UTC (4 AM EST, 1 AM PST)
     - cron: '0 9 * * *'

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -18,6 +18,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # NOTE: The following secrets must be defined in the repository or organization settings.
+  # Some static analyzers may flag them as "Context access might be invalid" even though this
+  # is valid GitHub Actions syntax. Leave as-is unless the secret names change.
   NX_BRANCH: ${{ github.ref_name }}
   NX_CLOUD_ENCRYPTION_KEY: ${{ secrets.NX_CLOUD_ENCRYPTION_KEY }}
 
@@ -51,6 +54,7 @@ jobs:
         # those functions. This keeps PATH setup minimal and avoids manual PATH surgery.
         shell: bash -l {0}
     env:
+      # NOTE: See comment above about secret name validation.
       # # Disable Nx Cloud usage for this workflow to avoid consuming tokens / network calls when
       # # simply regenerating artifacts. If later we want hashing/distributed features, remove this.
       # NX_NO_CLOUD: 'true'

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -89,17 +89,17 @@ jobs:
             workspace-install
           '
 
-      # - name: Build API description & regenerate generated projects (unprivileged)
-      #   run: |
-      #     # Execute build/generation as ubuntu (non-root) to avoid root-owned artifacts.
-      #     sudo -u ubuntu bash -lc '
-      #       set -euo pipefail
-      #       . ./dev-env.sh
-      #       echo "🔄 Building API description (includes downloading latest OpenAPI specification)..."
-      #       nx build synapse-api-description
-      #       echo "🔄 Regenerating synapse-* generated projects (clients, docs, etc.)..."
-      #       nx run-many --target=generate --projects="synapse-*"
-      #     '
+      - name: Build API description & regenerate generated projects (unprivileged)
+        run: |
+          # Execute build/generation as ubuntu (non-root) to avoid root-owned artifacts.
+          sudo -u ubuntu bash -lc '
+            set -euo pipefail
+            . ./dev-env.sh
+            echo "🔄 Building API description (includes downloading latest OpenAPI specification)..."
+            nx build synapse-api-description
+            echo "🔄 Regenerating synapse-* generated projects (clients, docs, etc.)..."
+            nx run-many --target=generate --projects="synapse-*"
+          '
 
       # - name: Create or update Pull Request
       #   uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -73,13 +73,13 @@ jobs:
       # Leaving off --user restores normal permissions and resolves the checkout EACCES error.
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Give ubuntu ownership of the workspace and temp dirs
         run: |
           chown -R ubuntu:ubuntu "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE" 2>/dev/null || true
           chmod -R u+w "$RUNNER_TEMP"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Prepare the workspace
         run: |

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -74,13 +74,13 @@ jobs:
       # Leaving off --user restores normal permissions and resolves the checkout EACCES error.
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Give ubuntu ownership of the workspace and temp dirs
         run: |
           chown -R ubuntu:ubuntu "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE" 2>/dev/null || true
           chmod -R u+w "$RUNNER_TEMP"
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
 
       - name: Prepare the workspace
         run: |

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -3,7 +3,7 @@ name: Update Synapse API description and generated artifacts
 on:
   push:
     branches:
-      - synapse/workflow-container-root # trigger workflow when changes are pushed to this maintenance branch
+      - synapse/update-synapse-api-test # trigger workflow when changes are pushed to this maintenance branch
   schedule:
     # Run daily at 9 AM UTC (4 AM EST, 1 AM PST)
     - cron: '0 9 * * *'
@@ -40,19 +40,6 @@ jobs:
   update-synapse-api:
     runs-on: ubuntu-latest
     needs: extract-devcontainer-image
-    defaults:
-      run:
-        # Use a login Bash shell so profile scripts (/etc/profile, /etc/bash.bashrc, and user profile)
-        # populate PATH with user-local bin directories (e.g. /home/ubuntu/.local/bin) where the devcontainer
-        # installs tools like `uv`. Without `-l`, a non-login, non-interactive shell would often miss those
-        # PATH entries and `uv` (and similar user-scoped tools) could be reported as "command not found".
-        # NOTE: The devcontainer's ~/.bashrc sources dev-env.sh only AFTER a non-interactive guard
-        # (e.g. a pattern like: [ -z "$PS1" ] && return). GitHub Actions steps run in a non-interactive
-        # shell, so that guard causes an early return and dev-env.sh is NOT sourced automatically.
-        # Therefore we still explicitly source dev-env.sh in a step to obtain functions like
-        # workspace-install. The login shell here is strictly for PATH hydration, not for loading
-        # those functions. This keeps PATH setup minimal and avoids manual PATH surgery.
-        shell: bash -l {0}
     env:
       # NOTE: See comment above about secret name validation.
       # # Disable Nx Cloud usage for this workflow to avoid consuming tokens / network calls when
@@ -110,6 +97,14 @@ jobs:
           '
 
       - name: Create or update Pull Request
+        # NOTE: This action executes as root because the job's container user was set to root and
+        # only the build/generation commands were explicitly downgraded via 'sudo -u ubuntu'. We do
+        # not wrap third-party composite/actions steps with sudo. The workspace files (already
+        # chowned to ubuntu) remain ubuntu-owned; only the git operations (commit, branch ref
+        # updates) are initiated by root which is acceptable here. If we later prefer this to run
+        # unprivileged, we could replace the action with explicit git commands invoked via
+        # 'sudo -u ubuntu bash -lc ...' or experiment with a wrapper script that preserves the
+        # required environment variables.
         uses: peter-evans/create-pull-request@v7
         with:
           branch: synapse/update-synapse-api
@@ -120,6 +115,7 @@ jobs:
             ## Description
 
             This is an automated update triggered by changes detected in the Synapse OpenAPI specification.
+
             The workflow downloads the latest specification and regenerates dependent generated projects (clients, docs, etc.) to keep them in sync.
 
             ## Review checklist

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -3,7 +3,7 @@ name: Update Synapse API description and generated artifacts
 on:
   push:
     branches:
-      - synapse/update-synapse-api-workflow-test # trigger workflow when changes are pushed to this maintenance branch
+      - synapse/update-synapse-api-workflow-dev # trigger workflow when changes are pushed to this maintenance branch
   schedule:
     # Run daily at 9 AM UTC (4 AM EST, 1 AM PST)
     - cron: '0 9 * * *'

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -73,29 +73,32 @@ jobs:
       # Leaving off --user restores normal permissions and resolves the checkout EACCES error.
 
     steps:
-      - name: Give ubuntu ownership of the workspace and temp dirs
-        run: |
-          chown -R ubuntu:ubuntu "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE" 2>/dev/null || true
-          chmod -R u+w "$RUNNER_TEMP"
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Prepare the workspace
+      - name: Adjust ownership & prepare workspace (unprivileged)
         run: |
-          su -l ubuntu -c 'bash -lc "
+          # Change ownership of only the GitHub workspace to ubuntu so dependency installs and
+          # generated artifacts are written with non-root permissions. We deliberately do NOT
+          # touch $RUNNER_TEMP or $RUNNER_TOOL_CACHE (runner-managed bind mounts) to avoid EPERM.
+          chown -R ubuntu:ubuntu "$GITHUB_WORKSPACE"
+          sudo -u ubuntu bash -lc '
+            set -euo pipefail
             . ./dev-env.sh
             workspace-install
-          "'
+          '
 
-      # - name: Build API description & regenerate generated projects
+      # - name: Build API description & regenerate generated projects (unprivileged)
       #   run: |
-      #     . ./dev-env.sh
-      #     set -euo pipefail
-      #     echo '🔄 Building API description (includes downloading latest OpenAPI specification)...'
-      #     nx build synapse-api-description
-      #     echo '🔄 Regenerating synapse-* generated projects (clients, docs, etc.)...'
-      #     nx run-many --target=generate --projects='synapse-*'
+      #     # Execute build/generation as ubuntu (non-root) to avoid root-owned artifacts.
+      #     sudo -u ubuntu bash -lc '
+      #       set -euo pipefail
+      #       . ./dev-env.sh
+      #       echo "🔄 Building API description (includes downloading latest OpenAPI specification)..."
+      #       nx build synapse-api-description
+      #       echo "🔄 Regenerating synapse-* generated projects (clients, docs, etc.)..."
+      #       nx run-many --target=generate --projects="synapse-*"
+      #     '
 
       # - name: Create or update Pull Request
       #   uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -1,6 +1,9 @@
 name: Update Synapse API description and generated artifacts
 
 on:
+  push:
+    branches:
+      - synapse/workflow-container-root # trigger workflow when changes are pushed to this maintenance branch
   schedule:
     # Run daily at 9 AM UTC (4 AM EST, 1 AM PST)
     - cron: '0 9 * * *'
@@ -55,42 +58,57 @@ jobs:
 
     container:
       image: ${{ needs.extract-devcontainer-image.outputs.image }}
-      options: --user ubuntu
+      # NOTE: We intentionally run with the image's default user (likely root) here.
+      # Setting --user ubuntu caused actions/checkout to fail writing state files under $RUNNER_TEMP
+      # (EACCES opening /__w/_temp/_runner_file_commands/save_state_*). GitHub mounts /__w with
+      # ownership that assumes the container user can write. Overriding to a non-root user without
+      # adjusting ownership (chown) breaks any action that uses file command APIs. If we later need
+      # to run generation as a non-root user, prefer either:
+      #  1. A step wrapper: sudo -u ubuntu bash -lc '...'; or
+      #  2. A custom image whose default USER already matches the desired UID and has correct perms.
+      # Leaving off --user restores normal permissions and resolves the checkout EACCES error.
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Give ubuntu ownership of the workspace and temp dirs
+        run: |
+          chown -R ubuntu:ubuntu "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE" 2>/dev/null || true
+          chmod -R u+w "$RUNNER_TEMP"
+
       - name: Prepare the workspace
         run: |
-          . ./dev-env.sh
-          workspace-install
+          su -l ubuntu -c 'bash -lc "
+            . ./dev-env.sh
+            workspace-install
+          "'
 
-      - name: Build API description & regenerate generated projects
-        run: |
-          . ./dev-env.sh
-          set -euo pipefail
-          echo '🔄 Building API description (includes downloading latest OpenAPI specification)...'
-          nx build synapse-api-description
-          echo '🔄 Regenerating synapse-* generated projects (clients, docs, etc.)...'
-          nx run-many --target=generate --projects='synapse-*'
+      # - name: Build API description & regenerate generated projects
+      #   run: |
+      #     . ./dev-env.sh
+      #     set -euo pipefail
+      #     echo '🔄 Building API description (includes downloading latest OpenAPI specification)...'
+      #     nx build synapse-api-description
+      #     echo '🔄 Regenerating synapse-* generated projects (clients, docs, etc.)...'
+      #     nx run-many --target=generate --projects='synapse-*'
 
-      - name: Create or update Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          branch: synapse/update-synapse-api
-          delete-branch: true
-          title: 'chore(synapse): update Synapse API description and generated artifacts'
-          commit-message: 'chore(synapse): update Synapse API description and generated artifacts'
-          body: |
-            ## Description
+      # - name: Create or update Pull Request
+      #   uses: peter-evans/create-pull-request@v7
+      #   with:
+      #     branch: synapse/update-synapse-api
+      #     delete-branch: true
+      #     title: 'chore(synapse): update Synapse API description and generated artifacts'
+      #     commit-message: 'chore(synapse): update Synapse API description and generated artifacts'
+      #     body: |
+      #       ## Description
 
-            This is an automated update triggered by changes detected in the Synapse OpenAPI specification.
-            The workflow downloads the latest specification and regenerates dependent generated projects (clients, docs, etc.) to keep them in sync.
+      #       This is an automated update triggered by changes detected in the Synapse OpenAPI specification.
+      #       The workflow downloads the latest specification and regenerates dependent generated projects (clients, docs, etc.) to keep them in sync.
 
-            ## Review checklist
+      #       ## Review checklist
 
-            - [ ] Verify that the API changes are expected
-            - [ ] Check that generated artifacts build/compile successfully
-            - [ ] Run tests to ensure compatibility
-            - [ ] Review any breaking changes in the API
+      #       - [ ] Verify that the API changes are expected
+      #       - [ ] Check that generated artifacts build/compile successfully
+      #       - [ ] Run tests to ensure compatibility
+      #       - [ ] Review any breaking changes in the API

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -62,20 +62,28 @@ jobs:
 
     container:
       image: ${{ needs.extract-devcontainer-image.outputs.image }}
+      # NOTE: The devcontainer image sets its default USER to 'ubuntu'. We override to root here
+      # (via --user root) so early framework mechanics (actions/checkout writing state files under
+      # $RUNNER_TEMP, file command APIs, etc.) are guaranteed to have write permission to the mounted
+      # runner directories without pre-adjusting ownership. After checkout we immediately drop
+      # privileges for build / generation by chowning only $GITHUB_WORKSPACE and invoking commands
+      # with 'sudo -u ubuntu'.
+      #
+      # Why not stay ubuntu from the start? When the workspace and temp mounts arrive owned by root
+      # (common when the host bind mounts into the container), starting as ubuntu can cause EACCES
+      # on state files (e.g. /__w/_temp/_runner_file_commands/save_state_*). Forcing root avoids the
+      # race/permission edge cases and lets us perform a controlled, minimal privilege drop.
+      #
+      # Principles followed:
+      #  * Do NOT chown $RUNNER_TEMP or $RUNNER_TOOL_CACHE (runner-managed, can break file commands)
+      #  * Only chown the repository workspace before running unprivileged steps
+      #  * Use 'sudo -u ubuntu' for generation so artifacts are not root-owned
+      #  * Keep the privileged window as small as possible
       options: --user root
-      # NOTE: We intentionally run with the image's default user (likely root) here.
-      # Setting --user ubuntu caused actions/checkout to fail writing state files under $RUNNER_TEMP
-      # (EACCES opening /__w/_temp/_runner_file_commands/save_state_*). GitHub mounts /__w with
-      # ownership that assumes the container user can write. Overriding to a non-root user without
-      # adjusting ownership (chown) breaks any action that uses file command APIs. If we later need
-      # to run generation as a non-root user, prefer either:
-      #  1. A step wrapper: sudo -u ubuntu bash -lc '...'; or
-      #  2. A custom image whose default USER already matches the desired UID and has correct perms.
-      # Leaving off --user restores normal permissions and resolves the checkout EACCES error.
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Adjust ownership & prepare workspace (unprivileged)
         run: |
@@ -101,22 +109,22 @@ jobs:
             nx run-many --target=generate --projects="synapse-*"
           '
 
-      # - name: Create or update Pull Request
-      #   uses: peter-evans/create-pull-request@v7
-      #   with:
-      #     branch: synapse/update-synapse-api
-      #     delete-branch: true
-      #     title: 'chore(synapse): update Synapse API description and generated artifacts'
-      #     commit-message: 'chore(synapse): update Synapse API description and generated artifacts'
-      #     body: |
-      #       ## Description
+      - name: Create or update Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: synapse/update-synapse-api
+          delete-branch: true
+          title: 'chore(synapse): update Synapse API description and generated artifacts'
+          commit-message: 'chore(synapse): update Synapse API description and generated artifacts'
+          body: |
+            ## Description
 
-      #       This is an automated update triggered by changes detected in the Synapse OpenAPI specification.
-      #       The workflow downloads the latest specification and regenerates dependent generated projects (clients, docs, etc.) to keep them in sync.
+            This is an automated update triggered by changes detected in the Synapse OpenAPI specification.
+            The workflow downloads the latest specification and regenerates dependent generated projects (clients, docs, etc.) to keep them in sync.
 
-      #       ## Review checklist
+            ## Review checklist
 
-      #       - [ ] Verify that the API changes are expected
-      #       - [ ] Check that generated artifacts build/compile successfully
-      #       - [ ] Run tests to ensure compatibility
-      #       - [ ] Review any breaking changes in the API
+            - [ ] Verify that the API changes are expected
+            - [ ] Check that generated artifacts build/compile successfully
+            - [ ] Run tests to ensure compatibility
+            - [ ] Review any breaking changes in the API

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -97,14 +97,13 @@ jobs:
           '
 
       - name: Create or update Pull Request
-        # NOTE: This action executes as root because the job's container user was set to root and
-        # only the build/generation commands were explicitly downgraded via 'sudo -u ubuntu'. We do
-        # not wrap third-party composite/actions steps with sudo. The workspace files (already
-        # chowned to ubuntu) remain ubuntu-owned; only the git operations (commit, branch ref
-        # updates) are initiated by root which is acceptable here. If we later prefer this to run
-        # unprivileged, we could replace the action with explicit git commands invoked via
-        # 'sudo -u ubuntu bash -lc ...' or experiment with a wrapper script that preserves the
-        # required environment variables.
+        # NOTE: This step still runs as root. We start the container as root for early runner
+        # internals (checkout, file command state). Only build / generation phases are dropped to
+        # the unprivileged 'ubuntu' user via 'sudo -u ubuntu'; we do not wrap third‑party actions.
+        # The workspace files are already owned by ubuntu (we chown'd $GITHUB_WORKSPACE), so the
+        # only root-originated effects here are git commits / ref updates, which is acceptable.
+        # To make this unprivileged in future, replace the action with explicit git commands run
+        # under 'sudo -u ubuntu bash -lc ...', or add a thin wrapper that exports required env vars.
         uses: peter-evans/create-pull-request@v7
         with:
           branch: synapse/update-synapse-api

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -62,6 +62,7 @@ jobs:
 
     container:
       image: ${{ needs.extract-devcontainer-image.outputs.image }}
+      options: --user root
       # NOTE: We intentionally run with the image's default user (likely root) here.
       # Setting --user ubuntu caused actions/checkout to fail writing state files under $RUNNER_TEMP
       # (EACCES opening /__w/_temp/_runner_file_commands/save_state_*). GitHub mounts /__w with

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -74,20 +74,20 @@ jobs:
       # Leaving off --user restores normal permissions and resolves the checkout EACCES error.
 
     steps:
+      - name: Give ubuntu ownership of the workspace and temp dirs
+        run: |
+          chown -R ubuntu:ubuntu "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE" 2>/dev/null || true
+          chmod -R u+w "$RUNNER_TEMP"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Adjust ownership & prepare workspace (unprivileged)
+      - name: Prepare the workspace
         run: |
-          # Change ownership of only the GitHub workspace to ubuntu so dependency installs and
-          # generated artifacts are written with non-root permissions. We deliberately do NOT
-          # touch $RUNNER_TEMP or $RUNNER_TOOL_CACHE (runner-managed bind mounts) to avoid EPERM.
-          chown -R ubuntu:ubuntu "$GITHUB_WORKSPACE"
-          sudo -u ubuntu bash -lc '
-            set -euo pipefail
+          su -l ubuntu -c 'bash -lc "
             . ./dev-env.sh
             workspace-install
-          '
+          "'
 
       # - name: Build API description & regenerate generated projects (unprivileged)
       #   run: |

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -77,17 +77,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Give ubuntu ownership of the workspace and temp dirs
+      - name: Adjust ownership & prepare workspace (unprivileged)
         run: |
-          chown -R ubuntu:ubuntu "$RUNNER_TEMP" "$RUNNER_TOOL_CACHE" 2>/dev/null || true
-          chmod -R u+w "$RUNNER_TEMP"
-
-      - name: Prepare the workspace
-        run: |
-          su -l ubuntu -c 'bash -lc "
+          # Change ownership of only the GitHub workspace to ubuntu so dependency installs and
+          # generated artifacts are written with non-root permissions. We deliberately do NOT
+          # touch $RUNNER_TEMP or $RUNNER_TOOL_CACHE (runner-managed bind mounts) to avoid EPERM.
+          chown -R ubuntu:ubuntu "$GITHUB_WORKSPACE"
+          sudo -u ubuntu bash -lc '
+            set -euo pipefail
             . ./dev-env.sh
             workspace-install
-          "'
+          '
 
       # - name: Build API description & regenerate generated projects (unprivileged)
       #   run: |


### PR DESCRIPTION
## Description

This PR fix the broken workflow that updates the Synapse API description and its generated artifacts.

As part of the solution, this PR explored another way to run tasks and GitHub Actions inside the dev container provided by the monorepo.

The benefit of this approach is it's "simplicity", compared to when using the dev container CLI, its faster dev container setup runtime, and the ability to using GitHub actions that depends on tools installed inside the dev container (here `peter-evans/create-pull-request@v7` that creates commits and push to a remote, triggering git hooks that executes tools provided by the dev container).

## Related issues

- [SMR-435](https://sagebionetworks.jira.com/browse/SMR-435)

## Preview

### Dev container setup runtime

The new approach takes about 3 minutes to setup the dev container and run `workspace-install`.

<img width="1226" height="122" alt="image" src="https://github.com/user-attachments/assets/fd483c5d-c604-403b-803e-867da8dc3790" />

This is potentially faster than when starting it using the dev container CLI, though this evaluation is not robust. Below is the setup run time of our CI workflow run when merging to `main` and executed 12 hours ago.

<img width="1207" height="83" alt="image" src="https://github.com/user-attachments/assets/fd49911d-993a-47f4-a43d-f7c6411d9113" />

[SMR-435]: https://sagebionetworks.jira.com/browse/SMR-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ