### PR TITLE
chore(bixarena): switch bixarena-app task names to serve different versions

### DIFF
--- a/apps/bixarena/app/project.json
+++ b/apps/bixarena/app/project.json
@@ -34,7 +34,7 @@
       "options": {
         "commands": [
           "envsubst < model_config.template.json > model_config.json",
-          "uv run python -m fastchat.serve.gradio_web_server_multi --port ${APP_PORT} --controller-url '' --register-api-endpoint-file model_config.json"
+          "uv run python -m main --port ${APP_PORT} --register-api-endpoint-file model_config.json"
         ],
         "cwd": "{projectRoot}",
         "parallel": false
@@ -46,12 +46,12 @@
         "command": "docker/bixarena/serve-detach.sh {projectName}"
       }
     },
-    "serve-demo": {
+    "serve-legacy": {
       "executor": "nx:run-commands",
       "options": {
         "commands": [
           "envsubst < model_config.template.json > model_config.json",
-          "uv run python -m main --port ${APP_PORT} --register-api-endpoint-file model_config.json"
+          "uv run python -m fastchat.serve.gradio_web_server_multi --port ${APP_PORT} --controller-url '' --register-api-endpoint-file model_config.json"
         ],
         "cwd": "{projectRoot}",
         "parallel": false


### PR DESCRIPTION
## Description

Updates BixArena app configuration to support different serving modes:

- `nx serve bixarena-app` task: serve the demo app (original `serve-demo`)
- `nx run bixarena-app:serve-legacy` task: serve the original FastChat app based on `gradio_web_server_multi` module

## Changelog
- switch `bixarena-app` task names to serve different versions
