### PR TITLE
fix(synapse): set `COREPACK_ENABLE_DOWNLOAD_PROMPT` in Synapse API workflow (SMR-507)

### DIFF
--- a/.github/workflows/update-synapse-api.yml
+++ b/.github/workflows/update-synapse-api.yml
@@ -46,6 +46,9 @@ jobs:
       # # simply regenerating artifacts. If later we want hashing/distributed features, remove this.
       # NX_NO_CLOUD: 'true'
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN_READ_WRITE }}
+      # By default, Corepack prompts for a confirmation before downloading and enabling
+      # a package manager. We disable the prompt here to ensure non-interactive execution.
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
     container:
       image: ${{ needs.extract-devcontainer-image.outputs.image }}


### PR DESCRIPTION
## Description

Set `COREPACK_ENABLE_DOWNLOAD_PROMPT` in Synapse API workflow to fix a recent issue that stems from having a version of pnpm in `package.json` that is different from the one installed in the Docker image of the dev container.

## Related Issue

- [SMR-507](https://sagebionetworks.jira.com/browse/SMR-507)

[SMR-507]: https://sagebionetworks.jira.com/browse/SMR-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ