### PR TITLE
chore(deps): remove `packageManager` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,6 @@
     "vitest": "3.2.4",
     "yaml": "2.8.1"
   },
-  "packageManager": "pnpm@10.17.1",
   "pnpm": {
     "onlyBuiltDependencies": [
       "canvas"


### PR DESCRIPTION
## Description

pnpm is installed at two different places:

- In the Dockerfile of the dev container
- In `package,json` (property `packageManager`)

Until now, updating `packageManager` provided a convenient way to update `pnpm` without waiting for the release of a new dev container. However, a recent issue in the Synapse API workflow occurred when the two versions of pnpm defined above mismatched, hence triggering the installation of the version of pnpm specified in `package.json`. In that case, the issue comes from the fact that the Synapse API workflow is written in a way that disallow the writing of files outside of the repo workspace folder by the non-root user "ubuntu". This could be considered a lack of flexibility of the Synapse API workflow that may be addressed in the future.

More fundamentally, this PR aims to eliminate the need to specify two versions of pnpm and having to maintain them. Here, I keep the installation of pnpm as part of the dev container so that it's always available to the user. The approach will also accelerate GitHub workflows as they won't need to install pnpm.

## Related Issue

- [SMR-507](https://sagebionetworks.jira.com/browse/SMR-507)

## Changelog

- Remove the property `packageManager` from `package.json`.


[SMR-507]: https://sagebionetworks.jira.com/browse/SMR-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ