### PR TITLE
fix(synapse): update the Synapse API workflow to create PR that triggers downstream workflows (SMR-507)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,8 @@ jobs:
 
   pr:
     runs-on: ubuntu-22.04-4core-16GBRAM-150GBSSD
-    # Runs this job if triggered by a PR and if the PR originates from a fork
-    if: |
-      github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.full_name !=
-            github.event.pull_request.base.repo.full_name
+    # Runs for any pull_request (fork or same-repo)
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
         name: Checkout merge commit

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -17,6 +17,13 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  # Ensures only one lint run per PR is active at a time; new pushes cancel the prior run.
+  # For pull_request / pull_request_target events we have github.event.pull_request.number.
+  # Fallback to github.ref (e.g., non-PR events like manual dispatch, if ever added).
+  group: lint-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -6,6 +6,12 @@ on:
       - opened
       - edited
       - synchronize
+  pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
   merge_group:
 
 permissions:

--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           branch: synapse/update-synapse-api
           delete-branch: true
+          draft: always-true
           title: 'chore(synapse): update Synapse API description and generated artifacts'
           commit-message: 'chore(synapse): update Synapse API description and generated artifacts'
           body: |


### PR DESCRIPTION
## Description

Update the Synapse API workflow to create PR that triggers downstream workflows.

## Related Issue

- [SMR-507](https://sagebionetworks.jira.com/browse/SMR-507)

## Changelog

- Open PRs that update the Synapse API in draft mode.
- Run the main CI/CD workflow triggered by internal and external PRs.
- Trigger the Lint PR workflow by internal PRs.
- Add `concurrency` config to the Lint PR workflow to run only the latest lint task per PR.


[SMR-507]: https://sagebionetworks.jira.com/browse/SMR-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ