### PR TITLE
fix(explorers): attempt to stabilize flaky e2e tests (AG-1887)

### DIFF
--- a/apps/agora/app/e2e/gene-details.spec.ts
+++ b/apps/agora/app/e2e/gene-details.spec.ts
@@ -39,8 +39,10 @@ test.describe('gene details', () => {
 
     await expect(page.getByRole('heading', { name: gene1.name, exact: true })).toBeVisible();
 
+    const responsePromise = page.waitForResponse(`**/genes/search/enhanced?q=${gene2.id}`);
     const searchInput = page.getByRole('textbox', { name: 'Search genes' });
     await searchInput.pressSequentially(gene2.id);
+    await responsePromise;
 
     const searchList = page.getByRole('list').filter({ hasText: gene2.name });
     const searchListItem = searchList.getByRole('listitem');

--- a/apps/model-ad/app/e2e/model-details.spec.ts
+++ b/apps/model-ad/app/e2e/model-details.spec.ts
@@ -448,8 +448,8 @@ test.describe('model details - boxplots selector - share links - same-document n
       window.location.hash = fragment;
     }, invalidFragment);
 
-    await expect(page).toHaveURL(`${baseURL}${basePath}`);
     await expectPageAtTop(page);
+    await expect(page).toHaveURL(`${baseURL}${basePath}`);
     await expect(page.getByRole('heading', { level: 1, name: modelName })).toBeInViewport();
   });
 });


### PR DESCRIPTION
## Description

The explorers e2e tests have failed on recent pushes to main, so adjust the flaky tests.

## Related Issue

[AG-1887](https://sagebionetworks.jira.com/browse/AG-1887)

## Changelog

- Attempt to stabilize flaky e2e tests

## Preview

`agora-build-images && agora-docker-start && CI=true nx e2e agora-app --no-cloud`
`model-ad-build-images && model-ad-docker-start && CI=true nx e2e model-ad-ap --no-cloud`