### PR TITLE
fix: create Python-specific Nx task inputs to better identify affected Python projects (SMR-522)

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -212,7 +212,13 @@
       "!{projectRoot}/.storybook/**/*",
       "!{projectRoot}/tsconfig.storybook.json",
       "!{projectRoot}/src/test/**/*"
-    ]
+    ],
+    "defaultPython": [
+      "{projectRoot}/**/*",
+      "{workspaceRoot}/pyproject.toml",
+      "{workspaceRoot}/uv.lock"
+    ],
+    "production-python": ["defaultPython"]
   },
   "useInferencePlugins": false,
   "defaultBase": "main",


### PR DESCRIPTION
## Description

## Related Issue

- [SMR-522](https://sagebionetworks.jira.com/browse/SMR-522)

## Changelog

- Add the named input `defaultPython` modeled upon `default`.
- Add the named input `productionPython` modeled upon `production`.