### PR TITLE
feat(model-ad): align TOC and plot headings with plot edges (MG-882)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -36,7 +36,7 @@
     </div>
   </div>
 
-  <div class="table-of-contents-container full-width-container" #tableOfContentsContainer>
+  <div class="table-of-contents-container plots-width-bleed" #tableOfContentsContainer>
     <div class="table-of-contents-title-bar">
       <h2>Table of Contents</h2>
       <div class="title-bar-actions">
@@ -85,7 +85,7 @@
     @for (section of boxplotSections(); track section.evidenceType; let last = $last) {
       @let evidenceType = section.evidenceType;
       <div
-        class="boxplots-evidence-type"
+        class="boxplots-evidence-type plots-width-bleed"
         [id]="generateAnchorId(evidenceType)"
         (mouseenter)="activeShareLink.set(evidenceType)"
         (mouseleave)="activeShareLink.set('')"
@@ -114,24 +114,23 @@
           }
         </div>
 
-        <!-- Wrapper handles full-width positioning; inner div is the download capture
-             target so html-to-image doesn't re-apply the wrapper's pixel offsets -->
-        <div class="boxplots-full-width-wrapper">
-          <div #sectionBody>
-            <ng-container
-              [ngTemplateOutlet]="sectionTemplate()"
-              [ngTemplateOutletContext]="{
-                data: sectionDataByEvidenceType().get(evidenceType)?.transformedData,
-                sexFilter: selectedSexOption().value,
-                copyLinkFn: copyShareLinkCallbackFn,
-                tooltipTextFn: getShareLinkTooltipText,
-                setActiveShareLink: setActiveShareLinkFn,
-                clearActiveShareLink: clearActiveShareLinkFn,
-                isShareLinkActive: isShareLinkActiveFn,
-              }"
-            />
-          </div>
+        <!-- Download capture target: the capture is sized from this element's own width
+             and offsets, so the viewport bleed has to live on the wrapper above -->
+        <div #sectionBody>
+          <ng-container
+            [ngTemplateOutlet]="sectionTemplate()"
+            [ngTemplateOutletContext]="{
+              data: sectionDataByEvidenceType().get(evidenceType)?.transformedData,
+              sexFilter: selectedSexOption().value,
+              copyLinkFn: copyShareLinkCallbackFn,
+              tooltipTextFn: getShareLinkTooltipText,
+              setActiveShareLink: setActiveShareLinkFn,
+              clearActiveShareLink: clearActiveShareLinkFn,
+              isShareLinkActive: isShareLinkActiveFn,
+            }"
+          />
         </div>
+
         @if (!last) {
           <hr class="boxplots-separator" />
         }

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -1,8 +1,14 @@
 @use 'model-ad/styles/src/mixins' as mixins;
-@use 'model-ad/styles/src/variables' as vars;
 
 :host {
   --toc-items-per-column: 6;
+
+  // Distance from the viewport edge to the left- and right-most plot edge. Row-level
+  // elements inset by this to line up with the plots. The 15% has to stay a percentage:
+  // it resolves against each consumer's containing block, which is the section content
+  // box for all of them. max(0px, ...) is the overflow past the 2500px cap on the plots,
+  // which keeps them centered on very wide viewports.
+  --plots-content-inset: calc(max(0px, (100vw - 2500px) / 2) + 15%);
 }
 
 [class*='-container'] {
@@ -18,11 +24,21 @@
   }
 }
 
-.full-width-container {
+// Bleed to the viewport edges; each re-insets its own content below.
+.full-width-container,
+.plots-width-bleed {
   width: 100vw;
-  margin-left: calc(-1 * (100vw - 100%) / 2);
+  margin-left: calc((100% - 100vw) / 2);
+}
+
+.full-width-container {
   padding-left: calc((100vw - 100%) / 2);
   padding-right: calc((100vw - 100%) / 2);
+}
+
+.plots-width-bleed {
+  padding-left: var(--plots-content-inset);
+  padding-right: var(--plots-content-inset);
 }
 
 .filters-container {
@@ -110,15 +126,6 @@
 }
 
 .boxplots-container {
-  .boxplots-full-width-wrapper {
-    width: 100vw;
-    max-width: 2500px;
-    position: relative;
-    left: 50%;
-    transform: translateX(-50%);
-    padding: 0 15%;
-  }
-
   .boxplots-evidence-type-title-bar {
     padding-bottom: 30px;
     display: flex;
@@ -130,8 +137,7 @@
   }
 
   .boxplots-separator {
-    margin-top: 80px;
-    margin-bottom: 80px;
+    margin: 80px 0;
     border: 2px solid var(--color-gray-300);
   }
 }

--- a/libs/model-ad/styles/src/lib/_mixins.scss
+++ b/libs/model-ad/styles/src/lib/_mixins.scss
@@ -1,12 +1,12 @@
 @forward 'explorers/styles/src/mixins';
 
 // Auto-fit grid for boxplot items. Items wrap to fill available width, with a
-// minimum of 495px per item. The negative margin offsets the per-item margin so
-// that item content aligns with surrounding headers when captured in screenshots.
+// minimum of 495px per item, or a single full-width column when the grid is
+// narrower than that. The negative margin offsets the per-item margin so that
+// item content aligns with surrounding headers when captured in screenshots.
 @mixin boxplots-auto-grid($item-selector) {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(495px, 1fr));
-  justify-content: center;
+  grid-template-columns: repeat(auto-fit, minmax(min(495px, 100%), 1fr));
   margin: -15px -25px;
 
   #{$item-selector} {


### PR DESCRIPTION
## Description

On the model details page, the boxplot panels rendered their plots in a wide, viewport-bleeding box while everything that labels those plots ("Table of Contents", "Download All", "Expand", each row heading, each row "Download" button, and the section dividers) sat in the narrower `<section>` content box. The result was that every row-level element appeared indented relative to the plots it describes. The plots' horizontal bounds are now expressed once as a CSS custom property and consumed by all of those elements, so they share one set of left and right edges and cannot drift apart again.

## Related Issue

- [MG-882](https://sagebionetworks.jira.com/browse/MG-882)

## Changelog

- Express the plots' horizontal bounds once as a `.plots-width-bleed` class, and apply it to the table of contents and each evidence-type block so the TOC, row headings, row Download buttons, and section dividers all line up with the plot edges
- Drop the plots' full-width wrapper element, which the shared bleed class replaces
- Collapse the boxplot grid to a single full-width column when the available width is under the 495px item minimum

## Testing

- On a mouse model's Biomarkers panel (e.g. `/models/3xTg-AD?modelOrganism=mouse`), confirm the TOC, row headings, row Download buttons, and section dividers line up with the plot edges -- check at a variety of widths (e.g. 400px, 1600px, and 2500px)
- Confirm the sticky TOC still spans the full viewport, parks under the panel nav, and scrolls a clicked link's heading clear of itself
- Confirm the per-row "Download" and the TOC's "Download All" zip still produce correctly framed images, and that plot tooltips still position correctly -- a wrapper element with a transform on it was removed
- Check the gene details boxplots grid (e.g. `/genes/Apoe`), which shares the modified grid mixin

### Preview

page | size | dev | this pr 
:---: | :---: | :---: | :---: 
mouse | 400 | <img width="200" height="953" alt="MG-882_mouse_400_dev" src="https://github.com/user-attachments/assets/2095d743-67ca-4c1d-bb62-ea70dc3d53e3" /> | <img width="201" height="950" alt="MG-882_mouse_400_pr" src="https://github.com/user-attachments/assets/89785cf1-22b1-4771-bc00-fa8aee21bb36" />
mouse | 1600 | <img width="802" height="950" alt="MG-882_mouse_1600_dev" src="https://github.com/user-attachments/assets/491d8317-d27e-4418-8673-9f5bad844029" /> | <img width="801" height="954" alt="MG-882_mouse_1600_pr" src="https://github.com/user-attachments/assets/caf8151c-f27c-4583-972a-2a80e9bef785" />
mouse | 2500 | <img width="1247" height="951" alt="MG-882_mouse_2500_dev" src="https://github.com/user-attachments/assets/9e56faa4-3f51-4521-930d-11359aa25f1e" /> | <img width="1250" height="950" alt="MG-882_mouse_2500_pr" src="https://github.com/user-attachments/assets/1cc1b448-9b8d-41ee-9d02-2a16e6e43884" />
marmoset | 400 | <img width="205" height="955" alt="MG-882_marmoset_400_dev" src="https://github.com/user-attachments/assets/fd1c4a35-2eb9-4dcb-80a1-75a767473b0a" /> | <img width="200" height="948" alt="MG-882_marmoset_400_pr" src="https://github.com/user-attachments/assets/160d8d67-d247-4e36-8af6-58dd537495ac" />
marmoset | 1600 | <img width="799" height="952" alt="MG-882_marmoset_1600_dev" src="https://github.com/user-attachments/assets/9ea7e042-fc8d-4cce-ac48-4a11822d819a" /> | <img width="800" height="953" alt="MG-882_marmoset_1600_pr" src="https://github.com/user-attachments/assets/e45ab4d4-7dec-48d6-bcfa-f376b283970c" />
marmoset | 2500 | <img width="1250" height="949" alt="MG-882_marmoset_2500_dev" src="https://github.com/user-attachments/assets/2d6c7a3a-6277-4cca-8eb7-b40957e24ef1" /> | <img width="1253" height="954" alt="MG-882_marmoset_2500_pr" src="https://github.com/user-attachments/assets/2d4f85fc-f08f-4ad4-beaa-b7279d2a0fa2" />

[MG-882]: https://sagebionetworks.jira.com/browse/MG-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ