### PR TITLE
feat(bixarena): containerize the AI service (SMR-519)

### DIFF
--- a/apps/bixarena/ai-service/Dockerfile
+++ b/apps/bixarena/ai-service/Dockerfile
@@ -1,7 +1,11 @@
+ # Allow overriding the Python patch version at build time:
+ #   docker build --build-arg PYTHON_VERSION=3.13.4 -t bixarena-ai-service .
+ARG PYTHON_VERSION=3.13.3
+
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
 # Builder stage (compile native deps like ujson)
-FROM mirror.gcr.io/python:3.13.3-slim AS builder
+FROM mirror.gcr.io/python:${PYTHON_VERSION}-slim AS builder
 
 ARG USERNAME=app
 ARG USER_UID=1000
@@ -25,8 +29,17 @@ COPY dist/*.tar.gz /tmp/
 RUN uv pip install /tmp/*.tar.gz --system \
   && rm -rf /root/.cache
 
+# Archive only the site-packages (avoid copying the full stdlib later)
+RUN python - <<'EOF'
+import site, tarfile, pathlib
+sp = site.getsitepackages()[0]
+with tarfile.open('/tmp/site-packages.tar', 'w') as tf:
+    for p in pathlib.Path(sp).iterdir():
+        tf.add(p, arcname=p.name)
+EOF
+
 # Runtime stage (no build-essential)
-FROM mirror.gcr.io/python:3.13.3-slim AS runtime
+FROM mirror.gcr.io/python:${PYTHON_VERSION}-slim AS runtime
 
 ARG USERNAME=app
 ARG USER_UID=1000
@@ -49,10 +62,19 @@ RUN groupadd --gid "$USER_GID" "$USERNAME" \
 
 WORKDIR ${APP_DIR}
 
-# Copy installed site-packages & console scripts from builder
-# (These include the project package and all dependencies, including compiled wheels/modules)
-COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Extract archived site-packages into the runtime's site-packages path
+COPY --from=builder /tmp/site-packages.tar /tmp/site-packages.tar
+RUN set -e; python - <<'EOF'
+import site, tarfile, os
+sp = site.getsitepackages()[0]
+with tarfile.open('/tmp/site-packages.tar') as tf:
+  tf.extractall(sp)
+os.remove('/tmp/site-packages.tar')
+EOF
+
+# Copy only necessary console scripts (uvicorn + project entry point)
+COPY --from=builder /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY --from=builder /usr/local/bin/bixarena-ai-service /usr/local/bin/bixarena-ai-service
 
 # Copy runtime configuration / entrypoint script
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/apps/bixarena/ai-service/Dockerfile
+++ b/apps/bixarena/ai-service/Dockerfile
@@ -1,0 +1,38 @@
+FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
+
+# Runtime stage
+FROM mirror.gcr.io/python:3.13.3-slim
+
+ARG USERNAME=app
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ENV APP_DIR=/app \
+    APP_USERNAME=${USERNAME}
+
+# Copy uv binary
+COPY --from=uv /uv /bin/uv
+
+# Create user and install system dependencies
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+  && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" \
+  && apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get install --no-install-recommends -qq -y \
+    gosu build-essential \
+  && apt-get -y clean \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${APP_DIR}
+
+# Install the built sdist - this will install all other dependencies
+COPY dist/*.tar.gz /tmp/
+RUN uv pip install /tmp/*.tar.gz --system
+
+# Copy configuration files
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+RUN chown -R ${APP_USERNAME}:${APP_USERNAME} ${APP_DIR} && \
+    chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["python"]

--- a/apps/bixarena/ai-service/Dockerfile
+++ b/apps/bixarena/ai-service/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/astral-sh/uv:0.5.14 AS uv
 
-# Runtime stage
-FROM mirror.gcr.io/python:3.13.3-slim
+# Builder stage (compile native deps like ujson)
+FROM mirror.gcr.io/python:3.13.3-slim AS builder
 
 ARG USERNAME=app
 ARG USER_UID=1000
@@ -9,30 +9,56 @@ ARG USER_GID=$USER_UID
 ENV APP_DIR=/app \
     APP_USERNAME=${USERNAME}
 
-# Copy uv binary
+# Copy uv binary into builder
 COPY --from=uv /uv /bin/uv
 
-# Create user and install system dependencies
+WORKDIR ${APP_DIR}
+
+# Install build toolchain only in builder
+RUN apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get install --no-install-recommends -qq -y \
+    build-essential \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy distribution artifact(s) and install (brings in all dependencies)
+COPY dist/*.tar.gz /tmp/
+RUN uv pip install /tmp/*.tar.gz --system \
+  && rm -rf /root/.cache
+
+# Runtime stage (no build-essential)
+FROM mirror.gcr.io/python:3.13.3-slim AS runtime
+
+ARG USERNAME=app
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ENV APP_DIR=/app \
+    APP_USERNAME=${USERNAME}
+
+# Copy uv binary into runtime
+COPY --from=uv /uv /bin/uv
+
+# Create user & minimal runtime deps only
 RUN groupadd --gid "$USER_GID" "$USERNAME" \
   && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" \
   && apt-get update -qq -y && export DEBIAN_FRONTEND=noninteractive \
   && apt-get install --no-install-recommends -qq -y \
-    gosu build-essential \
+    gosu \
   && apt-get -y clean \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR ${APP_DIR}
 
-# Install the built sdist - this will install all other dependencies
-COPY dist/*.tar.gz /tmp/
-RUN uv pip install /tmp/*.tar.gz --system
+# Copy installed site-packages & console scripts from builder
+# (These include the project package and all dependencies, including compiled wheels/modules)
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 
-# Copy configuration files
+# Copy runtime configuration / entrypoint script
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-RUN chown -R ${APP_USERNAME}:${APP_USERNAME} ${APP_DIR} && \
-    chmod +x /docker-entrypoint.sh
+RUN chown -R ${APP_USERNAME}:${APP_USERNAME} ${APP_DIR} /docker-entrypoint.sh \
+  && chmod +x /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["python"]

--- a/apps/bixarena/ai-service/bixarena_ai_service/__main__.py
+++ b/apps/bixarena/ai-service/bixarena_ai_service/__main__.py
@@ -1,0 +1,71 @@
+"""Console script entry point for the BixArena AI Service.
+
+This wrapper intentionally avoids a custom argument parser. It provides:
+  * A default ASGI app target: ``bixarena_ai_service.main:app`` if the user
+    doesn't specify one as the first argument.
+  * Optional defaults for ``--host`` and ``--port`` (env overridable via
+    ``APP_HOST`` / ``APP_PORT``) only when the user hasn't already supplied
+    those flags.
+
+Usage examples:
+  bixarena-ai-service --reload
+  bixarena-ai-service --reload --port 9000
+  bixarena-ai-service bixarena_ai_service.main:app --host 0.0.0.0 --port 8114
+
+Environment variables:
+  APP_HOST  (default: 0.0.0.0)
+  APP_PORT  (default: 8000)
+
+Any additional flags are passed straight through to uvicorn.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import uvicorn
+
+DEFAULT_APP = "bixarena_ai_service.main:app"
+
+
+def _inject_defaults(argv: list[str]) -> list[str]:
+    """Return a modified argv (excluding program name) with defaults injected.
+
+    Rules:
+      1. If the first arg is missing or starts with '--', insert DEFAULT_APP.
+      2. If '--host' not present (and no UNIX socket specified via '--uds'), add
+         a default host (APP_HOST env or 0.0.0.0) immediately after app target.
+    3. If '--port' not present and no '--uds', add default port
+      (APP_PORT env or 8000).
+    """
+
+    if not argv or argv[0].startswith("--"):
+        argv = [DEFAULT_APP, *argv]
+
+    # Detect if user provided host/port/uds already
+    has_host = "--host" in argv or "--uds" in argv
+    has_port = "--port" in argv or "--uds" in argv
+
+    # Insert defaults only if missing
+    parts: list[str] = [argv[0]]  # start with app target
+
+    if not has_host:
+        parts += ["--host", os.getenv("APP_HOST", "0.0.0.0")]
+    if not has_port:
+        parts += ["--port", os.getenv("APP_PORT", "8000")]
+
+    parts.extend(argv[1:])
+    return parts
+
+
+def main() -> None:  # noqa: D401
+    """Entry point that adapts arguments then delegates to ``uvicorn.main``."""
+    args = _inject_defaults(sys.argv[1:])
+    # Rebuild sys.argv for uvicorn's own CLI parsing
+    sys.argv = ["uvicorn", *args]
+    uvicorn.main()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/apps/bixarena/ai-service/docker-entrypoint.sh
+++ b/apps/bixarena/ai-service/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$1" = 'python' ]; then
+    cd ${APP_DIR}
+    : "${APP_PORT:=8114}"
+    # Use installed console script (provided by pyproject [project.scripts])
+    exec gosu "$APP_USERNAME" bixarena-ai-service \
+        --host 0.0.0.0 \
+        --port "${APP_PORT}"
+fi
+
+exec "$@"

--- a/apps/bixarena/ai-service/project.json
+++ b/apps/bixarena/ai-service/project.json
@@ -33,9 +33,7 @@
     "serve": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": [
-          "uv run uvicorn bixarena_ai_service.main:app --reload --host 0.0.0.0 --port ${APP_PORT}"
-        ],
+        "commands": ["uv run bixarena-ai-service --reload --host 0.0.0.0 --port ${APP_PORT}"],
         "cwd": "{projectRoot}",
         "parallel": false
       }

--- a/apps/bixarena/ai-service/pyproject.toml
+++ b/apps/bixarena/ai-service/pyproject.toml
@@ -62,6 +62,9 @@ dependencies = [
   "websockets==10.0",
 ]
 
+# Transitional console script now points to wrapper package
+[project.scripts]
+bixarena-ai-service = "bixarena_ai_service.__main__:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["bixarena_ai_service"]

--- a/docker/bixarena/serve-detach.sh
+++ b/docker/bixarena/serve-detach.sh
@@ -4,6 +4,7 @@ product_name="bixarena"
 
 args=(
   # List of services in alphanumeric order
+  --file docker/"$product_name"/services/ai-service.yml
   --file docker/"$product_name"/services/apex.yml
   --file docker/"$product_name"/services/api-gateway.yml
   --file docker/"$product_name"/services/api.yml

--- a/docker/bixarena/services/ai-service.yml
+++ b/docker/bixarena/services/ai-service.yml
@@ -1,0 +1,17 @@
+services:
+  bixarena-ai-service:
+    image: ghcr.io/sage-bionetworks/bixarena-ai-service:${BIXARENA_VERSION:-local}
+    container_name: bixarena-ai-service
+    restart: always
+    env_file:
+      - ../../../apps/bixarena/ai-service/.env
+    networks:
+      - bixarena
+    ports:
+      - '8114:8114'
+    deploy:
+      resources:
+        limits:
+          memory: 1GB
+    depends_on:
+      - bixarena-postgres

--- a/docker/bixarena/services/api-gateway.yml
+++ b/docker/bixarena/services/api-gateway.yml
@@ -14,7 +14,10 @@ services:
         limits:
           memory: 1G
     depends_on:
+      bixarena-ai-service:
+        condition: service_started
       bixarena-api:
         condition: service_started
     extra_hosts:
+      - 'bixarena-ai-service:host-gateway'
       - 'bixarena-api:host-gateway'


### PR DESCRIPTION
## Description

<!-- Please include a brief summary of the changes and the related issue. Itemize
the changes in the section Changelog (see below). -->

## Related Issue

- [SMR-519](https://sagebionetworks.jira.com/browse/SMR-519)
- Depends on #3553

## Changelog

- Define a console script in `pyproject.toml` to start the app with `uv run bixarena-ai-service ...`.
- Add `Dockerfile` and entry point file to enable the `build-image` task.

## Preview

### Build the image

```bash
nx build-image bixarena-ai-service
```

Notes that `usjon` requires `g++`, which would make the Docker image 1.32 GB. By separating the build and runtime stage in the Dockerfile, the resulting image is only 256 GB.

### Build all the images

Includes the image of the AI service:

```bash
bixarena-build-images
```

Output:

```console
 NX   Running target build-image for 6 projects and 9 tasks they depend on

   →  Executing 3/13 remaining tasks in parallel...
   ✔  nx run bixarena-api-description:build (3s)
   ✔  nx run bixarena-app:build (2s)
   ✔  nx run bixarena-ai-service:build (1s)
   ✔  nx run bixarena-apex:generate-dockerfile (12ms)
   ✔  nx run bixarena-postgres:generate-dockerfile (12ms)
   ✔  nx run bixarena-app:build-image:local (4s)
   ✔  nx run bixarena-api:build-image-base (15s)
   ✔  nx run bixarena-apex:build-image:local (2s)
   ✔  nx run bixarena-postgres:build-image:local (2s)
   ✔  nx run bixarena-api:build-image:local (1s)
   ✔  nx run bixarena-api-gateway:build-image-base (23s)
   ✔  nx run bixarena-api-gateway:build-image:local (957ms)
   ✔  nx run bixarena-ai-service:build-image:local (16s)
```

### Start the stack

Includes the AI service:

```bash
nx serve-detach bixarena-apex
```

[SMR-519]: https://sagebionetworks.jira.com/browse/SMR-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ