### PR TITLE
feat(explorers): optimize database indexes for query performance (AG-2164, MG-989)

### DIFF
--- a/apps/agora/data/src/data/collections-indexes.json
+++ b/apps/agora/data/src/data/collections-indexes.json
@@ -50,10 +50,6 @@
     "indexes": [{ "ensembl_gene_id": 1 }]
   },
   {
-    "name": "geneexpvalidation",
-    "indexes": [{ "ensembl_gene_id": 1 }]
-  },
-  {
     "name": "nominateddrugs",
     "indexes": [{ "common_name": 1 }, { "chembl_id": 1, "combined_with": 1 }]
   },

--- a/apps/agora/data/src/data/collections-indexes.json
+++ b/apps/agora/data/src/data/collections-indexes.json
@@ -6,20 +6,28 @@
       { "hgnc_symbol": 1 },
       { "alias": 1 },
       { "total_nominations": -1, "hgnc_symbol": 1 }
-    ]
+    ],
+    "collatedIndexes": [{ "hgnc_symbol": 1, "ensembl_gene_id": 1 }]
   },
   {
     "name": "genes",
-    "indexes": [
-      { "ensembl_gene_id": 1, "tissue": 1, "model": 1 },
-      { "ensembl_gene_id": 1, "model": 1 },
-      { "hgnc_symbol": 1, "tissue": 1, "model": 1 }
-    ],
+    "indexes": [{ "ensembl_gene_id": 1, "tissue": 1, "model": 1 }],
     "collatedIndexes": [{ "hgnc_symbol": 1, "tissue": 1, "model": 1 }]
   },
   {
     "name": "geneslinks",
-    "indexes": [{ "geneA_ensembl_gene_id": 1 }, { "geneB_ensembl_gene_id": 1 }]
+    "indexes": [
+      { "geneA_ensembl_gene_id": 1, "geneB_ensembl_gene_id": 1 },
+      { "geneB_ensembl_gene_id": 1 }
+    ]
+  },
+  {
+    "name": "genesneuropathcorr",
+    "indexes": [{ "ensg": 1 }]
+  },
+  {
+    "name": "genesoverallscores",
+    "indexes": [{ "ensembl_gene_id": 1 }]
   },
   {
     "name": "genesmetabolomics",
@@ -42,8 +50,8 @@
     "indexes": [{ "ensembl_gene_id": 1 }]
   },
   {
-    "name": "biodomaininfo",
-    "indexes": [{ "name": 1 }]
+    "name": "geneexpvalidation",
+    "indexes": [{ "ensembl_gene_id": 1 }]
   },
   {
     "name": "nominateddrugs",
@@ -51,7 +59,7 @@
   },
   {
     "name": "nominatedtargets",
-    "indexes": [{ "ensembl_gene_id": 1 }]
+    "indexes": [{ "ensembl_gene_id": 1 }, { "hgnc_symbol": 1 }]
   },
   {
     "name": "uiconfig",

--- a/apps/agora/data/src/main.py
+++ b/apps/agora/data/src/main.py
@@ -143,16 +143,13 @@ def create_collections_indexes(
         for collection_index_data in collections_indexes_data:
             collection_name = collection_index_data["name"]
             logger.debug("Creating indexes for collection '%s'", collection_name)
-            indexes = collection_index_data["indexes"]
+            indexes = collection_index_data.get("indexes", [])
             collection = db.get_collection(collection_name)
             for index in indexes:
                 collection.create_index(list(index.items()))
             for index in collection_index_data.get("collatedIndexes", []):
                 key = list(index.items())
-                name = "_".join(f"{k}_{v}" for k, v in key) + "_collated"
-                collection.create_index(
-                    key, name=name, collation=Collation("en", strength=2)
-                )
+                collection.create_index(key, collation=Collation("en", strength=2))
             logger.debug(
                 "Created indexes for collection '%s' successfully",
                 collection_name,

--- a/apps/model-ad/data/src/data/collections-indexes.json
+++ b/apps/model-ad/data/src/data/collections-indexes.json
@@ -18,7 +18,6 @@
   },
   {
     "name": "model_overview",
-    "indexes": [{ "name": 1 }],
     "collatedIndexes": [{ "name": 1 }]
   },
   {

--- a/apps/model-ad/data/src/data/collections-indexes.json
+++ b/apps/model-ad/data/src/data/collections-indexes.json
@@ -27,14 +27,17 @@
   },
   {
     "name": "rna_de_aggregate",
-    "indexes": [{ "ensembl_gene_id": 1 }, { "tissue": 1, "ensembl_gene_id": 1, "name": 1 }],
+    "indexes": [
+      { "ensembl_gene_id": 1 },
+      { "tissue": 1, "ensembl_gene_id": 1, "name.link_text": 1, "sex": 1 }
+    ],
     "collatedIndexes": [{ "tissue": 1 }]
   },
   {
     "name": "rna_de_individual",
     "indexes": [
-      { "ensembl_gene_id": 1 },
-      { "ensembl_gene_id": 1, "tissue": 1, "name": 1, "model_group": 1 }
+      { "ensembl_gene_id": 1, "tissue": 1, "name": 1, "model_group": 1 },
+      { "ensembl_gene_id": 1, "model_group": 1, "tissue": 1 }
     ]
   },
   {

--- a/apps/model-ad/data/src/main.py
+++ b/apps/model-ad/data/src/main.py
@@ -137,16 +137,13 @@ def create_collections_indexes(
         for collection_index_data in collections_indexes_data:
             collection_name = collection_index_data["name"]
             logger.debug("Creating indexes for collection '%s'", collection_name)
-            indexes = collection_index_data["indexes"]
+            indexes = collection_index_data.get("indexes", [])
             collection = db.get_collection(collection_name)
             for index in indexes:
                 collection.create_index(list(index.items()))
             for index in collection_index_data.get("collatedIndexes", []):
                 key = list(index.items())
-                name = "_".join(f"{k}_{v}" for k, v in key) + "_collated"
-                collection.create_index(
-                    key, name=name, collation=Collation("en", strength=2)
-                )
+                collection.create_index(key, collation=Collation("en", strength=2))
             logger.debug(
                 "Created indexes for collection '%s' successfully",
                 collection_name,


### PR DESCRIPTION
## Description

Mirror the data-manager index changes into local data loaders for both apps. Also fixes a DocumentDB limitation where binary and collated indexes cannot coexist on the same key pattern, and removes the `_collated` suffix naming (unnecessary since only one index per key can exist on DocumentDB).

For full index audit details, see:
- https://github.com/Sage-Bionetworks/model-ad-data-manager/pull/45
- https://github.com/Sage-Bionetworks/agora-data-manager/pull/159

## Related Issue

- [MG-989](https://sagebionetworks.jira.com/browse/MG-989)
- [AG-2164](https://sagebionetworks.jira.com/browse/AG-2164)

## Changelog

- Optimize `rna_de_individual` and `rna_de_aggregate` indexes for Model-AD
- Optimize indexes for Agora: add missing, remove redundant, add collated
- Remove binary `{name: 1}` from `model_overview` — DocumentDB can't have binary + collated on same key
- Remove `_collated` suffix from index creation in both `main.py` files
- Add `.get("indexes", [])` safety for collections with only `collatedIndexes`

## Testing

- Start local stack and verify the sorting/filtering/search works as expected
- After corresponding data-manager PRs are deployed, verify the dev app loads without errors and the sorting/filtering/search works as expected

[MG-989]: https://sagebionetworks.jira.com/browse/MG-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-2164]: https://sagebionetworks.jira.com/browse/AG-2164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ