### PR TITLE
feat(explorers): add _id tiebreaker to CT sort for deterministic pagination (MG-1034, AG-2181)

### DIFF
--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -413,6 +413,7 @@ public abstract class ComparisonToolRepositorySupport<T> {
       sortDoc.append(ApiHelper.isEmptyFlagKey(field), 1);
       sortDoc.append(resolved, order.isAscending() ? 1 : -1);
     }
+    sortDoc.append("_id", 1);
 
     return context -> new Document("$sort", sortDoc);
   }

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -413,7 +413,11 @@ public abstract class ComparisonToolRepositorySupport<T> {
       sortDoc.append(ApiHelper.isEmptyFlagKey(field), 1);
       sortDoc.append(resolved, order.isAscending() ? 1 : -1);
     }
-    sortDoc.append("_id", 1);
+    // Break ties on _id so equal sort values keep a stable order across pages. Skip when the
+    // caller already sorts by _id -- re-appending would overwrite their direction.
+    if (!sortDoc.containsKey("_id")) {
+      sortDoc.append("_id", 1);
+    }
 
     return context -> new Document("$sort", sortDoc);
   }

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -429,6 +429,35 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
+  @DisplayName("should append _id once after every sort key when multiple sort orders are requested")
+  void shouldAppendIdTiebreakerOnceAfterAllSortKeysForMultiSort() {
+    ComputedRepo repo = new ComputedRepo(mongoTemplate);
+    stubMongoTemplate(0L);
+
+    Pageable pageable = PageRequest.of(
+      0,
+      10,
+      Sort.by(Sort.Order.asc("name"), Sort.Order.desc("hgnc_symbol"))
+    );
+    repo.run(new Criteria(), pageable);
+
+    String pipeline = capturePipeline().toString();
+    assertThat(pipeline)
+      .as("_id must be appended exactly once, not per sort order")
+      .containsOnlyOnce("\"_id\" : 1");
+
+    int computedIdx = pipeline.indexOf("\"name_sort\" : 1");
+    int plainIdx = pipeline.indexOf("\"hgnc_symbol\" : -1");
+    int idIdx = pipeline.indexOf("\"_id\" : 1");
+    assertThat(idIdx)
+      .as("_id must rank below the computed first sort key, not between the sort keys")
+      .isGreaterThan(computedIdx);
+    assertThat(idIdx)
+      .as("_id must rank below the second sort key so it only breaks full ties")
+      .isGreaterThan(plainIdx);
+  }
+
+  @Test
   @DisplayName("should not include _id tiebreaker when sort is unsorted")
   void shouldNotIncludeIdTiebreakerWhenUnsorted() {
     BareRepo repo = new BareRepo(mongoTemplate);

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -429,7 +429,7 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
-  @DisplayName("should append _id once after every sort key when multiple sort orders are requested")
+  @DisplayName("should append _id once, after all sort keys, when multiple sort orders are requested")
   void shouldAppendIdTiebreakerOnceAfterAllSortKeysForMultiSort() {
     ComputedRepo repo = new ComputedRepo(mongoTemplate);
     stubMongoTemplate(0L);
@@ -450,7 +450,7 @@ class ComparisonToolRepositorySupportTest {
     int plainIdx = pipeline.indexOf("\"hgnc_symbol\" : -1");
     int idIdx = pipeline.indexOf("\"_id\" : 1");
     assertThat(idIdx)
-      .as("_id must rank below the computed first sort key, not between the sort keys")
+      .as("_id must rank below the computed first sort key")
       .isGreaterThan(computedIdx);
     assertThat(idIdx)
       .as("_id must rank below the second sort key so it only breaks full ties")
@@ -458,7 +458,27 @@ class ComparisonToolRepositorySupportTest {
   }
 
   @Test
-  @DisplayName("should not include _id tiebreaker when sort is unsorted")
+  @DisplayName("should preserve the caller's descending _id direction when sorting by _id")
+  void shouldPreserveCallerIdSortWhenSortingById() {
+    BareRepo repo = new BareRepo(mongoTemplate);
+    stubMongoTemplate(0L);
+
+    Pageable pageable = PageRequest.of(
+      0,
+      10,
+      Sort.by(Sort.Order.desc("_id"), Sort.Order.asc("name"))
+    );
+    repo.run(new Criteria(), pageable);
+
+    String pipeline = capturePipeline().toString();
+    assertThat(pipeline)
+      .as("the caller's descending _id direction must not be overwritten by the tiebreaker")
+      .contains("\"_id\" : -1")
+      .doesNotContain("\"_id\" : 1");
+  }
+
+  @Test
+  @DisplayName("should not include _id tiebreaker when no sort is requested")
   void shouldNotIncludeIdTiebreakerWhenUnsorted() {
     BareRepo repo = new BareRepo(mongoTemplate);
     stubMongoTemplate(0L);

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupportTest.java
@@ -411,4 +411,33 @@ class ComparisonToolRepositorySupportTest {
       assertThat(pipeline).contains("\"name_sort\" : 1");
     }
   }
+
+  @Test
+  @DisplayName("should append _id as final tiebreaker in sort document for deterministic pagination")
+  void shouldAppendIdTiebreakerInSortDocument() {
+    BareRepo repo = new BareRepo(mongoTemplate);
+    stubMongoTemplate(0L);
+
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Order.asc("name")));
+    repo.run(new Criteria(), pageable);
+
+    String pipeline = capturePipeline().toString();
+    assertThat(pipeline).contains("\"_id\" : 1");
+    int nameIdx = pipeline.indexOf("\"name\" : 1");
+    int idIdx = pipeline.indexOf("\"_id\" : 1");
+    assertThat(idIdx).as("_id should appear after the user-requested sort field").isGreaterThan(nameIdx);
+  }
+
+  @Test
+  @DisplayName("should not include _id tiebreaker when sort is unsorted")
+  void shouldNotIncludeIdTiebreakerWhenUnsorted() {
+    BareRepo repo = new BareRepo(mongoTemplate);
+    stubMongoTemplate(0L);
+
+    Pageable pageable = PageRequest.of(0, 10);
+    repo.run(new Criteria(), pageable);
+
+    String pipeline = capturePipeline().toString();
+    assertThat(pipeline).doesNotContain("\"_id\" : 1");
+  }
 }


### PR DESCRIPTION
## Description

When multiple rows share the same sort value, MongoDB doesn't guarantee their order across paginated requests — a row can appear on two pages or be missing entirely. This appends `_id` as a final tiebreaker to the CT sort document, ensuring deterministic ordering across all paginated queries in both apps.

## Related Issue

- [MG-1034](https://sagebionetworks.jira.com/browse/MG-1034)
- [AG-2181](https://sagebionetworks.jira.com/browse/AG-2181)

## Changelog

- Append `_id: 1` to the sort document in `ComparisonToolRepositorySupport.buildSortOperation()` after all user-requested sort fields
- Add unit tests verifying `_id` tiebreaker is present and positioned after user sort fields

## Testing

- Navigate to any CT page (e.g. Disease Correlation), sort by a column with duplicate values (e.g. `model_type`), paginate back and forth — rows should never duplicate or disappear across pages

[MG-1034]: https://sagebionetworks.jira.com/browse/MG-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-2181]: https://sagebionetworks.jira.com/browse/AG-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ