### PR TITLE
feat(model-ad): add marmoset model overview comparison tool (MG-940)

### DIFF
--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/document/ComparisonToolConfigDocumentTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/document/ComparisonToolConfigDocumentTest.java
@@ -1,0 +1,84 @@
+package org.sagebionetworks.model.ad.api.next.model.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+/**
+ * Pins the Spring Data conversion behavior that reads of the `ui_config` collection depend on.
+ * Some filters store `values` as a bare string instead of an array (e.g. `"values": "PSEN1"` in
+ * the marmoset config), while both this document class and the API contract declare it as a list.
+ * Spring's ObjectToCollectionConverter wraps the lone string during the read; no mapping code
+ * performs that normalization, so losing it would silently empty a filter panel.
+ */
+class ComparisonToolConfigDocumentTest {
+
+  private MappingMongoConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    MongoMappingContext mappingContext = new MongoMappingContext();
+    mappingContext.afterPropertiesSet();
+
+    converter = new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, mappingContext);
+    converter.afterPropertiesSet();
+  }
+
+  @Test
+  @DisplayName("should read bare string filter values as a single-element list")
+  void shouldReadBareStringFilterValuesAsSingleElementList() {
+    // given
+    Document source = configWithFilterValues("PSEN1");
+
+    // when
+    ComparisonToolConfigDocument result = converter.read(
+      ComparisonToolConfigDocument.class,
+      source
+    );
+
+    // then
+    assertThat(filterValuesOf(result)).containsExactly("PSEN1");
+  }
+
+  @Test
+  @DisplayName("should read array filter values as a list")
+  void shouldReadArrayFilterValuesAsList() {
+    // given
+    Document source = configWithFilterValues(List.of("Familial AD", "Late Onset AD"));
+
+    // when
+    ComparisonToolConfigDocument result = converter.read(
+      ComparisonToolConfigDocument.class,
+      source
+    );
+
+    // then
+    assertThat(filterValuesOf(result)).containsExactly("Familial AD", "Late Onset AD");
+  }
+
+  private static Document configWithFilterValues(Object values) {
+    Document filter = new Document()
+      .append("name", "Modified Gene")
+      .append("data_key", "modified_genes")
+      .append("query_param_key", "modifiedGenes")
+      .append("values", values);
+
+    return new Document()
+      .append("page", "Marmoset Model Overview")
+      .append("dropdowns", List.of())
+      .append("columns", List.of())
+      .append("filters", List.of(filter));
+  }
+
+  private static List<String> filterValuesOf(ComparisonToolConfigDocument document) {
+    assertThat(document.getFilters()).hasSize(1);
+    return document.getFilters().get(0).getValues();
+  }
+}

--- a/apps/model-ad/app/e2e/constants.ts
+++ b/apps/model-ad/app/e2e/constants.ts
@@ -10,6 +10,13 @@ export const COMPARISON_TOOL_API_PATHS: Record<string, string> = {
   'Disease Correlation': '/comparison-tools/disease-correlation',
 };
 
+// Header navigation path to each comparison tool, from the top-level nav item to the link itself
+export const COMPARISON_TOOL_NAV_TRAILS: Record<string, string[]> = {
+  'Model Overview': ['Model Overview', 'Mouse Models'],
+  'Differential Expression': ['Differential Expression'],
+  'Disease Correlation': ['Disease Correlation'],
+};
+
 export const COMPARISON_TOOL_CONFIG_PATH = 'comparison-tools/config';
 
 // Default sort configurations for each comparison tool (required by API)

--- a/apps/model-ad/app/e2e/constants.ts
+++ b/apps/model-ad/app/e2e/constants.ts
@@ -1,10 +1,12 @@
 export const COMPARISON_TOOL_PATHS: Record<string, string> = {
+  'Marmoset Model Overview': '/comparison/model/marmoset',
   'Model Overview': '/comparison/model',
   'Differential Expression': '/comparison/expression',
   'Disease Correlation': '/comparison/correlation',
 };
 
 export const COMPARISON_TOOL_API_PATHS: Record<string, string> = {
+  'Marmoset Model Overview': '/comparison-tools/marmoset-model-overview',
   'Model Overview': '/comparison-tools/mouse-model-overview',
   'Differential Expression': '/comparison-tools/transcriptomics',
   'Disease Correlation': '/comparison-tools/disease-correlation',
@@ -12,6 +14,7 @@ export const COMPARISON_TOOL_API_PATHS: Record<string, string> = {
 
 // Header navigation path to each comparison tool, from the top-level nav item to the link itself
 export const COMPARISON_TOOL_NAV_TRAILS: Record<string, string[]> = {
+  'Marmoset Model Overview': ['Model Overview', 'Marmoset Models'],
   'Model Overview': ['Model Overview', 'Mouse Models'],
   'Differential Expression': ['Differential Expression'],
   'Disease Correlation': ['Disease Correlation'],
@@ -21,6 +24,7 @@ export const COMPARISON_TOOL_CONFIG_PATH = 'comparison-tools/config';
 
 // Default sort configurations for each comparison tool (required by API)
 export const COMPARISON_TOOL_DEFAULT_SORTS: Record<string, { field: string; order: 1 | -1 }[]> = {
+  'Marmoset Model Overview': [{ field: 'name', order: 1 }],
   'Model Overview': [
     { field: 'model_type', order: -1 },
     { field: 'name', order: 1 },

--- a/apps/model-ad/app/e2e/helpers/comparison-tool.ts
+++ b/apps/model-ad/app/e2e/helpers/comparison-tool.ts
@@ -14,6 +14,7 @@ import {
   COMPARISON_TOOL_API_PATHS,
   COMPARISON_TOOL_CONFIG_PATH,
   COMPARISON_TOOL_DEFAULT_SORTS,
+  COMPARISON_TOOL_NAV_TRAILS,
   COMPARISON_TOOL_PATHS,
 } from '../constants';
 
@@ -34,7 +35,17 @@ export const navigateToComparison = async (
     if (await menuButton.isVisible().catch(() => false)) {
       await menuButton.click();
     }
-    await page.getByRole('link', { name: name }).click();
+
+    const navTrail = COMPARISON_TOOL_NAV_TRAILS[name];
+    if (navTrail.length > 1) {
+      // Desktop renders the parent nav item as a dropdown trigger that must be opened first;
+      // mobile renders the children directly, so there is no trigger to click.
+      const dropdownTrigger = page.getByRole('button', { name: navTrail[0] });
+      if (await dropdownTrigger.isVisible().catch(() => false)) {
+        await dropdownTrigger.click();
+      }
+    }
+    await page.getByRole('link', { name: navTrail[navTrail.length - 1] }).click();
   }
 
   await expectComparisonToolTableLoaded(page, name, shouldCloseVisualizationOverviewDialog);

--- a/apps/model-ad/app/e2e/helpers/comparison-tool.ts
+++ b/apps/model-ad/app/e2e/helpers/comparison-tool.ts
@@ -4,6 +4,8 @@ import {
   ComparisonToolConfig,
   DiseaseCorrelation,
   DiseaseCorrelationsPage,
+  MarmosetModelOverview,
+  MarmosetModelOverviewsPage,
   MouseModelOverview,
   MouseModelOverviewsPage,
   Transcriptomics,
@@ -87,6 +89,14 @@ export const fetchComparisonToolData = async <T>(
 export const fetchMouseModelOverviews = async (page: Page): Promise<MouseModelOverview[]> => {
   const data = await fetchComparisonToolData<MouseModelOverviewsPage>(page, 'Model Overview');
   return data.mouseModelOverviews;
+};
+
+export const fetchMarmosetModelOverviews = async (page: Page): Promise<MarmosetModelOverview[]> => {
+  const data = await fetchComparisonToolData<MarmosetModelOverviewsPage>(
+    page,
+    'Marmoset Model Overview',
+  );
+  return data.marmosetModelOverviews;
 };
 
 export const fetchDiseaseCorrelations = async (

--- a/apps/model-ad/app/e2e/marmoset-model-overview-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/marmoset-model-overview-comparison-tool.spec.ts
@@ -4,7 +4,6 @@ import {
   ColumnConfig,
   expectPinnedParams,
   getPinnedTable,
-  getQueryParamFromValues,
   getQueryParamsFromRecords,
   getRowByName,
   getUnpinnedTable,

--- a/apps/model-ad/app/e2e/marmoset-model-overview-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/marmoset-model-overview-comparison-tool.spec.ts
@@ -1,0 +1,215 @@
+import { expect, test } from '@playwright/test';
+import {
+  clickViewDetailsButtonByName,
+  ColumnConfig,
+  expectPinnedParams,
+  getPinnedTable,
+  getQueryParamFromValues,
+  getQueryParamsFromRecords,
+  getRowByName,
+  getUnpinnedTable,
+  pinByName,
+  runFilterPanelTests,
+  testClickColumnTogglesSortOrder,
+  testClickColumnUpdatesSortUrl,
+  testClickDifferentColumnsReplacesSingleSort,
+  testFilterSelectionRestoredFromUrl,
+  testFilterSelectionUpdatesUrl,
+  testFiltersRemovedFromUrlOnClearAll,
+  testMetaClickBuildsMultiColumnSort,
+  testMetaClickTogglesExistingSortOrder,
+  testMultiColumnSortRestoredFromUrl,
+  testPartialCaseInsensitiveSearch,
+  testSortRestoredFromUrl,
+  unPinByName,
+} from '@sagebionetworks/explorers/testing/e2e';
+import { baseURL } from '../playwright.config';
+import { COMPARISON_TOOL_PATHS } from './constants';
+import { fetchMarmosetModelOverviews, navigateToComparison } from './helpers/comparison-tool';
+
+const CT_PAGE = 'Marmoset Model Overview';
+const MARMOSET_MODEL_OVERVIEW_PATH = COMPARISON_TOOL_PATHS[CT_PAGE];
+
+const MODEL = 'Presenilin 1';
+const MODEL_BIOMARKERS_PATH = `/models/${encodeURIComponent(MODEL)}/biomarkers?modelOrganism=marmoset`;
+
+test.describe('marmoset model overview', () => {
+  runFilterPanelTests(async (page) => navigateToComparison(page, CT_PAGE, true));
+
+  test('share URL button copies URL to clipboard', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read']);
+
+    await navigateToComparison(page, CT_PAGE, true);
+
+    const shareUrlButton = page.getByRole('button', { name: 'Share URL' });
+    await expect(shareUrlButton).toBeVisible();
+
+    await page.waitForURL(MARMOSET_MODEL_OVERVIEW_PATH);
+
+    await shareUrlButton.click();
+
+    const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardContent).toEqual(`${baseURL}${MARMOSET_MODEL_OVERVIEW_PATH}`);
+  });
+
+  test('pinning and unpinning items updates the pinned query param', async ({ page }) => {
+    const [firstModel] = await fetchMarmosetModelOverviews(page);
+    expect(firstModel).toBeDefined();
+
+    await navigateToComparison(page, CT_PAGE, true);
+
+    const pinnedTable = getPinnedTable(page);
+    const unpinnedTable = getUnpinnedTable(page);
+
+    await pinByName(unpinnedTable, page, firstModel.name);
+    await expect(getRowByName(pinnedTable, page, firstModel.name)).toHaveCount(1);
+    await expectPinnedParams(page, [firstModel.name]);
+
+    const pinnedRow = await unPinByName(pinnedTable, page, firstModel.name);
+    await expect(pinnedRow).toHaveCount(0);
+    await expectPinnedParams(page, []);
+  });
+
+  test('filterbox search without comma returns partial case-insensitive matches', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true);
+    await testPartialCaseInsensitiveSearch(page, 'presenilin', [MODEL]);
+  });
+
+  test.describe('sort URL sync', () => {
+    // Columns: 0=Model (name), 1=Model Type, 2=Plasma Biomarkers, 3=Study Data
+    // Default sort: name ASC
+
+    const sortColumns: ColumnConfig[] = [
+      { name: 'Model Type', field: 'model_type' },
+      { name: 'Plasma Biomarkers', field: 'biomarkers' },
+      { name: 'Study Data', field: 'study_data' },
+    ];
+
+    test('clicking column updates URL with sortFields and sortOrders', async ({ page }) => {
+      await navigateToComparison(page, CT_PAGE, true);
+      await testClickColumnUpdatesSortUrl(page, sortColumns[0].name, sortColumns[0].field);
+    });
+
+    test('clicking same column toggles between descending and ascending', async ({ page }) => {
+      await navigateToComparison(page, CT_PAGE, true);
+      await testClickColumnTogglesSortOrder(page, sortColumns[0].name, sortColumns[0].field);
+    });
+
+    test('sort is restored from URL on page load', async ({ page }) => {
+      await navigateToComparison(page, CT_PAGE, true, 'url', 'sortFields=biomarkers&sortOrders=1');
+      await testSortRestoredFromUrl(page, sortColumns[1].name, sortColumns[1].field);
+    });
+
+    test('clicking different columns in sequence replaces single-column sort', async ({ page }) => {
+      await navigateToComparison(page, CT_PAGE, true);
+      await testClickDifferentColumnsReplacesSingleSort(page, sortColumns);
+    });
+
+    test('Meta+click builds multi-column sort with multiple columns', async ({ page }) => {
+      await navigateToComparison(page, CT_PAGE, true);
+      await testMetaClickBuildsMultiColumnSort(page, sortColumns);
+    });
+
+    test('multi-column sort is restored from URL', async ({ page }) => {
+      await navigateToComparison(
+        page,
+        CT_PAGE,
+        true,
+        'url',
+        'sortFields=model_type,biomarkers&sortOrders=-1,1',
+      );
+      await testMultiColumnSortRestoredFromUrl(page, sortColumns.slice(0, 2), sortColumns[2]);
+    });
+
+    test('Meta+click on existing sort columns toggles their order', async ({ page }) => {
+      await navigateToComparison(page, CT_PAGE, true);
+      await testMetaClickTogglesExistingSortOrder(page, sortColumns);
+    });
+  });
+
+  test.describe('filter URL sync', () => {
+    // Every value matches the single marmoset model, so applying them never empties the table
+    const filterParams = {
+      modelTypes: ['Familial AD'],
+      availableData: ['Plasma Biomarkers'],
+      modifiedGenes: ['PSEN1'],
+    };
+    const selectedFilters = {
+      'Model Type': ['Familial AD'],
+      'Available Data': ['Plasma Biomarkers'],
+      'Modified Gene': ['PSEN1'],
+    };
+
+    test('filter selections are added to URL when selected and removed when cleared', async ({
+      page,
+    }) => {
+      await navigateToComparison(page, CT_PAGE, true);
+      await testFilterSelectionUpdatesUrl(page, 'modelTypes', 'Model Type', 'Familial AD');
+    });
+
+    test('filter selections are restored from URL on page load', async ({ page }) => {
+      await navigateToComparison(
+        page,
+        CT_PAGE,
+        true,
+        'url',
+        getQueryParamsFromRecords(filterParams),
+      );
+      await testFilterSelectionRestoredFromUrl(page, filterParams, selectedFilters);
+    });
+
+    test('filters are removed from URL when Clear All is clicked', async ({ page }) => {
+      await navigateToComparison(
+        page,
+        CT_PAGE,
+        true,
+        'url',
+        getQueryParamsFromRecords(filterParams),
+      );
+      await testFiltersRemovedFromUrlOnClearAll(page, filterParams);
+    });
+  });
+
+  test('plasma biomarkers link opens the marmoset model biomarkers tab in a new tab', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true);
+
+    const link = page.getByRole('link', { name: 'Results' }).first();
+    await expect(link).toHaveAttribute('href', MODEL_BIOMARKERS_PATH);
+
+    const popupPromise = page.waitForEvent('popup');
+    await link.click();
+    const popup = await popupPromise;
+
+    await popup.waitForURL(MODEL_BIOMARKERS_PATH);
+    await expect(popup.getByRole('heading', { level: 1, name: MODEL })).toBeVisible();
+  });
+
+  test('study data link points to the Synapse study page in a new tab', async ({ page }) => {
+    const [firstModel] = await fetchMarmosetModelOverviews(page);
+    const studyDataUrl = firstModel.study_data.link_url ?? '';
+    expect(studyDataUrl).toContain('synapse.org');
+
+    await navigateToComparison(page, CT_PAGE, true);
+
+    const link = page.getByRole('link', { name: 'View Data' }).first();
+    await expect(link).toHaveAttribute('href', studyDataUrl);
+    await expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  test('view details button opens the marmoset model details page in a new tab', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true);
+
+    const popupPromise = page.waitForEvent('popup');
+    await clickViewDetailsButtonByName(getUnpinnedTable(page), page, MODEL);
+    const popup = await popupPromise;
+
+    await popup.waitForURL(`/models/${encodeURIComponent(MODEL)}?modelOrganism=marmoset`);
+    await expect(popup.getByRole('heading', { level: 1, name: MODEL })).toBeVisible();
+  });
+});

--- a/apps/model-ad/app/src/app/app.routes.ts
+++ b/apps/model-ad/app/src/app/app.routes.ts
@@ -57,6 +57,18 @@ export const routes: Route[] = [
     },
   },
   {
+    path: ROUTE_PATHS.MARMOSET_MODEL_OVERVIEW,
+    loadChildren: () =>
+      import('@sagebionetworks/model-ad/marmoset-model-overview-comparison-tool').then(
+        (routes) => routes.routes,
+      ),
+    data: {
+      title: "Marmoset Model Overview | Overview of marmoset models of Alzheimer's Disease",
+      description:
+        "Explore emerging marmoset models of Alzheimer's Disease developed by the Marmo-AD consortium.",
+    },
+  },
+  {
     path: ROUTE_PATHS.MOUSE_MODEL_OVERVIEW,
     loadChildren: () =>
       import('@sagebionetworks/model-ad/mouse-model-overview-comparison-tool').then(

--- a/libs/explorers/testing/src/lib/e2e/comparison-tool.ts
+++ b/libs/explorers/testing/src/lib/e2e/comparison-tool.ts
@@ -77,6 +77,14 @@ export const getRowByName = (table: Locator, page: Page, name: string): Locator 
     has: page.getByRole('cell', { name, exact: true }),
   });
 
+export const clickViewDetailsButtonByName = async (table: Locator, page: Page, name: string) => {
+  const row = getRowByName(table, page, name);
+  await expect(row).toHaveCount(1);
+  const viewDetailsButton = row.getByRole('button', { name: 'View Details' });
+  await viewDetailsButton.focus();
+  await viewDetailsButton.press('Enter');
+};
+
 export const togglePinByName = async (
   table: Locator,
   page: Page,

--- a/libs/explorers/ui/src/lib/components/header/header.component.html
+++ b/libs/explorers/ui/src/lib/components/header/header.component.html
@@ -22,17 +22,22 @@
               @for (link of links; track link.label) {
                 <li [class.mobile-dropdown-item]="link.children && isMobile">
                   @if (link.children && !isMobile) {
-                    <a
+                    <button
+                      type="button"
                       class="dropdown-trigger"
+                      aria-haspopup="menu"
+                      [attr.aria-expanded]="menu.visible ?? false"
+                      [attr.aria-controls]="menu.visible ? menu.id + '_list' : null"
                       [class.active]="isDropdownActive(link)"
                       (click)="menu.toggle($event)"
                     >
                       <span>{{ link.label }}</span>
-                    </a>
+                    </button>
                     <p-menu
                       #menu
                       [model]="getDropdownItems(link)"
                       [popup]="true"
+                      [ariaLabel]="link.label"
                       styleClass="header-dropdown-menu"
                       [pt]="{ root: { style: 'transform: translateY(1.25rem)' } }"
                     />

--- a/libs/explorers/ui/src/lib/components/header/header.component.scss
+++ b/libs/explorers/ui/src/lib/components/header/header.component.scss
@@ -74,7 +74,12 @@
     margin: 0;
   }
 
-  a {
+  .dropdown-trigger {
+    @include mixins.reset-button;
+  }
+
+  a,
+  .dropdown-trigger {
     font-size: var(--font-size-lg);
     font-weight: 700;
     color: var(--color-text);
@@ -120,7 +125,8 @@
       padding: 0 20px;
     }
 
-    a {
+    a,
+    .dropdown-trigger {
       position: relative;
       display: flex;
       padding: 8px 0;

--- a/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.spec.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Router, provideRouter } from '@angular/router';
 import { footerLinks, headerLinks } from '@sagebionetworks/explorers/testing';
 import { render, screen } from '@testing-library/angular';
@@ -31,6 +32,7 @@ async function setup() {
     },
     imports: [CommonModule, SvgImageComponent],
     providers: [
+      provideNoopAnimations(),
       provideRouter([
         { path: 'header-link-1', component: DummyComponent },
         { path: 'header-link-2', component: DummyComponent },
@@ -93,12 +95,43 @@ describe('HeaderComponent', () => {
     expect(screen.queryByRole('link', { name: 'FooterLinkInternal2' })).not.toBeInTheDocument();
   });
 
-  it('should show dropdown trigger for link with children in desktop mode', async () => {
+  it('should render a collapsed menu button for a link with children in desktop mode', async () => {
     changeWindowSize(DESKTOP_WIDTH);
     await setup();
 
-    // The dropdown trigger should be visible with the parent label
-    expect(screen.getByText('DropdownLink')).toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: 'DropdownLink' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('menu', { name: 'DropdownLink' })).not.toBeInTheDocument();
+  });
+
+  it('should open the dropdown when the trigger is clicked', async () => {
+    changeWindowSize(DESKTOP_WIDTH);
+    const { user } = await setup();
+
+    const trigger = screen.getByRole('button', { name: 'DropdownLink' });
+    await user.click(trigger);
+
+    const menu = screen.getByRole('menu', { name: 'DropdownLink' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-controls', menu.id);
+    expect(screen.getByRole('link', { name: 'ChildLink1' })).toBeInTheDocument();
+  });
+
+  it('should focus the dropdown trigger and open it with the keyboard in desktop mode', async () => {
+    changeWindowSize(DESKTOP_WIDTH);
+    const { user } = await setup();
+
+    const trigger = screen.getByRole('button', { name: 'DropdownLink' });
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    const menu = screen.getByRole('menu', { name: 'DropdownLink' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-controls', menu.id);
+    expect(screen.getByRole('link', { name: 'ChildLink1' })).toBeInTheDocument();
   });
 
   it('should show dropdown label and children in mobile mode', async () => {

--- a/libs/model-ad/CLAUDE.md
+++ b/libs/model-ad/CLAUDE.md
@@ -43,6 +43,7 @@ Mock data and test fixtures come from `@sagebionetworks/model-ad/testing`.
 | `model-ad-model-details`                           | `model-details/`                           | Model details page with omics, biomarkers, pathology panels                                                                            |
 | `model-ad-differential-expression-comparison-tool` | `differential-expression-comparison-tool/` | Differential expression heatmap comparison tool                                                                                        |
 | `model-ad-disease-correlation-comparison-tool`     | `disease-correlation-comparison-tool/`     | Disease correlation heatmap comparison tool                                                                                            |
+| `model-ad-marmoset-model-overview-comparison-tool` | `marmoset-model-overview-comparison-tool/` | Marmoset model overview comparison tool                                                                                                |
 | `model-ad-mouse-model-overview-comparison-tool`    | `mouse-model-overview-comparison-tool/`    | Mouse model overview comparison tool                                                                                                   |
 | `model-ad-services`                                | `services/`                                | Angular services (currently minimal)                                                                                                   |
 | `model-ad-styles`                                  | `styles/`                                  | Shared SCSS variables and mixins                                                                                                       |
@@ -86,4 +87,4 @@ nx build model-ad-api-description
 
 ## Comparison Tool Pattern
 
-The three `*-comparison-tool` libraries all follow the same pattern: they wrap `ComparisonToolComponent` from `@sagebionetworks/explorers/comparison-tool` and provide it with a `ComparisonToolConfig` and `ComparisonToolViewConfig`. Each has its own service that fetches data via the generated API client and transforms it into the config the explorers component expects.
+The `*-comparison-tool` libraries all follow the same pattern: they wrap `ComparisonToolComponent` from `@sagebionetworks/explorers/comparison-tool` and provide it with a `ComparisonToolConfig` and `ComparisonToolViewConfig`. Each has its own service that fetches data via the generated API client and transforms it into the config the explorers component expects.

--- a/libs/model-ad/config/src/lib/constants.ts
+++ b/libs/model-ad/config/src/lib/constants.ts
@@ -16,6 +16,7 @@ export const ROUTE_PATHS = {
   HOME: '',
   ABOUT: 'about',
   NEWS: 'news',
+  MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
   MOUSE_MODEL_OVERVIEW: 'comparison/model',
   DIFFERENTIAL_EXPRESSION: 'comparison/expression',
   GENES: 'genes',

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/.eslintrc.json
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/.eslintrc.json
@@ -1,0 +1,41 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "env": {
+    "jest": true
+  },
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates",
+        "plugin:jest/recommended"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "modelAd",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "model-ad",
+            "style": "kebab-case"
+          }
+        ],
+        "@angular-eslint/prefer-standalone": "off"
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/README.md
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/README.md
@@ -1,0 +1,7 @@
+# model-ad-marmoset-model-overview-comparison-tool
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test model-ad-marmoset-model-overview-comparison-tool` to execute the unit tests.

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/jest.config.ts
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/jest.config.ts
@@ -1,0 +1,24 @@
+/* eslint-disable */
+export default {
+  displayName: 'model-ad-marmoset-model-overview-comparison-tool',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {},
+  coverageDirectory: '../../../coverage/libs/model-ad/marmoset-model-overview-comparison-tool',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  testEnvironment: 'jest-fixed-jsdom',
+  transformIgnorePatterns: ['node_modules/(?!(.pnpm/.*/node_modules/)?(.*\\.mjs$))'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/project.json
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "model-ad-marmoset-model-overview-comparison-tool",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/model-ad/marmoset-model-overview-comparison-tool/src",
+  "prefix": "model-ad",
+  "tags": ["type:feature", "scope:model-ad", "language:typescript"],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/model-ad/marmoset-model-overview-comparison-tool"],
+      "options": {
+        "jestConfig": "libs/model-ad/marmoset-model-overview-comparison-tool/jest.config.ts",
+        "tsConfig": "libs/model-ad/marmoset-model-overview-comparison-tool/tsconfig.spec.json"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "lint-fix": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "fix": true
+      }
+    }
+  }
+}

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/index.ts
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/marmoset-model-overview-comparison-tool.routes';

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.html
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.html
@@ -1,0 +1,1 @@
+<explorers-comparison-tool [isLoading]="!isInitialized()" />

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.scss
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.scss
@@ -1,0 +1,4 @@
+.marmoset-model-overview-comparison-tool {
+  width: 100%;
+  height: 100%;
+}

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.spec.ts
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.spec.ts
@@ -1,0 +1,64 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { ComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tool';
+import {
+  PlatformService,
+  provideComparisonToolFilterService,
+  provideComparisonToolService,
+  provideExplorersConfig,
+} from '@sagebionetworks/explorers/services';
+import { provideLoadingIconColors } from '@sagebionetworks/explorers/testing';
+import {
+  ComparisonToolConfigService,
+  MarmosetModelOverviewService,
+} from '@sagebionetworks/model-ad/api-client';
+import { MODEL_AD_LOADING_ICON_COLORS } from '@sagebionetworks/model-ad/config';
+import { render } from '@testing-library/angular';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+import { MarmosetModelOverviewComparisonToolComponent } from './marmoset-model-overview-comparison-tool.component';
+import { MarmosetModelOverviewComparisonToolService } from './services/marmoset-model-overview-comparison-tool.service';
+
+async function setup() {
+  const { fixture } = await render(MarmosetModelOverviewComparisonToolComponent, {
+    imports: [ComparisonToolComponent],
+    providers: [
+      MessageService,
+      provideLoadingIconColors(MODEL_AD_LOADING_ICON_COLORS),
+      provideExplorersConfig({ visualizationOverviewPanes: [] }),
+      provideHttpClient(),
+      provideNoopAnimations(),
+      provideRouter([]),
+      {
+        provide: PlatformService,
+        useValue: { isBrowser: true },
+      },
+      {
+        provide: ComparisonToolConfigService,
+        useValue: {
+          getComparisonToolConfig: jest.fn().mockReturnValue(of([])),
+        },
+      },
+      {
+        provide: MarmosetModelOverviewService,
+        useValue: {
+          getMarmosetModelOverviews: jest.fn().mockReturnValue(of([])),
+        },
+      },
+      ...provideComparisonToolService(),
+      ...provideComparisonToolFilterService(),
+      MarmosetModelOverviewComparisonToolService,
+    ],
+  });
+
+  const component = fixture.componentInstance;
+  return { component, fixture };
+}
+
+describe('MarmosetModelOverviewComparisonToolComponent', () => {
+  it('should create', async () => {
+    const { component } = await setup();
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.ts
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.component.ts
@@ -1,0 +1,179 @@
+import { Component, DestroyRef, effect, inject, OnDestroy, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { ComparisonToolComponent } from '@sagebionetworks/explorers/comparison-tool';
+import { ComparisonToolQuery, ComparisonToolViewConfig } from '@sagebionetworks/explorers/models';
+import {
+  ComparisonToolUrlService,
+  LoggerService,
+  PlatformService,
+} from '@sagebionetworks/explorers/services';
+import {
+  ComparisonToolConfigService,
+  ComparisonToolPage,
+  ItemFilterTypeQuery,
+  MarmosetModelOverview,
+  MarmosetModelOverviewSearchQuery,
+  MarmosetModelOverviewService,
+  MarmosetModelOverviewsPage,
+  ModelOrganism,
+} from '@sagebionetworks/model-ad/api-client';
+import { ROUTE_PATHS } from '@sagebionetworks/model-ad/config';
+import { SortMeta } from 'primeng/api';
+import { catchError, EMPTY, shareReplay } from 'rxjs';
+import { MarmosetModelOverviewComparisonToolService } from './services/marmoset-model-overview-comparison-tool.service';
+
+@Component({
+  selector: 'model-ad-marmoset-model-overview-comparison-tool',
+  imports: [ComparisonToolComponent],
+  templateUrl: './marmoset-model-overview-comparison-tool.component.html',
+  styleUrls: ['./marmoset-model-overview-comparison-tool.component.scss'],
+})
+export class MarmosetModelOverviewComparisonToolComponent implements OnInit, OnDestroy {
+  private readonly platformService = inject(PlatformService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly marmosetModelOverviewService = inject(MarmosetModelOverviewService);
+  private readonly comparisonToolService = inject(MarmosetModelOverviewComparisonToolService);
+  private readonly comparisonToolConfigService = inject(ComparisonToolConfigService);
+  private readonly comparisonToolUrlService = inject(ComparisonToolUrlService);
+  private readonly logger = inject(LoggerService);
+
+  isInitialized = this.comparisonToolService.isInitialized;
+  query = this.comparisonToolService.query;
+
+  readonly config$ = this.comparisonToolConfigService
+    .getComparisonToolConfig(ComparisonToolPage.MarmosetModelOverview)
+    .pipe(
+      catchError((error) => {
+        this.logger.error('Error retrieving comparison tool config', error);
+        return EMPTY;
+      }),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+
+  viewConfig: Partial<ComparisonToolViewConfig> = {
+    headerTitle: ComparisonToolPage.MarmosetModelOverview,
+    filterResultsButtonTooltip: 'Filter results by Model Type, Modified Gene, and more',
+    showSignificanceControls: false,
+    viewDetailsTooltip: 'Open model details page',
+    viewDetailsClick: (rowData: unknown) => {
+      const data = rowData as MarmosetModelOverview;
+      const url = this.router.serializeUrl(
+        this.router.createUrlTree([ROUTE_PATHS.MODELS, data.name], {
+          queryParams: { modelOrganism: ModelOrganism.Marmoset },
+        }),
+      );
+      window.open(url, '_blank');
+    },
+    legendEnabled: false,
+    rowIdDataKey: 'name',
+    allowPinnedImageDownload: false,
+    defaultSort: [{ field: 'name', order: 1 }],
+  };
+
+  constructor() {
+    this.comparisonToolService.setViewConfig(this.viewConfig);
+  }
+
+  readonly pinnedDataEffect = effect(() => {
+    if (this.platformService.isBrowser && this.isInitialized()) {
+      const pinnedItems = this.comparisonToolService.pinnedItems();
+      const sortMeta = this.comparisonToolService.multiSortMeta();
+      this.getPinnedData(pinnedItems, sortMeta);
+    }
+  });
+
+  readonly unpinnedDataEffect = effect(() => {
+    if (this.platformService.isBrowser && this.isInitialized()) {
+      const query = this.query();
+      this.getUnpinnedData(query);
+    }
+  });
+
+  ngOnInit() {
+    if (this.platformService.isServer) {
+      return;
+    }
+
+    this.comparisonToolService.connect({
+      config$: this.config$,
+      queryParams$: this.comparisonToolUrlService.params$,
+    });
+  }
+
+  ngOnDestroy() {
+    this.comparisonToolService.disconnect();
+  }
+
+  getUnpinnedData(currentQuery: ComparisonToolQuery) {
+    const { sortFields, sortOrders } = this.comparisonToolService.convertSortMetaToArrays(
+      currentQuery.multiSortMeta,
+    );
+
+    const selectedFilters = this.comparisonToolService.selectedFilters();
+
+    const query: MarmosetModelOverviewSearchQuery = {
+      items: currentQuery.pinnedItems,
+      itemFilterType: ItemFilterTypeQuery.Exclude,
+      pageNumber: currentQuery.pageNumber,
+      pageSize: currentQuery.pageSize,
+      search: currentQuery.searchTerm,
+      sortFields,
+      sortOrders,
+      availableData: selectedFilters['availableData'],
+      modelTypes: selectedFilters['modelTypes'],
+      modifiedGenes: selectedFilters['modifiedGenes'],
+    };
+    this.comparisonToolService.startFetch();
+    this.logger.log(
+      `MarmosetModelOverviewComparisonToolComponent: unpinned query ${JSON.stringify(query)}`,
+    );
+
+    this.marmosetModelOverviewService
+      .getMarmosetModelOverviews(query)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response: MarmosetModelOverviewsPage) => {
+          const data = response.marmosetModelOverviews;
+          this.comparisonToolService.setUnpinnedData(data);
+          this.comparisonToolService.totalResultsCount.set(response.page.totalElements);
+        },
+        error: () => {
+          this.comparisonToolService.setUnpinnedData([]);
+          this.comparisonToolService.totalResultsCount.set(0);
+        },
+      });
+  }
+
+  getPinnedData(pinnedItems: string[], sortMeta: SortMeta[]) {
+    const { sortFields, sortOrders } = this.comparisonToolService.convertSortMetaToArrays(sortMeta);
+
+    const query: MarmosetModelOverviewSearchQuery = {
+      items: pinnedItems,
+      itemFilterType: ItemFilterTypeQuery.Include,
+      sortFields,
+      sortOrders,
+    };
+
+    this.comparisonToolService.startFetch();
+    this.logger.log(
+      `MarmosetModelOverviewComparisonToolComponent: pinned query ${JSON.stringify(query)}`,
+    );
+
+    this.marmosetModelOverviewService
+      .getMarmosetModelOverviews(query)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response: MarmosetModelOverviewsPage) => {
+          const data = response.marmosetModelOverviews;
+          this.comparisonToolService.setPinnedData(data);
+          this.comparisonToolService.pinnedResultsCount.set(data.length);
+        },
+        error: () => {
+          this.comparisonToolService.setPinnedData([]);
+          this.comparisonToolService.pinnedResultsCount.set(0);
+        },
+      });
+  }
+}

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.routes.ts
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/marmoset-model-overview-comparison-tool.routes.ts
@@ -1,0 +1,21 @@
+import { Routes } from '@angular/router';
+import {
+  ComparisonToolFilterService,
+  ComparisonToolService,
+  ComparisonToolUrlService,
+} from '@sagebionetworks/explorers/services';
+import { MarmosetModelOverviewComparisonToolComponent } from './marmoset-model-overview-comparison-tool.component';
+import { MarmosetModelOverviewComparisonToolService } from './services/marmoset-model-overview-comparison-tool.service';
+
+export const routes: Routes = [
+  {
+    path: '',
+    component: MarmosetModelOverviewComparisonToolComponent,
+    providers: [
+      { provide: ComparisonToolService, useExisting: MarmosetModelOverviewComparisonToolService },
+      MarmosetModelOverviewComparisonToolService,
+      ComparisonToolFilterService,
+      ComparisonToolUrlService,
+    ],
+  },
+];

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/services/marmoset-model-overview-comparison-tool.service.ts
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/lib/services/marmoset-model-overview-comparison-tool.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+import { ComparisonToolService } from '@sagebionetworks/explorers/services';
+import { MarmosetModelOverview } from '@sagebionetworks/model-ad/api-client';
+
+@Injectable()
+export class MarmosetModelOverviewComparisonToolService extends ComparisonToolService<MarmosetModelOverview> {}

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/src/test-setup.ts
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/src/test-setup.ts
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+setupZoneTestEnv();

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/tsconfig.json
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "target": "es2024",
+    "esModuleInterop": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/tsconfig.lib.json
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/model-ad/marmoset-model-overview-comparison-tool/tsconfig.spec.json
+++ b/libs/model-ad/marmoset-model-overview-comparison-tool/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts", "jest.config.ts"]
+}

--- a/libs/model-ad/util/src/lib/navigation-links.ts
+++ b/libs/model-ad/util/src/lib/navigation-links.ts
@@ -14,6 +14,10 @@ export const headerLinks: NavigationLink[] = [
         label: 'Mouse Models',
         routerLink: [ROUTE_PATHS.MOUSE_MODEL_OVERVIEW],
       },
+      {
+        label: 'Marmoset Models',
+        routerLink: [ROUTE_PATHS.MARMOSET_MODEL_OVERVIEW],
+      },
     ],
   },
   {

--- a/libs/model-ad/util/src/lib/navigation-links.ts
+++ b/libs/model-ad/util/src/lib/navigation-links.ts
@@ -9,7 +9,12 @@ export const headerLinks: NavigationLink[] = [
   },
   {
     label: 'Model Overview',
-    routerLink: [ROUTE_PATHS.MOUSE_MODEL_OVERVIEW],
+    children: [
+      {
+        label: 'Mouse Models',
+        routerLink: [ROUTE_PATHS.MOUSE_MODEL_OVERVIEW],
+      },
+    ],
   },
   {
     label: 'Differential Expression',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -77,6 +77,9 @@
       ],
       "@sagebionetworks/model-ad/gene-details": ["libs/model-ad/gene-details/src/index.ts"],
       "@sagebionetworks/model-ad/home": ["libs/model-ad/home/src/index.ts"],
+      "@sagebionetworks/model-ad/marmoset-model-overview-comparison-tool": [
+        "libs/model-ad/marmoset-model-overview-comparison-tool/src/index.ts"
+      ],
       "@sagebionetworks/model-ad/model-details": ["libs/model-ad/model-details/src/index.ts"],
       "@sagebionetworks/model-ad/mouse-model-overview-comparison-tool": [
         "libs/model-ad/mouse-model-overview-comparison-tool/src/index.ts"


### PR DESCRIPTION
## Description

Adds the Marmoset Model Overview comparison tool frontend as a new library that wraps `ComparisonToolComponent` and reads from the existing marmoset endpoint, wires it up as a lazy-loaded route at `/comparison/model/marmoset`, and restructures the header nav so "Model Overview" becomes a dropdown containing both Mouse Models and Marmoset Models.

## Related Issue

- [MG-940](https://sagebionetworks.jira.com/browse/MG-940)

## Changelog

- Add the `model-ad-marmoset-model-overview-comparison-tool` library and register its path in `tsconfig.base.json`
- Add the `MARMOSET_MODEL_OVERVIEW` route path and lazy-loaded app route with page title and description metadata
- Nest Mouse Models and Marmoset Models under a "Model Overview" header dropdown
- Make the explorers header dropdown trigger a real `<button>` with `aria-haspopup`, `aria-expanded`, and `aria-controls` so e2e tests can find it by role, and so it is keyboard-operable and announced as a menu
- Add e2e coverage for marmoset model overview CT
- Add a `ComparisonToolConfigDocument` unit test pinning Spring Data's coercion of a bare-string `ui_config` filter `values` into a single-element list — the marmoset config is the first to store `values` as a single string rather than an array, which the API already handles, so the test flags it if that default behavior ever changes
- Update the `libs/model-ad/CLAUDE.md` library table and comparison tool notes

## Testing

- Serve the Model-AD stack, hover/click "Model Overview" in the header, and confirm the dropdown lists Mouse Models and Marmoset Models, both navigating to the correct routes
- Tab to the "Model Overview" nav item with the keyboard and confirm it receives focus and opens with Enter/Space, then close it with Escape
- Shrink the viewport to mobile width and confirm the Model Overview children still render inline in the hamburger menu, with no separate trigger to click
- Load `/comparison/model/marmoset`, confirm the table populates, then verify the filter panel (Model Type, Modified Gene, Available Data) narrows results and that selections round-trip through the URL on reload
- Confirm the Modified Gene filter panel lists `PSEN1` — this is the marmoset config entry whose `values` is stored as a bare string rather than an array
- Click a row's View Details button and a Results/View Data link, and confirm each opens in a new tab at the marmoset model details page (with `modelOrganism=marmoset`) or the Synapse study page

### Preview

<img width="1624" height="1056" alt="MG-940" src="https://github.com/user-attachments/assets/1d4e6dec-bdbf-4ded-898f-4de6c65b09fa" />

New header menu and opening marmoset details page: 

https://github.com/user-attachments/assets/a3275320-4814-4ca1-afa1-1384b4143e59

Pinning: 

https://github.com/user-attachments/assets/4db75bb8-deb5-4c87-b7ce-11db558c83a8

[MG-940]: https://sagebionetworks.jira.com/browse/MG-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ