### PR TITLE
feat(model-ad): adjust share url behavior to use tooltip instead of toast (MG-365)

### DIFF
--- a/apps/model-ad/app/e2e/model-overview-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/model-overview-comparison-tool.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+import { baseURL } from '../playwright.config';
+
+test.describe('model overview', () => {
+  test('share URL button copies URL to clipboard', async ({ page, context }) => {
+    const path = '/comparison/model';
+    await context.grantPermissions(['clipboard-read']);
+
+    await page.goto(path);
+    await expect(page.getByRole('heading', { level: 1, name: 'Model Overview' })).toBeVisible();
+
+    const shareUrlButton = page.getByRole('button', { name: 'Share URL' });
+    await expect(shareUrlButton).toBeVisible();
+
+    await page.waitForURL(path);
+
+    await shareUrlButton.click();
+
+    const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardContent).toEqual(`${baseURL}${path}`);
+  });
+});

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.html
@@ -5,6 +5,6 @@
       [tooltip]="filterResultsButtonTooltip()"
     />
     <h1>{{ headerTitle() }}</h1>
-    <explorers-comparison-tool-share-url-button [tooltip]="shareUrlButtonTooltip()" />
+    <explorers-comparison-tool-share-url-button />
   </div>
 </div>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.stories.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.stories.ts
@@ -1,0 +1,24 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig } from '@storybook/angular';
+import { ComparisonToolHeaderComponent } from './comparison-tool-header.component';
+
+const meta: Meta<ComparisonToolHeaderComponent> = {
+  component: ComparisonToolHeaderComponent,
+  title: 'Comparison Tools/ComparisonToolHeaderComponent',
+  decorators: [
+    applicationConfig({
+      providers: [provideRouter([]), provideHttpClient(withInterceptorsFromDi())],
+    }),
+  ],
+};
+export default meta;
+type Story = StoryObj<ComparisonToolHeaderComponent>;
+
+export const Demo: Story = {
+  args: {
+    headerTitle: 'Gene Comparison',
+    filterResultsButtonTooltip: 'Filter the results based on the selected criteria',
+  },
+};

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-header.component.ts
@@ -11,7 +11,6 @@ import { ComparisonToolShareURLButtonComponent } from './comparison-tool-share-u
 export class ComparisonToolHeaderComponent {
   filterResultsButtonTooltip = input.required<string>();
   headerTitle = input.required<string>();
-  shareUrlButtonTooltip = input.required<string>();
 
   toggleFilterPanel() {
     // TODO: Replace this alert with proper filter panel toggle behavior in a future update (MG-246)

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.html
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.html
@@ -1,10 +1,11 @@
-<p-button
-  label="Share URL"
-  (click)="copyUrl()"
-  [rounded]="true"
-  variant="outlined"
-  size="small"
-  [pTooltip]="tooltip()"
+<explorers-tooltip-button
+  [onClick]="copyUrl"
+  [tooltipText]="getTooltipText()"
   tooltipPosition="left"
-></p-button>
-<p-toast key="share-url-button-toast" [life]="toastDuration"></p-toast>
+  buttonLabel="Share URL"
+  [buttonProps]="{
+    outlined: true,
+    rounded: true,
+    size: 'small',
+  }"
+/>

--- a/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
+++ b/libs/explorers/comparison-tools/src/lib/comparison-tool-header/comparison-tool-share-url-button/comparison-tool-share-url-button.component.ts
@@ -1,31 +1,35 @@
-import { Component, inject, input } from '@angular/core';
-import { MessageService } from 'primeng/api';
-import { ButtonModule } from 'primeng/button';
-import { TooltipModule } from 'primeng/tooltip';
-import { ToastModule } from 'primeng/toast';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Component, inject } from '@angular/core';
+import { TooltipButtonComponent } from '@sagebionetworks/explorers/util';
 
 @Component({
   selector: 'explorers-comparison-tool-share-url-button',
-  imports: [ButtonModule, TooltipModule, ToastModule],
+  imports: [TooltipButtonComponent],
   templateUrl: './comparison-tool-share-url-button.component.html',
   styleUrls: ['./comparison-tool-share-url-button.component.scss'],
 })
 export class ComparisonToolShareURLButtonComponent {
-  messageService = inject(MessageService);
+  private readonly clipboard = inject(Clipboard);
 
-  tooltip = input('');
+  private hasCopied = false;
+  private timeoutId?: ReturnType<typeof setTimeout>;
 
-  toastDuration = 5000;
+  copyUrl = () => {
+    this.clipboard.copy(window.location.href);
+    this.hasCopied = true;
 
-  copyUrl() {
-    navigator.clipboard.writeText(window.location.href);
-    this.messageService.clear();
-    this.messageService.add({
-      key: 'share-url-button-toast',
-      severity: 'info',
-      summary: 'URL Copied',
-      detail:
-        'URL copied to clipboard! Use this URL to share or bookmark the current table configuration.',
-    });
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+    }
+
+    this.timeoutId = setTimeout(() => {
+      this.hasCopied = false;
+    }, 5000);
+  };
+
+  getTooltipText(): string {
+    return this.hasCopied
+      ? 'URL copied to clipboard'
+      : "Copy the URL to capture the table's current filtering, sorting, and pinned results";
   }
 }

--- a/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.html
+++ b/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.html
@@ -1,13 +1,14 @@
-<button
+<p-button
   type="button"
   (click)="onClick()()"
   [attr.aria-describedby]="buttonAriaDescribedBy()"
-  [attr.aria-label]="buttonAriaLabel()"
   [pTooltip]="tooltipText()"
   (mouseenter)="showTooltip()"
   (mouseleave)="hideTooltip()"
   [autoHide]="false"
   [tooltipEvent]="'focus'"
+  [tooltipPosition]="tooltipPosition()"
+  [buttonProps]="buttonProps()"
 >
   @if (buttonSvgIconConfig()?.imagePath) {
     @let cfg = buttonSvgIconConfig()!;
@@ -23,4 +24,4 @@
   @if (buttonLabel()) {
     {{ buttonLabel() }}
   }
-</button>
+</p-button>

--- a/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.spec.ts
+++ b/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.spec.ts
@@ -33,18 +33,18 @@ describe('TooltipButtonComponent', () => {
   });
 
   it('should pass through aria label', async () => {
-    await setup({ buttonAriaLabel: 'Custom label' });
+    await setup({ buttonProps: { ariaLabel: 'Custom label' } });
     expect(screen.getByRole('button', { name: /custom label/i })).toBeInTheDocument();
   });
 
   it('should call onClick when clicked', async () => {
-    const { user } = await setup({ buttonAriaLabel: 'Do action' });
+    const { user } = await setup({ buttonProps: { ariaLabel: 'Do action' } });
     await user.click(screen.getByRole('button', { name: /do action/i }));
     expect(onClickSpy).toHaveBeenCalled();
   });
 
   it('should show tooltip text on hover', async () => {
-    const { user } = await setup({ buttonAriaLabel: 'Has tooltip' });
+    const { user } = await setup({ buttonProps: { ariaLabel: 'Has tooltip' } });
     const btn = screen.getByRole('button', { name: /has tooltip/i });
     await user.hover(btn);
     expect(await screen.findByText(defaultTooltipText)).toBeInTheDocument();

--- a/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.stories.ts
+++ b/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.stories.ts
@@ -32,7 +32,7 @@ export const IconButton: Story = {
       height: 12,
       width: 24,
     },
-    buttonAriaLabel: 'Icon button',
+    buttonProps: { ariaLabel: 'Icon button', link: true },
     tooltipText: 'This is an icon button',
     onClick: mockOnClick,
   },

--- a/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.ts
+++ b/libs/explorers/util/src/lib/tooltip-button/tooltip-button.component.ts
@@ -1,10 +1,11 @@
 import { Component, input, viewChild } from '@angular/core';
+import { ButtonModule, ButtonProps } from 'primeng/button';
 import { Tooltip, TooltipModule } from 'primeng/tooltip';
 import { SvgIconComponent } from '../svg-icon/svg-icon.component';
 
 @Component({
   selector: 'explorers-tooltip-button',
-  imports: [Tooltip, TooltipModule, SvgIconComponent],
+  imports: [Tooltip, TooltipModule, SvgIconComponent, ButtonModule],
   templateUrl: './tooltip-button.component.html',
   styleUrls: ['./tooltip-button.component.scss'],
 })
@@ -12,12 +13,13 @@ export class TooltipButtonComponent {
   tooltip = viewChild(Tooltip);
 
   tooltipText = input.required<string>();
+  tooltipPosition = input<string>('right');
   onClick = input.required<() => void>();
 
   buttonLabel = input<string>();
   buttonSvgIconConfig = input<Partial<SvgIconComponent>>();
   buttonAriaDescribedBy = input<string>();
-  buttonAriaLabel = input<string>();
+  buttonProps = input<ButtonProps>();
 
   showTooltip() {
     this.tooltip()?.show();

--- a/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.html
+++ b/libs/model-ad/disease-correlation-comparison-tool/src/lib/disease-correlation-comparison-tool.component.html
@@ -3,7 +3,6 @@
     <explorers-comparison-tool-header
       headerTitle="Disease Correlation"
       filterResultsButtonTooltip="Filter the results based on the selected criteria"
-      shareUrlButtonTooltip="Copy the URL to capture the table’s current filtering, sorting, and pinned results"
     />
     <model-ad-disease-correlation-help-links />
   </div>

--- a/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.html
+++ b/libs/model-ad/gene-expression-comparison-tool/src/lib/gene-expression-comparison-tool.component.html
@@ -3,7 +3,6 @@
     <explorers-comparison-tool-header
       headerTitle="Gene Expression"
       filterResultsButtonTooltip="Filter the results based on the selected criteria"
-      shareUrlButtonTooltip="Copy the URL to capture the table’s current filtering, sorting, and pinned results"
     />
     <model-ad-gene-expression-help-links />
   </div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -80,7 +80,11 @@
               <explorers-tooltip-button
                 [onClick]="copyShareLinkCallbackFn(evidenceType)"
                 [buttonAriaDescribedBy]="generateAnchorId(evidenceType)"
-                [buttonAriaLabel]="`Copy link to ${evidenceType | decodeGreekEntity }`"
+                [buttonProps]="{
+                  ariaLabel: `Copy link to ${evidenceType | decodeGreekEntity }`,
+                  link: true,
+                  style: { 'padding': '0' }
+                }"
                 [tooltipText]="getShareLinkTooltipText(evidenceType)"
                 [buttonSvgIconConfig]="{
                   imagePath: '/explorers-assets/icons/link.svg',

--- a/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.html
+++ b/libs/model-ad/model-overview-comparison-tool/src/lib/model-overview-comparison-tool.component.html
@@ -3,7 +3,6 @@
     <explorers-comparison-tool-header
       headerTitle="Model Overview"
       filterResultsButtonTooltip="Filter the results based on the selected criteria"
-      shareUrlButtonTooltip="Copy the URL to capture the table’s current filtering, sorting, and pinned results"
     />
     <explorers-displayed-results />
     <explorers-comparison-tool-columns />


### PR DESCRIPTION
## Description

We want to adjust the Share URL button’s functionality to update the button's tooltip instead of displaying a toast when the button is clicked.

## Related Issue

[MG-365](https://sagebionetworks.jira.com/browse/MG-365)

## Changelog

- Display tooltip instead of toast on clicking share url button
- Refactor shared tooltip-button component to use a PrimeNG button and allow passing in `buttonProps` and `tooltipPosition`

## Preview

`model-ad-build-images && model-ad-docker-start`

#### Share URL

Current behavior (dev):

https://github.com/user-attachments/assets/68ca33c7-e286-4157-9db5-92f13e370975

Updated behavior (this PR):

https://github.com/user-attachments/assets/366e2964-4057-46fc-b35c-7e06d7d41aec

#### Model Details Share Link

The share link in the model details page is unchanged by the updates to the shared component: 

dev | this PR
:---: | :---: 
<img width="439" height="86" alt="MG-365_modelDetails_dev" src="https://github.com/user-attachments/assets/d788f18f-478e-4520-99cc-00b2836f49b5" /> | <img width="466" height="87" alt="MG-365_modelDetails_pr" src="https://github.com/user-attachments/assets/2185e987-0a5a-4bbc-9021-27a6a60b3cb6" />
