### PR TITLE
fix(explorers): size header nav underline to the widest line of text (MG-1029)

### DIFF
--- a/libs/explorers/ui/src/lib/components/header/header.component.html
+++ b/libs/explorers/ui/src/lib/components/header/header.component.html
@@ -25,6 +25,7 @@
                     <button
                       type="button"
                       class="dropdown-trigger"
+                      explorersWidestLineWidth
                       aria-haspopup="menu"
                       [attr.aria-expanded]="menu.visible ?? false"
                       [attr.aria-controls]="menu.visible ? menu.id + '_list' : null"
@@ -80,12 +81,18 @@
                       [routerLink]="link.routerLink"
                       routerLinkActive="active"
                       [routerLinkActiveOptions]="link.activeOptions || { exact: false }"
+                      explorersWidestLineWidth
                       (click)="toggleNav()"
                     >
                       <span>{{ link.label }}</span>
                     </a>
                   } @else if (link.url) {
-                    <a [attr.href]="link.url" [attr.target]="link.target" (click)="toggleNav()">
+                    <a
+                      [attr.href]="link.url"
+                      [attr.target]="link.target"
+                      explorersWidestLineWidth
+                      (click)="toggleNav()"
+                    >
                       <span>{{ link.label }}</span>
                     </a>
                   } @else {

--- a/libs/explorers/ui/src/lib/components/header/header.component.scss
+++ b/libs/explorers/ui/src/lib/components/header/header.component.scss
@@ -147,6 +147,9 @@
         display: block;
         bottom: 0;
         left: 0;
+
+        // Set by WidestLineWidthDirective on the link; falls back to the full element box
+        // before the first measurement.
         width: var(--widest-line-width, 100%);
         height: 4px;
         background-color: var(--header-link-color, var(--color-action-primary));

--- a/libs/explorers/ui/src/lib/components/header/header.component.scss
+++ b/libs/explorers/ui/src/lib/components/header/header.component.scss
@@ -76,6 +76,8 @@
 
   .dropdown-trigger {
     @include mixins.reset-button;
+
+    text-align: left;
   }
 
   a,
@@ -145,7 +147,7 @@
         display: block;
         bottom: 0;
         left: 0;
-        right: 0;
+        width: var(--widest-line-width, 100%);
         height: 4px;
         background-color: var(--header-link-color, var(--color-action-primary));
         border-radius: 2px;

--- a/libs/explorers/ui/src/lib/components/header/header.component.ts
+++ b/libs/explorers/ui/src/lib/components/header/header.component.ts
@@ -2,13 +2,14 @@ import { CommonModule } from '@angular/common';
 import { Component, inject, input, OnInit } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { NavigationLink } from '@sagebionetworks/explorers/models';
+import { WidestLineWidthDirective } from '@sagebionetworks/explorers/util';
 import { MenuItem } from 'primeng/api';
 import { MenuModule } from 'primeng/menu';
 import { SvgImageComponent } from '../svg-image/svg-image.component';
 
 @Component({
   selector: 'explorers-header',
-  imports: [CommonModule, SvgImageComponent, RouterModule, MenuModule],
+  imports: [CommonModule, SvgImageComponent, RouterModule, MenuModule, WidestLineWidthDirective],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
 })

--- a/libs/explorers/util/src/index.ts
+++ b/libs/explorers/util/src/index.ts
@@ -9,4 +9,5 @@ export * from './lib/popover-link/popover-link.component';
 export * from './lib/prefetch-config';
 export * from './lib/svg-icon/svg-icon.component';
 export * from './lib/tooltip-button/tooltip-button.component';
+export * from './lib/widest-line-width/widest-line-width.directive';
 export * from './lib/wiki/wiki.component';

--- a/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.spec.ts
+++ b/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.spec.ts
@@ -1,0 +1,71 @@
+import { ApplicationRef, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { render, screen } from '@testing-library/angular';
+import {
+  WIDEST_LINE_WIDTH_PROPERTY,
+  WidestLineWidthDirective,
+} from './widest-line-width.directive';
+
+const LINE_WIDTHS = [98.4, 100.2];
+const WIDEST_LINE_WIDTH = '101px';
+
+@Component({
+  imports: [WidestLineWidthDirective],
+  template: `<a explorersWidestLineWidth data-testid="link"><span>Disease Correlation</span></a>`,
+})
+class TestHostComponent {}
+
+let notifyResize: ResizeObserverCallback | undefined;
+const disconnect = jest.fn();
+
+class ResizeObserverStub {
+  constructor(callback: ResizeObserverCallback) {
+    notifyResize = callback;
+  }
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = disconnect;
+}
+
+async function setup() {
+  const { fixture } = await render(TestHostComponent);
+  // afterNextRender callbacks, which install the resize observer, only run on tick
+  TestBed.inject(ApplicationRef).tick();
+  return { fixture, link: screen.getByTestId('link') };
+}
+
+describe('WidestLineWidthDirective', () => {
+  beforeEach(() => {
+    notifyResize = undefined;
+    disconnect.mockClear();
+    global.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+    Range.prototype.getClientRects = jest.fn(
+      () => LINE_WIDTHS.map((width) => ({ width })) as unknown as DOMRectList,
+    );
+  });
+
+  it('should set the widest line width as a custom property when the host resizes', async () => {
+    const { link } = await setup();
+
+    notifyResize?.([], {} as ResizeObserver);
+
+    expect(link.style.getPropertyValue(WIDEST_LINE_WIDTH_PROPERTY)).toBe(WIDEST_LINE_WIDTH);
+  });
+
+  it('should leave the custom property unset when the host renders no text lines', async () => {
+    Range.prototype.getClientRects = jest.fn(() => [] as unknown as DOMRectList);
+    const { link } = await setup();
+
+    notifyResize?.([], {} as ResizeObserver);
+
+    expect(link.style.getPropertyValue(WIDEST_LINE_WIDTH_PROPERTY)).toBe('');
+  });
+
+  it('should disconnect the resize observer when destroyed', async () => {
+    const { fixture } = await setup();
+
+    fixture.destroy();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.spec.ts
+++ b/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.spec.ts
@@ -31,7 +31,15 @@ async function setup() {
   const { fixture } = await render(TestHostComponent);
   // afterNextRender callbacks, which install the resize observer, only run on tick
   TestBed.inject(ApplicationRef).tick();
-  return { fixture, link: screen.getByTestId('link') };
+
+  const resizeCallback = notifyResize;
+  if (!resizeCallback) throw new Error('The directive never constructed a ResizeObserver');
+
+  return {
+    fixture,
+    link: screen.getByTestId('link'),
+    triggerResize: () => resizeCallback([], {} as ResizeObserver),
+  };
 }
 
 describe('WidestLineWidthDirective', () => {
@@ -45,18 +53,18 @@ describe('WidestLineWidthDirective', () => {
   });
 
   it('should set the widest line width as a custom property when the host resizes', async () => {
-    const { link } = await setup();
+    const { link, triggerResize } = await setup();
 
-    notifyResize?.([], {} as ResizeObserver);
+    triggerResize();
 
     expect(link.style.getPropertyValue(WIDEST_LINE_WIDTH_PROPERTY)).toBe(WIDEST_LINE_WIDTH);
   });
 
   it('should leave the custom property unset when the host renders no text lines', async () => {
     Range.prototype.getClientRects = jest.fn(() => [] as unknown as DOMRectList);
-    const { link } = await setup();
+    const { link, triggerResize } = await setup();
 
-    notifyResize?.([], {} as ResizeObserver);
+    triggerResize();
 
     expect(link.style.getPropertyValue(WIDEST_LINE_WIDTH_PROPERTY)).toBe('');
   });

--- a/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.ts
+++ b/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.ts
@@ -1,0 +1,54 @@
+import { afterNextRender, Directive, ElementRef, inject, OnDestroy } from '@angular/core';
+
+export const WIDEST_LINE_WIDTH_PROPERTY = '--widest-line-width';
+
+/**
+ * Exposes the width of the host's widest rendered line of text as a CSS custom property, so styles
+ * can size decorations (underlines, highlights) to the text rather than to the full element box.
+ */
+@Directive({
+  selector: '[explorersWidestLineWidth]',
+})
+export class WidestLineWidthDirective implements OnDestroy {
+  private readonly element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
+
+  private resizeObserver?: ResizeObserver;
+
+  constructor() {
+    afterNextRender(() => {
+      this.resizeObserver = new ResizeObserver(() => this.updateWidestLineWidth());
+      this.resizeObserver.observe(this.element);
+      // A web font swap changes text metrics without necessarily resizing the host element.
+      document.fonts?.ready.then(() => this.updateWidestLineWidth());
+    });
+  }
+
+  ngOnDestroy() {
+    this.resizeObserver?.disconnect();
+  }
+
+  private updateWidestLineWidth() {
+    const lineWidths = this.getTextLineWidths();
+    if (lineWidths.length === 0) return;
+
+    this.element.style.setProperty(
+      WIDEST_LINE_WIDTH_PROPERTY,
+      `${Math.ceil(Math.max(...lineWidths))}px`,
+    );
+  }
+
+  private getTextLineWidths(): number[] {
+    // Ranges over text nodes yield one rect per rendered line; a range over the host would instead
+    // yield the box of any block-level child, which is as wide as the host.
+    const textNodes = document.createTreeWalker(this.element, NodeFilter.SHOW_TEXT);
+    const textRange = document.createRange();
+    const lineWidths: number[] = [];
+
+    for (let textNode = textNodes.nextNode(); textNode; textNode = textNodes.nextNode()) {
+      textRange.selectNodeContents(textNode);
+      lineWidths.push(...Array.from(textRange.getClientRects(), (rect) => rect.width));
+    }
+
+    return lineWidths;
+  }
+}

--- a/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.ts
+++ b/libs/explorers/util/src/lib/widest-line-width/widest-line-width.directive.ts
@@ -1,5 +1,7 @@
 import { afterNextRender, Directive, ElementRef, inject, OnDestroy } from '@angular/core';
 
+// Components using this directive must read var(--widest-line-width) in their styles, with a
+// fallback for before the first measurement.
 export const WIDEST_LINE_WIDTH_PROPERTY = '--widest-line-width';
 
 /**


### PR DESCRIPTION
## Description

The active-link underline in the shared explorers header spanned the full width of the link box. Once the viewport narrows enough to force a nav label to wrap onto two lines, that box is wider than any line of text, so the underline visibly overhangs the label. This sizes the underline to the widest rendered line instead, which is the behavior MG-1029 asks for. The header is shared across Agora, Model-AD, and QTL, so the fix lands in `libs/explorers` and benefits all three.  Also, the 'Model Overview' nav link is center justified but the other nav links are left-justified so this PR also fixes this inconsistency.

A CSS-only fix isn't possible here: shrink-to-fit width (`fit-content`, `inline-block`, `display: table`, `float`) is resolved from intrinsic sizes *before* line breaking, so a wrapped box stays as wide as the space available and never collapses to its longest line. The widest line box only exists after layout, hence the small measuring directive.

## Related Issue

- [MG-1029](https://sagebionetworks.jira.com/browse/MG-1029) — Header nav element underline is too wide when text wraps

## Changelog

- Add `WidestLineWidthDirective` to `explorers-util`, exposing the host's widest rendered text line as the `--widest-line-width` custom property
- Size the header's active-link underline to `--widest-line-width` instead of the full link box
- Apply the directive to header nav links, external links, and dropdown triggers
- Left-align the dropdown trigger's label, which the `reset-button` mixin left centered by the UA stylesheet
- Export the new directive from the `explorers-util` public API

## Testing

- Open any explorer (Model-AD at `/comparison/model` puts "Model Overview" in the active state) and narrow the browser to roughly 1300–1400px so nav labels wrap onto two lines.
- Confirm the active link's underline matches the widest line of its label rather than overhanging it, and that it starts flush with the left edge of the text.
- Confirm the "Model Overview" dropdown trigger wraps left-aligned, matching the plain `<a>` nav links beside it.
- Widen the browser until labels fit on one line; the underline should still span the full label.
- Resize slowly across the wrap threshold and confirm the underline re-measures rather than sticking at a stale width.
- Narrow below 1300px into the mobile menu and confirm the stacked nav links still show their full-width underline.
- Spot-check the Agora and QTL headers, since the component is shared.

### Preview

| Before                                                                                                                        | After                                                                                                                       |
| ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
| <img width="1036" height="91" alt="image" src="https://github.com/user-attachments/assets/fced9844-2850-4e56-9e91-e05c5a5b71b6" /> | <img width="1045" height="92" alt="image" src="https://github.com/user-attachments/assets/704cd2e9-d21c-4841-9760-227d5771e601" /> |


[MG-1029]: https://sagebionetworks.jira.com/browse/MG-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-945]: https://sagebionetworks.jira.com/browse/MG-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ