### PR TITLE
fix(model-ad): remove duplicated marmoset model overview path

### DIFF
--- a/libs/model-ad/config/src/lib/constants.ts
+++ b/libs/model-ad/config/src/lib/constants.ts
@@ -18,7 +18,6 @@ export const ROUTE_PATHS = {
   NEWS: 'news',
   MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
   MOUSE_MODEL_OVERVIEW: 'comparison/model',
-  MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
   DIFFERENTIAL_EXPRESSION: 'comparison/expression',
   GENES: 'genes',
   DISEASE_CORRELATION: 'comparison/correlation',


### PR DESCRIPTION
## Description

#4159 and #4160 both added the marmoset model overview path to the`ROUTE_PATHS` constant, but in slightly different positions in the object. When these PRs were merged, the marmoset model overview path was duplicated. This PR updates the object to remove the duplicated entry.

See related failing `model-ad-app` build in the CI job triggered when #4159 was merged: https://github.com/Sage-Bionetworks/sage-monorepo/actions/runs/32053688875

```
Application bundle generation failed. [56.973 seconds] - 2026-08-17T18:17:40.223Z

▲ [WARNING] Duplicate key "MARMOSET_MODEL_OVERVIEW" in object literal [duplicate-object-key]

    libs/model-ad/config/src/lib/constants.ts:14:2:
      14 │   MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
         ╵   ~~~~~~~~~~~~~~~~~~~~~~~

  The original key "MARMOSET_MODEL_OVERVIEW" is here:

    libs/model-ad/config/src/lib/constants.ts:12:2:
      12 │   MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
         ╵   ~~~~~~~~~~~~~~~~~~~~~~~


▲ [WARNING] Duplicate key "MARMOSET_MODEL_OVERVIEW" in object literal [duplicate-object-key]

    libs/model-ad/config/src/lib/constants.ts:14:2:
      14 │   MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
         ╵   ~~~~~~~~~~~~~~~~~~~~~~~

  The original key "MARMOSET_MODEL_OVERVIEW" is here:

    libs/model-ad/config/src/lib/constants.ts:12:2:
      12 │   MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
         ╵   ~~~~~~~~~~~~~~~~~~~~~~~


✘ [ERROR] TS1117: An object literal cannot have multiple properties with the same name. [plugin angular-compiler]

    libs/model-ad/config/src/lib/constants.ts:21:2:
      21 │   MARMOSET_MODEL_OVERVIEW: 'comparison/model/marmoset',
         ╵   ~~~~~~~~~~~~~~~~~~~~~~~
```

## Related Issue

N/A

## Changelog

- Remove duplicated marmoset model overview path