### PR TITLE
feat(model-ad): match full ensembl gene ids in the differential expression filterbox search (MG-1048)

### DIFF
--- a/apps/agora/app/e2e/nominated-drugs.spec.ts
+++ b/apps/agora/app/e2e/nominated-drugs.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
   ColumnConfig,
+  expectSearchResults,
   getQueryParamFromValues,
   getQueryParamsFromRecords,
   runFilterPanelTests,
@@ -14,7 +15,6 @@ import {
   testMetaClickBuildsMultiColumnSort,
   testMetaClickTogglesExistingSortOrder,
   testMultiColumnSortRestoredFromUrl,
-  testPartialCaseInsensitiveSearch,
   testPinLastItemLastPageGoesToPreviousPage,
   testSearchExcludesPinnedItems,
   testSortRestoredFromUrl,
@@ -56,7 +56,7 @@ test.describe('nominated drugs - comparison tool', () => {
       page,
     }) => {
       await navigateToComparison(page, CT_PAGE, true, 'url');
-      await testPartialCaseInsensitiveSearch(page, 'raz', pinnedItems);
+      await expectSearchResults(page, 'raz', pinnedItems);
     });
 
     test('filterbox search excludes pinned items from results', async ({ page }) => {

--- a/apps/agora/app/e2e/nominated-targets.spec.ts
+++ b/apps/agora/app/e2e/nominated-targets.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
   ColumnConfig,
+  expectSearchResults,
   getQueryParamFromValues,
   getQueryParamsFromRecords,
   runFilterPanelTests,
@@ -14,7 +15,6 @@ import {
   testMetaClickBuildsMultiColumnSort,
   testMetaClickTogglesExistingSortOrder,
   testMultiColumnSortRestoredFromUrl,
-  testPartialCaseInsensitiveSearch,
   testPinLastItemLastPageGoesToPreviousPage,
   testSearchExcludesPinnedItems,
   testSortRestoredFromUrl,
@@ -60,7 +60,7 @@ test.describe('nominated targets - comparison tool', () => {
       page,
     }) => {
       await navigateToComparison(page, CT_PAGE, true, 'url');
-      await testPartialCaseInsensitiveSearch(page, 'od', ['APOD', 'LMOD3', 'NEUROD6']);
+      await expectSearchResults(page, 'od', ['APOD', 'LMOD3', 'NEUROD6']);
     });
 
     test('filterbox search excludes pinned items from results', async ({ page }) => {

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -46,7 +46,7 @@ public class CustomTranscriptomicsRepositoryImpl
    * this filterbox is case-insensitive; without it a lower-cased ID would fall through to the
    * gene_symbol path and return nothing.
    */
-  private static final Pattern FULL_ENSEMBL_GENE_ID = Pattern.compile(
+  private static final Pattern FULL_MOUSE_ENSEMBL_GENE_ID = Pattern.compile(
     "^ENSMUSG\\d{11}$",
     Pattern.CASE_INSENSITIVE
   );
@@ -257,7 +257,7 @@ public class CustomTranscriptomicsRepositoryImpl
   }
 
   private static boolean isFullEnsemblGeneId(String term) {
-    return FULL_ENSEMBL_GENE_ID.matcher(term).matches();
+    return FULL_MOUSE_ENSEMBL_GENE_ID.matcher(term).matches();
   }
 
   private static Criteria equalsAnyIgnoringCase(String field, List<String> terms) {

--- a/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
+++ b/apps/model-ad/api-next/src/main/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImpl.java
@@ -38,7 +38,18 @@ public class CustomTranscriptomicsRepositoryImpl
 
   private static final String COLLECTION_NAME = "rna_de_aggregate";
   private static final String DISPLAY_GENE_SYMBOL_FIELD = "display_gene_symbol";
+  private static final String ENSEMBL_GENE_ID_FIELD = "ensembl_gene_id";
   private static final String GENE_SYMBOL_FIELD = "gene_symbol";
+
+  /**
+   * A complete Ensembl mouse gene ID. Matched case-insensitively because every other matcher in
+   * this filterbox is case-insensitive; without it a lower-cased ID would fall through to the
+   * gene_symbol path and return nothing.
+   */
+  private static final Pattern FULL_ENSEMBL_GENE_ID = Pattern.compile(
+    "^ENSMUSG\\d{11}$",
+    Pattern.CASE_INSENSITIVE
+  );
 
   public CustomTranscriptomicsRepositoryImpl(MongoTemplate mongoTemplate) {
     super(mongoTemplate);
@@ -143,17 +154,17 @@ public class CustomTranscriptomicsRepositoryImpl
   private AggregationOperation buildDisplayGeneSymbolField() {
     // Check if gene_symbol is null
     List<Object> eqNull = new ArrayList<>();
-    eqNull.add("$gene_symbol");
+    eqNull.add("$" + GENE_SYMBOL_FIELD);
     eqNull.add(null);
 
     // Check if gene_symbol is empty string
     List<Object> eqEmpty = new ArrayList<>();
-    eqEmpty.add("$gene_symbol");
+    eqEmpty.add("$" + GENE_SYMBOL_FIELD);
     eqEmpty.add("");
 
     // Check if gene_symbol is only whitespace
     List<Object> eqTrimmed = new ArrayList<>();
-    eqTrimmed.add(new Document("$trim", new Document("input", "$gene_symbol")));
+    eqTrimmed.add(new Document("$trim", new Document("input", "$" + GENE_SYMBOL_FIELD)));
     eqTrimmed.add("");
 
     // Combine all null/empty/whitespace checks with $or
@@ -165,8 +176,8 @@ public class CustomTranscriptomicsRepositoryImpl
     // $cond: if (gene_symbol is null/empty/whitespace) then ensembl_gene_id else gene_symbol
     List<Object> condArgs = new ArrayList<>();
     condArgs.add(new Document("$or", orConditions));
-    condArgs.add("$ensembl_gene_id");
-    condArgs.add("$gene_symbol");
+    condArgs.add("$" + ENSEMBL_GENE_ID_FIELD);
+    condArgs.add("$" + GENE_SYMBOL_FIELD);
 
     Document addFieldsDoc = new Document(
       "$addFields",
@@ -177,10 +188,13 @@ public class CustomTranscriptomicsRepositoryImpl
   }
 
   /**
-   * Override search to add gene_symbol/ensembl_gene_id fallback logic.
+   * Override search to route each term to the field it identifies.
    *
-   * <p>Since {@code display_gene_symbol = gene_symbol ?? ensembl_gene_id}, the search matches:
-   * (gene_symbol matches) OR (gene_symbol is null/empty AND ensembl_gene_id matches)
+   * <p>A term that is a complete Ensembl gene ID matches {@code ensembl_gene_id} only. Every other
+   * term matches {@code gene_symbol}, falling back to {@code ensembl_gene_id} when
+   * {@code gene_symbol} is null/empty, mirroring
+   * {@code display_gene_symbol = gene_symbol ?? ensembl_gene_id}. Terms in a comma-separated list
+   * are routed independently.
    *
    * <p><strong>NOTE:</strong> We cannot use {@code DISPLAY_GENE_SYMBOL_FIELD} here because it's a
    * computed field created by {@code $addFields} in the aggregation pipeline. The count query uses
@@ -190,29 +204,73 @@ public class CustomTranscriptomicsRepositoryImpl
    */
   @Override
   protected Criteria buildSearchCriteria(String field, String trimmedSearch) {
-    Criteria geneSymbolIsNullOrEmpty = new Criteria()
+    if (trimmedSearch.contains(",")) {
+      return buildCommaSeparatedSearchCriteria(trimmedSearch);
+    }
+    return buildSingleTermSearchCriteria(trimmedSearch);
+  }
+
+  /** Single term: case-insensitive exact match for a full Ensembl gene ID,
+   * partial match otherwise. */
+  private Criteria buildSingleTermSearchCriteria(String term) {
+    if (isFullEnsemblGeneId(term)) {
+      return equalsAnyIgnoringCase(ENSEMBL_GENE_ID_FIELD, List.of(term));
+    }
+
+    String regex = Pattern.quote(term);
+    return new Criteria()
+      .orOperator(
+        Criteria.where(GENE_SYMBOL_FIELD).regex(regex, "i"),
+        whenGeneSymbolIsBlank(Criteria.where(ENSEMBL_GENE_ID_FIELD).regex(regex, "i"))
+      );
+  }
+
+  /** Comma-separated list: case-insensitive exact match, each term routed independently. */
+  private Criteria buildCommaSeparatedSearchCriteria(String trimmedSearch) {
+    List<String> fullEnsemblGeneIdTerms = new ArrayList<>();
+    List<String> otherTerms = new ArrayList<>();
+    for (String term : ApiHelper.splitSearchTerms(trimmedSearch)) {
+      (isFullEnsemblGeneId(term) ? fullEnsemblGeneIdTerms : otherTerms).add(term);
+    }
+
+    List<Criteria> branches = new ArrayList<>();
+    if (!fullEnsemblGeneIdTerms.isEmpty()) {
+      branches.add(equalsAnyIgnoringCase(ENSEMBL_GENE_ID_FIELD, fullEnsemblGeneIdTerms));
+    }
+    if (!otherTerms.isEmpty()) {
+      branches.add(equalsAnyIgnoringCase(GENE_SYMBOL_FIELD, otherTerms));
+      // Only reachable for an off-pattern ensembl_gene_id (versioned, non-mouse, malformed), which
+      // the single-term path also matches. Without it, searching "A" finds such a row but "A,B"
+      // would not.
+      Criteria ensemblGeneIdFallback = equalsAnyIgnoringCase(ENSEMBL_GENE_ID_FIELD, otherTerms);
+      branches.add(whenGeneSymbolIsBlank(ensemblGeneIdFallback));
+    }
+
+    if (branches.isEmpty()) {
+      // Search was only commas: match nothing, as an empty $in would.
+      return Criteria.where("_id").is(null);
+    }
+    if (branches.size() == 1) {
+      return branches.get(0);
+    }
+    return new Criteria().orOperator(branches);
+  }
+
+  private static boolean isFullEnsemblGeneId(String term) {
+    return FULL_ENSEMBL_GENE_ID.matcher(term).matches();
+  }
+
+  private static Criteria equalsAnyIgnoringCase(String field, List<String> terms) {
+    return Criteria.where(field).in(ApiHelper.createCaseInsensitiveFullMatchPatterns(terms));
+  }
+
+  private static Criteria whenGeneSymbolIsBlank(Criteria fallbackMatch) {
+    Criteria geneSymbolIsBlank = new Criteria()
       .orOperator(
         Criteria.where(GENE_SYMBOL_FIELD).is(null),
         Criteria.where(GENE_SYMBOL_FIELD).is(""),
         Criteria.where(GENE_SYMBOL_FIELD).regex("^\\s*$")
       );
-
-    if (trimmedSearch.contains(",")) {
-      // Comma-separated list: exact match (case-insensitive)
-      List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns(trimmedSearch);
-      Criteria geneSymbolMatches = Criteria.where(GENE_SYMBOL_FIELD).in(patterns);
-      Criteria ensemblFallbackMatches = new Criteria()
-        .andOperator(geneSymbolIsNullOrEmpty, Criteria.where("ensembl_gene_id").in(patterns));
-
-      return new Criteria().orOperator(geneSymbolMatches, ensemblFallbackMatches);
-    } else {
-      // Single term: partial match (case-insensitive)
-      String regex = Pattern.quote(trimmedSearch);
-      Criteria geneSymbolMatches = Criteria.where(GENE_SYMBOL_FIELD).regex(regex, "i");
-      Criteria ensemblFallbackMatches = new Criteria()
-        .andOperator(geneSymbolIsNullOrEmpty, Criteria.where("ensembl_gene_id").regex(regex, "i"));
-
-      return new Criteria().orOperator(geneSymbolMatches, ensemblFallbackMatches);
-    }
+    return new Criteria().andOperator(geneSymbolIsBlank, fallbackMatch);
   }
 }

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +40,13 @@ import org.springframework.data.mongodb.core.query.Query;
 class CustomTranscriptomicsRepositoryImplTest {
 
   private static final String COLLECTION_NAME = "rna_de_aggregate";
+  private static final String ENSEMBL_GENE_ID_FIELD = "ensembl_gene_id";
+  private static final String GENE_SYMBOL_FIELD = "gene_symbol";
+  private static final String TISSUE_FIELD = "tissue";
+
+  private static final String ENSA_ENSEMBL_GENE_ID = "ENSMUSG00000038619";
+  private static final String OTHER_ENSEMBL_GENE_ID = "ENSMUSG00000000001";
+  private static final String PLEC_GENE_SYMBOL = "plec";
 
   private CustomTranscriptomicsRepositoryImpl repository;
 
@@ -75,7 +83,7 @@ class CustomTranscriptomicsRepositoryImplTest {
     Document criteriaDoc = captureCountQuery().getQueryObject();
     assertThat(criteriaDoc).containsKey("$and");
     List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
-    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("tissue"));
+    assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey(TISSUE_FIELD));
     assertThat(andConditions).anySatisfy(doc -> assertThat(doc).containsKey("biodomains"));
   }
 
@@ -163,7 +171,7 @@ class CustomTranscriptomicsRepositoryImplTest {
       "test-tissue"
     );
 
-    assertThat(captureCountQuery().getQueryObject().toJson()).doesNotContain("\"$regex\"");
+    assertThat(captureCountQuery().getQueryObject().toString()).doesNotContain(GENE_SYMBOL_FIELD);
   }
 
   @Test
@@ -176,7 +184,131 @@ class CustomTranscriptomicsRepositoryImplTest {
 
     repository.findAll(PageRequest.of(0, 10), query, Collections.emptyList(), "test-tissue");
 
-    assertThat(captureCountQuery().getQueryObject().toJson()).doesNotContain("\"$regex\"");
+    assertThat(captureCountQuery().getQueryObject().toString())
+      .doesNotContain(GENE_SYMBOL_FIELD)
+      .doesNotContain(ENSEMBL_GENE_ID_FIELD);
+  }
+
+  @Test
+  @DisplayName("should search ensembl_gene_id only when search is a full ensembl gene id")
+  void shouldSearchEnsemblGeneIdOnlyWhenSearchIsFullEnsemblGeneId() {
+    Document searchCondition = searchConditionFor(ENSA_ENSEMBL_GENE_ID);
+
+    assertThat(searchCondition.keySet())
+      .as("a full ensembl gene id routes to ensembl_gene_id with no gene_symbol branch")
+      .containsExactly(ENSEMBL_GENE_ID_FIELD);
+    assertThat(inPatterns(searchCondition, ENSEMBL_GENE_ID_FIELD))
+      .extracting(Pattern::pattern)
+      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID));
+  }
+
+  @Test
+  @DisplayName("should match case-insensitively when search is a lowercase full ensembl gene id")
+  void shouldMatchCaseInsensitivelyWhenSearchIsLowercaseFullEnsemblGeneId() {
+    Document searchCondition = searchConditionFor(ENSA_ENSEMBL_GENE_ID.toLowerCase());
+
+    assertThat(searchCondition.keySet()).containsExactly(ENSEMBL_GENE_ID_FIELD);
+    assertThat(inPatterns(searchCondition, ENSEMBL_GENE_ID_FIELD)).allSatisfy(pattern ->
+      assertThat(pattern.flags() & Pattern.CASE_INSENSITIVE).isNotZero()
+    );
+  }
+
+  @Test
+  @DisplayName(
+    "should route terms independently when search mixes a full ensembl gene id and a gene symbol"
+  )
+  void shouldRouteTermsIndependentlyWhenSearchMixesFullEnsemblGeneIdAndGeneSymbol() {
+    List<Document> branches = searchBranchesFor(ENSA_ENSEMBL_GENE_ID + "," + PLEC_GENE_SYMBOL);
+
+    assertThat(branches)
+      .as("ensembl_gene_id branch, gene_symbol branch, and blank-guarded fallback branch")
+      .hasSize(3);
+    assertThat(inPatterns(branchFor(branches, ENSEMBL_GENE_ID_FIELD), ENSEMBL_GENE_ID_FIELD))
+      .extracting(Pattern::pattern)
+      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID));
+    assertThat(inPatterns(branchFor(branches, GENE_SYMBOL_FIELD), GENE_SYMBOL_FIELD))
+      .as("the ensembl gene id term must not leak into the gene_symbol partition")
+      .extracting(Pattern::pattern)
+      .containsExactly(fullMatch(PLEC_GENE_SYMBOL));
+  }
+
+  @Test
+  @DisplayName(
+    "should route all terms to ensembl_gene_id when every comma term is a full ensembl gene id"
+  )
+  void shouldRouteAllTermsToEnsemblGeneIdWhenEveryCommaTermIsFullEnsemblGeneId() {
+    Document searchCondition = searchConditionFor(
+      ENSA_ENSEMBL_GENE_ID + "," + OTHER_ENSEMBL_GENE_ID
+    );
+
+    assertThat(searchCondition.keySet()).containsExactly(ENSEMBL_GENE_ID_FIELD);
+    assertThat(inPatterns(searchCondition, ENSEMBL_GENE_ID_FIELD))
+      .extracting(Pattern::pattern)
+      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID), fullMatch(OTHER_ENSEMBL_GENE_ID));
+  }
+
+  @Test
+  @DisplayName("should trim terms when comma-separated terms have surrounding whitespace")
+  void shouldTrimTermsWhenCommaSeparatedTermsHaveSurroundingWhitespace() {
+    List<Document> branches = searchBranchesFor(
+      "  " + ENSA_ENSEMBL_GENE_ID + " , " + PLEC_GENE_SYMBOL + "  "
+    );
+
+    assertThat(branches).hasSize(3);
+    assertThat(inPatterns(branchFor(branches, ENSEMBL_GENE_ID_FIELD), ENSEMBL_GENE_ID_FIELD))
+      .extracting(Pattern::pattern)
+      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID));
+    assertThat(inPatterns(branchFor(branches, GENE_SYMBOL_FIELD), GENE_SYMBOL_FIELD))
+      .extracting(Pattern::pattern)
+      .containsExactly(fullMatch(PLEC_GENE_SYMBOL));
+  }
+
+  @Test
+  @DisplayName("should fall back to gene_symbol when search is a partial ensembl gene id")
+  void shouldFallBackToGeneSymbolWhenSearchIsPartialEnsemblGeneId() {
+    String partialEnsemblGeneId = ENSA_ENSEMBL_GENE_ID.substring(
+      0,
+      ENSA_ENSEMBL_GENE_ID.length() - 1
+    );
+    List<Document> branches = searchBranchesFor(partialEnsemblGeneId);
+
+    assertThat(branches)
+      .as("gene_symbol partial match plus blank-guarded ensembl_gene_id fallback")
+      .hasSize(2);
+    Pattern geneSymbolPattern = (Pattern) branchFor(branches, GENE_SYMBOL_FIELD)
+      .get(GENE_SYMBOL_FIELD);
+    assertThat(geneSymbolPattern.pattern())
+      .as("a partial term stays an unanchored partial match")
+      .isEqualTo(Pattern.quote(partialEnsemblGeneId));
+  }
+
+  @Test
+  @DisplayName("should fall back to gene_symbol when an ensembl gene id has a version suffix")
+  void shouldFallBackToGeneSymbolWhenEnsemblGeneIdHasVersionSuffix() {
+    String versionedEnsemblGeneId = ENSA_ENSEMBL_GENE_ID + ".5";
+    List<Document> branches = searchBranchesFor(versionedEnsemblGeneId);
+
+    assertThat(branches).hasSize(2);
+    Pattern geneSymbolPattern = (Pattern) branchFor(branches, GENE_SYMBOL_FIELD)
+      .get(GENE_SYMBOL_FIELD);
+    assertThat(geneSymbolPattern.pattern()).isEqualTo(Pattern.quote(versionedEnsemblGeneId));
+  }
+
+  @Test
+  @DisplayName("should match nothing when search contains only commas")
+  void shouldMatchNothingWhenSearchContainsOnlyCommas() {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .search(",,")
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(PageRequest.of(0, 10), query, Collections.emptyList(), "test-tissue");
+
+    Document criteriaDoc = captureCountQuery().getQueryObject();
+    assertThat(searchCondition(criteriaDoc)).isEqualTo(new Document("_id", null));
+    assertThat(criteriaDoc.toString())
+      .doesNotContain(GENE_SYMBOL_FIELD)
+      .doesNotContain(ENSEMBL_GENE_ID_FIELD);
   }
 
   @Test
@@ -228,6 +360,48 @@ class CustomTranscriptomicsRepositoryImplTest {
     assertThat(pipeline)
       .as("$sort should not reference the raw '4 months' object directly as a sort key")
       .doesNotContain("\"4 months\" :");
+  }
+
+  /** Runs a search-only query (EXCLUDE mode, no items) and returns its search condition. */
+  private Document searchConditionFor(String search) {
+    TranscriptomicsSearchQueryDto query = TranscriptomicsSearchQueryDto.builder()
+      .search(search)
+      .itemFilterType(ItemFilterTypeQueryDto.EXCLUDE)
+      .build();
+
+    repository.findAll(PageRequest.of(0, 10), query, Collections.emptyList(), "test-tissue");
+
+    return searchCondition(captureCountQuery().getQueryObject());
+  }
+
+  private List<Document> searchBranchesFor(String search) {
+    return (List<Document>) searchConditionFor(search).get("$or");
+  }
+
+  /** The one $and condition that isn't the mandatory tissue scoping. */
+  private static Document searchCondition(Document criteriaDoc) {
+    List<Document> andConditions = (List<Document>) criteriaDoc.get("$and");
+    return andConditions
+      .stream()
+      .filter(condition -> !condition.containsKey(TISSUE_FIELD))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("no search condition in " + criteriaDoc));
+  }
+
+  private static Document branchFor(List<Document> branches, String field) {
+    return branches
+      .stream()
+      .filter(branch -> branch.containsKey(field))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("no " + field + " branch in " + branches));
+  }
+
+  private static List<Pattern> inPatterns(Document condition, String field) {
+    return (List<Pattern>) condition.get(field, Document.class).get("$in");
+  }
+
+  private static String fullMatch(String term) {
+    return "^" + Pattern.quote(term) + "$";
   }
 
   private Query captureCountQuery() {

--- a/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
+++ b/apps/model-ad/api-next/src/test/java/org/sagebionetworks/model/ad/api/next/model/repository/CustomTranscriptomicsRepositoryImplTest.java
@@ -44,8 +44,9 @@ class CustomTranscriptomicsRepositoryImplTest {
   private static final String GENE_SYMBOL_FIELD = "gene_symbol";
   private static final String TISSUE_FIELD = "tissue";
 
-  private static final String ENSA_ENSEMBL_GENE_ID = "ENSMUSG00000038619";
-  private static final String OTHER_ENSEMBL_GENE_ID = "ENSMUSG00000000001";
+  private static final String ENSA_MOUSE_ENSEMBL_GENE_ID = "ENSMUSG00000038619";
+  private static final String OTHER_MOUSE_ENSEMBL_GENE_ID = "ENSMUSG00000000001";
+  private static final String MARMOSET_ENSEMBL_GENE_ID = "ENSCJAG00000003645";
   private static final String PLEC_GENE_SYMBOL = "plec";
 
   private CustomTranscriptomicsRepositoryImpl repository;
@@ -192,20 +193,20 @@ class CustomTranscriptomicsRepositoryImplTest {
   @Test
   @DisplayName("should search ensembl_gene_id only when search is a full ensembl gene id")
   void shouldSearchEnsemblGeneIdOnlyWhenSearchIsFullEnsemblGeneId() {
-    Document searchCondition = searchConditionFor(ENSA_ENSEMBL_GENE_ID);
+    Document searchCondition = searchConditionFor(ENSA_MOUSE_ENSEMBL_GENE_ID);
 
     assertThat(searchCondition.keySet())
       .as("a full ensembl gene id routes to ensembl_gene_id with no gene_symbol branch")
       .containsExactly(ENSEMBL_GENE_ID_FIELD);
     assertThat(inPatterns(searchCondition, ENSEMBL_GENE_ID_FIELD))
       .extracting(Pattern::pattern)
-      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID));
+      .containsExactly(fullMatch(ENSA_MOUSE_ENSEMBL_GENE_ID));
   }
 
   @Test
   @DisplayName("should match case-insensitively when search is a lowercase full ensembl gene id")
   void shouldMatchCaseInsensitivelyWhenSearchIsLowercaseFullEnsemblGeneId() {
-    Document searchCondition = searchConditionFor(ENSA_ENSEMBL_GENE_ID.toLowerCase());
+    Document searchCondition = searchConditionFor(ENSA_MOUSE_ENSEMBL_GENE_ID.toLowerCase());
 
     assertThat(searchCondition.keySet()).containsExactly(ENSEMBL_GENE_ID_FIELD);
     assertThat(inPatterns(searchCondition, ENSEMBL_GENE_ID_FIELD)).allSatisfy(pattern ->
@@ -218,14 +219,16 @@ class CustomTranscriptomicsRepositoryImplTest {
     "should route terms independently when search mixes a full ensembl gene id and a gene symbol"
   )
   void shouldRouteTermsIndependentlyWhenSearchMixesFullEnsemblGeneIdAndGeneSymbol() {
-    List<Document> branches = searchBranchesFor(ENSA_ENSEMBL_GENE_ID + "," + PLEC_GENE_SYMBOL);
+    List<Document> branches = searchBranchesFor(
+      ENSA_MOUSE_ENSEMBL_GENE_ID + "," + PLEC_GENE_SYMBOL
+    );
 
     assertThat(branches)
       .as("ensembl_gene_id branch, gene_symbol branch, and blank-guarded fallback branch")
       .hasSize(3);
     assertThat(inPatterns(branchFor(branches, ENSEMBL_GENE_ID_FIELD), ENSEMBL_GENE_ID_FIELD))
       .extracting(Pattern::pattern)
-      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID));
+      .containsExactly(fullMatch(ENSA_MOUSE_ENSEMBL_GENE_ID));
     assertThat(inPatterns(branchFor(branches, GENE_SYMBOL_FIELD), GENE_SYMBOL_FIELD))
       .as("the ensembl gene id term must not leak into the gene_symbol partition")
       .extracting(Pattern::pattern)
@@ -238,26 +241,29 @@ class CustomTranscriptomicsRepositoryImplTest {
   )
   void shouldRouteAllTermsToEnsemblGeneIdWhenEveryCommaTermIsFullEnsemblGeneId() {
     Document searchCondition = searchConditionFor(
-      ENSA_ENSEMBL_GENE_ID + "," + OTHER_ENSEMBL_GENE_ID
+      ENSA_MOUSE_ENSEMBL_GENE_ID + "," + OTHER_MOUSE_ENSEMBL_GENE_ID
     );
 
     assertThat(searchCondition.keySet()).containsExactly(ENSEMBL_GENE_ID_FIELD);
     assertThat(inPatterns(searchCondition, ENSEMBL_GENE_ID_FIELD))
       .extracting(Pattern::pattern)
-      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID), fullMatch(OTHER_ENSEMBL_GENE_ID));
+      .containsExactly(
+        fullMatch(ENSA_MOUSE_ENSEMBL_GENE_ID),
+        fullMatch(OTHER_MOUSE_ENSEMBL_GENE_ID)
+      );
   }
 
   @Test
   @DisplayName("should trim terms when comma-separated terms have surrounding whitespace")
   void shouldTrimTermsWhenCommaSeparatedTermsHaveSurroundingWhitespace() {
     List<Document> branches = searchBranchesFor(
-      "  " + ENSA_ENSEMBL_GENE_ID + " , " + PLEC_GENE_SYMBOL + "  "
+      "  " + ENSA_MOUSE_ENSEMBL_GENE_ID + " , " + PLEC_GENE_SYMBOL + "  "
     );
 
     assertThat(branches).hasSize(3);
     assertThat(inPatterns(branchFor(branches, ENSEMBL_GENE_ID_FIELD), ENSEMBL_GENE_ID_FIELD))
       .extracting(Pattern::pattern)
-      .containsExactly(fullMatch(ENSA_ENSEMBL_GENE_ID));
+      .containsExactly(fullMatch(ENSA_MOUSE_ENSEMBL_GENE_ID));
     assertThat(inPatterns(branchFor(branches, GENE_SYMBOL_FIELD), GENE_SYMBOL_FIELD))
       .extracting(Pattern::pattern)
       .containsExactly(fullMatch(PLEC_GENE_SYMBOL));
@@ -266,17 +272,18 @@ class CustomTranscriptomicsRepositoryImplTest {
   @Test
   @DisplayName("should fall back to gene_symbol when search is a partial ensembl gene id")
   void shouldFallBackToGeneSymbolWhenSearchIsPartialEnsemblGeneId() {
-    String partialEnsemblGeneId = ENSA_ENSEMBL_GENE_ID.substring(
+    String partialEnsemblGeneId = ENSA_MOUSE_ENSEMBL_GENE_ID.substring(
       0,
-      ENSA_ENSEMBL_GENE_ID.length() - 1
+      ENSA_MOUSE_ENSEMBL_GENE_ID.length() - 1
     );
     List<Document> branches = searchBranchesFor(partialEnsemblGeneId);
 
     assertThat(branches)
       .as("gene_symbol partial match plus blank-guarded ensembl_gene_id fallback")
       .hasSize(2);
-    Pattern geneSymbolPattern = (Pattern) branchFor(branches, GENE_SYMBOL_FIELD)
-      .get(GENE_SYMBOL_FIELD);
+    Pattern geneSymbolPattern = (Pattern) branchFor(branches, GENE_SYMBOL_FIELD).get(
+      GENE_SYMBOL_FIELD
+    );
     assertThat(geneSymbolPattern.pattern())
       .as("a partial term stays an unanchored partial match")
       .isEqualTo(Pattern.quote(partialEnsemblGeneId));
@@ -285,13 +292,28 @@ class CustomTranscriptomicsRepositoryImplTest {
   @Test
   @DisplayName("should fall back to gene_symbol when an ensembl gene id has a version suffix")
   void shouldFallBackToGeneSymbolWhenEnsemblGeneIdHasVersionSuffix() {
-    String versionedEnsemblGeneId = ENSA_ENSEMBL_GENE_ID + ".5";
+    String versionedEnsemblGeneId = ENSA_MOUSE_ENSEMBL_GENE_ID + ".5";
     List<Document> branches = searchBranchesFor(versionedEnsemblGeneId);
 
     assertThat(branches).hasSize(2);
-    Pattern geneSymbolPattern = (Pattern) branchFor(branches, GENE_SYMBOL_FIELD)
-      .get(GENE_SYMBOL_FIELD);
+    Pattern geneSymbolPattern = (Pattern) branchFor(branches, GENE_SYMBOL_FIELD).get(
+      GENE_SYMBOL_FIELD
+    );
     assertThat(geneSymbolPattern.pattern()).isEqualTo(Pattern.quote(versionedEnsemblGeneId));
+  }
+
+  @Test
+  @DisplayName("should fall back to gene_symbol when search is a marmoset ensembl gene id")
+  void shouldFallBackToGeneSymbolWhenSearchIsMarmosetEnsemblGeneId() {
+    List<Document> branches = searchBranchesFor(MARMOSET_ENSEMBL_GENE_ID);
+
+    assertThat(branches)
+      .as("a non-mouse ensembl gene id is not a full ensembl gene id for this collection")
+      .hasSize(2);
+    Pattern geneSymbolPattern = (Pattern) branchFor(branches, GENE_SYMBOL_FIELD).get(
+      GENE_SYMBOL_FIELD
+    );
+    assertThat(geneSymbolPattern.pattern()).isEqualTo(Pattern.quote(MARMOSET_ENSEMBL_GENE_ID));
   }
 
   @Test

--- a/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
@@ -3,10 +3,12 @@ import {
   ColumnConfig,
   expectPinnedParams,
   expectPinnedRows,
+  expectSearchResults,
   getHeatmapDetailsPanelSubHeadings,
   getPinnedTable,
   getQueryParamFromValues,
   getQueryParamsFromRecords,
+  getRowByName,
   getUnpinnedTable,
   getVisibleHeatmapCircleButtons,
   pinByName,
@@ -23,7 +25,6 @@ import {
   testMetaClickBuildsMultiColumnSort,
   testMetaClickTogglesExistingSortOrder,
   testMultiColumnSortRestoredFromUrl,
-  testPartialCaseInsensitiveSearch,
   testPinLastItemLastPageGoesToPreviousPage,
   testSearchExcludesPinnedItems,
   testSortRestoredFromUrl,
@@ -49,6 +50,25 @@ const cacul1Matches = [
   'ENSMUSG00000033417~3xTg-AD~Male',
   'ENSMUSG00000033417~Abca7*V1599M~Female',
   'ENSMUSG00000033417~Abca7*V1599M~Male',
+];
+const ensaEnsemblGeneId = 'ENSMUSG00000038619';
+const ensaMatches = [
+  `${ensaEnsemblGeneId}~3xTg-AD~Female`,
+  `${ensaEnsemblGeneId}~3xTg-AD~Male`,
+  `${ensaEnsemblGeneId}~Abca7*V1599M~Female`,
+  `${ensaEnsemblGeneId}~Abca7*V1599M~Male`,
+]; // Ensa
+const plecGeneSymbol = 'plec';
+const plecMatches = [
+  'ENSMUSG00000022565~3xTg-AD~Female',
+  'ENSMUSG00000022565~3xTg-AD~Male',
+  'ENSMUSG00000022565~Abca7*V1599M~Female',
+  'ENSMUSG00000022565~Abca7*V1599M~Male',
+]; // Plec
+const noGeneSymbolEnsemblGeneId = 'ENSMUSG00000037982';
+const noGeneSymbolMatches = [
+  `${noGeneSymbolEnsemblGeneId}~Abca7*V1599M~Female`,
+  `${noGeneSymbolEnsemblGeneId}~Abca7*V1599M~Male`,
 ];
 
 test.describe('differential expression', () => {
@@ -81,7 +101,7 @@ test.describe('differential expression', () => {
     page,
   }) => {
     await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
-    await testPartialCaseInsensitiveSearch(page, 'acul', cacul1Matches);
+    await expectSearchResults(page, 'acul', cacul1Matches);
   });
 
   test('filterbox search excludes pinned items from results', async ({ page }) => {
@@ -112,12 +132,62 @@ test.describe('differential expression', () => {
     page,
   }) => {
     await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
-    await testPartialCaseInsensitiveSearch(page, '(r', [
+    await expectSearchResults(page, '(r', [
       'ENSMUSG00000086429~3xTg-AD~Female',
       'ENSMUSG00000086429~3xTg-AD~Male',
       'ENSMUSG00000086429~Abca7*V1599M~Female',
       'ENSMUSG00000086429~Abca7*V1599M~Male',
     ]); // Gt(ROSA)26Sor
+  });
+
+  test('filterbox search with full ensembl gene id returns rows for that gene', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
+    await expectSearchResults(page, ensaEnsemblGeneId, ensaMatches);
+  });
+
+  test('filterbox search with lowercase full ensembl gene id returns rows for that gene', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
+    await expectSearchResults(page, ensaEnsemblGeneId.toLowerCase(), ensaMatches);
+  });
+
+  test('filterbox search with comma-separated ensembl gene id and gene symbol returns both genes', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
+    await expectSearchResults(page, `${ensaEnsemblGeneId},${plecGeneSymbol}`, [
+      ...ensaMatches,
+      ...plecMatches,
+    ]);
+  });
+
+  test('filterbox search with full ensembl gene id returns rows for a gene without a gene symbol', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
+    await expectSearchResults(page, noGeneSymbolEnsemblGeneId, noGeneSymbolMatches);
+  });
+
+  test('filterbox search with partial ensembl gene id matches rows without a gene symbol', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
+    await expectSearchResults(page, noGeneSymbolEnsemblGeneId.slice(0, -1), noGeneSymbolMatches);
+  });
+
+  test('filterbox search with partial ensembl gene id matches gene symbols and ensembl gene ids', async ({
+    page,
+  }) => {
+    await navigateToComparison(page, CT_PAGE, true, 'url', categoriesAndModelsQueryParameters);
+    await searchViaFilterbox(page, 'ens');
+
+    const unpinnedTable = getUnpinnedTable(page);
+    for (const rowName of [...ensaMatches, ...noGeneSymbolMatches]) {
+      await expect(getRowByName(unpinnedTable, page, rowName)).toBeVisible();
+    }
   });
 
   test('pinned items are cached when switching between categories', async ({ page }) => {

--- a/apps/model-ad/app/e2e/disease-correlation-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/disease-correlation-comparison-tool.spec.ts
@@ -7,6 +7,7 @@ import {
   expectFiltersParams,
   expectPinnedParams,
   expectPinnedRows,
+  expectSearchResults,
   expectSortFieldsParams,
   expectSortOrdersParams,
   getPinnedTable,
@@ -26,7 +27,6 @@ import {
   testMetaClickBuildsMultiColumnSort,
   testMetaClickTogglesExistingSortOrder,
   testMultiColumnSortRestoredFromUrl,
-  testPartialCaseInsensitiveSearch,
   testPinLastItemLastPageGoesToPreviousPage,
   testSearchExcludesPinnedItems,
   testSortRestoredFromUrl,
@@ -298,7 +298,7 @@ test.describe('disease correlation', () => {
       getQueryParamFromValues(categories, 'categories'),
     );
 
-    await testPartialCaseInsensitiveSearch(page, 'apo', [
+    await expectSearchResults(page, 'apo', [
       'APOE4~4 months~Female',
       'APOE4~4 months~Male',
       'APOE4~8 months~Female',
@@ -373,7 +373,7 @@ test.describe('disease correlation', () => {
       getQueryParamFromValues(categories, 'categories'),
     );
 
-    await testPartialCaseInsensitiveSearch(page, '(iu', [
+    await expectSearchResults(page, '(iu', [
       '5xFAD (IU/Jax/Pitt)~4 months~Female',
       '5xFAD (IU/Jax/Pitt)~4 months~Male',
       '5xFAD (IU/Jax/Pitt)~12 months~Female',

--- a/apps/model-ad/app/e2e/marmoset-model-overview-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/marmoset-model-overview-comparison-tool.spec.ts
@@ -3,6 +3,7 @@ import {
   clickViewDetailsButtonByName,
   ColumnConfig,
   expectPinnedParams,
+  expectSearchResults,
   getPinnedTable,
   getQueryParamsFromRecords,
   getRowByName,
@@ -18,7 +19,6 @@ import {
   testMetaClickBuildsMultiColumnSort,
   testMetaClickTogglesExistingSortOrder,
   testMultiColumnSortRestoredFromUrl,
-  testPartialCaseInsensitiveSearch,
   testSortRestoredFromUrl,
   unPinByName,
 } from '@sagebionetworks/explorers/testing/e2e';
@@ -73,7 +73,7 @@ test.describe('marmoset model overview', () => {
     page,
   }) => {
     await navigateToComparison(page, CT_PAGE, true);
-    await testPartialCaseInsensitiveSearch(page, 'presenilin', [MODEL]);
+    await expectSearchResults(page, 'presenilin', [MODEL]);
   });
 
   test.describe('sort URL sync', () => {

--- a/apps/model-ad/app/e2e/mouse-model-overview-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/mouse-model-overview-comparison-tool.spec.ts
@@ -4,6 +4,7 @@ import {
   expectFiltersParams,
   expectPinnedParams,
   expectPinnedRows,
+  expectSearchResults,
   expectUnpinnedTableOnly,
   getFiltersQueryParams,
   getPinnedTable,
@@ -22,7 +23,6 @@ import {
   testMetaClickBuildsMultiColumnSort,
   testMetaClickTogglesExistingSortOrder,
   testMultiColumnSortRestoredFromUrl,
-  testPartialCaseInsensitiveSearch,
   testPinLastItemLastPageGoesToPreviousPage,
   testSearchExcludesPinnedItems,
   testSortRestoredFromUrl,
@@ -170,7 +170,7 @@ test.describe('mouse model overview', () => {
     page,
   }) => {
     await navigateToComparison(page, CT_PAGE, true);
-    await testPartialCaseInsensitiveSearch(page, 'tg-', ['3xTg-AD']);
+    await expectSearchResults(page, 'tg-', ['3xTg-AD']);
   });
 
   test('filterbox search excludes pinned items from results', async ({ page }) => {
@@ -192,7 +192,7 @@ test.describe('mouse model overview', () => {
     page,
   }) => {
     await navigateToComparison(page, CT_PAGE, true);
-    await testPartialCaseInsensitiveSearch(page, '(uc', ['5xFAD (UCI)']);
+    await expectSearchResults(page, '(uc', ['5xFAD (UCI)']);
   });
 
   test('table loads previous page when last item on last page is pinned', async ({ page }) => {

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ApiHelper.java
@@ -284,15 +284,37 @@ public final class ApiHelper {
   }
 
   /**
+   * Splits a comma-separated search string into trimmed, non-empty terms.
+   *
+   * @param commaSeparatedNames comma-separated list of names
+   * @return list of trimmed terms, excluding blank ones
+   */
+  public static List<String> splitSearchTerms(String commaSeparatedNames) {
+    return Arrays.stream(commaSeparatedNames.split(","))
+      .map(String::trim)
+      .filter(s -> !s.isEmpty())
+      .toList();
+  }
+
+  /**
    * Creates case-insensitive full match regex patterns from comma-separated names.
    *
    * @param commaSeparatedNames comma-separated list of names
    * @return list of compiled regex patterns for case-insensitive exact matching
    */
   public static List<Pattern> createCaseInsensitiveFullMatchPatterns(String commaSeparatedNames) {
-    return Arrays.stream(commaSeparatedNames.split(","))
-      .map(String::trim)
-      .filter(s -> !s.isEmpty())
+    return createCaseInsensitiveFullMatchPatterns(splitSearchTerms(commaSeparatedNames));
+  }
+
+  /**
+   * Creates case-insensitive full match regex patterns from already-split names.
+   *
+   * @param names list of names, expected to be trimmed and non-empty
+   * @return list of compiled regex patterns for case-insensitive exact matching
+   */
+  public static List<Pattern> createCaseInsensitiveFullMatchPatterns(List<String> names) {
+    return names
+      .stream()
       .map(name -> Pattern.compile("^" + Pattern.quote(name) + "$", Pattern.CASE_INSENSITIVE))
       .toList();
   }

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/ComparisonToolRepositorySupport.java
@@ -283,7 +283,7 @@ public abstract class ComparisonToolRepositorySupport<T> {
    *
    * <ul>
    *   <li>Comma-separated search → exact match (case-insensitive) via
-   *       {@link ApiHelper#createCaseInsensitiveFullMatchPatterns}
+   *       {@link ApiHelper#createCaseInsensitiveFullMatchPatterns(String)}
    *   <li>Single term → partial match (case-insensitive regex)
    * </ul>
    *

--- a/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/SearchFilterDef.java
+++ b/libs/explorers/api-helper/src/main/java/org/sagebionetworks/explorers/SearchFilterDef.java
@@ -7,7 +7,7 @@ package org.sagebionetworks.explorers;
  *
  * <ul>
  *   <li>Comma-separated search terms → exact match (case-insensitive) via
- *       {@link ApiHelper#createCaseInsensitiveFullMatchPatterns}
+ *       {@link ApiHelper#createCaseInsensitiveFullMatchPatterns(String)}
  *   <li>Single search term → partial match (case-insensitive regex)
  * </ul>
  *

--- a/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
+++ b/libs/explorers/api-helper/src/test/java/org/sagebionetworks/explorers/ApiHelperTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -334,6 +335,96 @@ class ApiHelperTest {
         .contains("missing")
         .contains("$isArray")
         .contains("$size");
+    }
+  }
+
+  @Nested
+  @DisplayName("splitSearchTerms")
+  class SplitSearchTerms {
+
+    @Test
+    @DisplayName("should return the single term when search has no comma")
+    void shouldReturnSingleTermWhenSearchHasNoComma() {
+      assertThat(ApiHelper.splitSearchTerms("APOE")).containsExactly("APOE");
+    }
+
+    @Test
+    @DisplayName("should trim each term when terms have surrounding whitespace")
+    void shouldTrimEachTermWhenTermsHaveSurroundingWhitespace() {
+      assertThat(ApiHelper.splitSearchTerms(" APOE , TREM2 ")).containsExactly("APOE", "TREM2");
+    }
+
+    @Test
+    @DisplayName("should drop blank terms when search has empty segments")
+    void shouldDropBlankTermsWhenSearchHasEmptySegments() {
+      assertThat(ApiHelper.splitSearchTerms("APOE,, ,TREM2")).containsExactly("APOE", "TREM2");
+    }
+
+    @Test
+    @DisplayName("should return empty list when search contains only commas")
+    void shouldReturnEmptyListWhenSearchContainsOnlyCommas() {
+      assertThat(ApiHelper.splitSearchTerms(",,")).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("createCaseInsensitiveFullMatchPatterns")
+  class CreateCaseInsensitiveFullMatchPatterns {
+
+    @Test
+    @DisplayName("should anchor and quote each term when given a comma-separated string")
+    void shouldAnchorAndQuoteEachTermWhenGivenCommaSeparatedString() {
+      List<Pattern> patterns = ApiHelper.createCaseInsensitiveFullMatchPatterns("APOE, TREM2");
+
+      assertThat(patterns)
+        .extracting(Pattern::pattern)
+        .containsExactly("^\\QAPOE\\E$", "^\\QTREM2\\E$");
+      assertThat(patterns).allSatisfy(pattern ->
+        assertThat(pattern.flags() & Pattern.CASE_INSENSITIVE).isNotZero()
+      );
+    }
+
+    @Test
+    @DisplayName("should match the full term regardless of case when the pattern is applied")
+    void shouldMatchFullTermRegardlessOfCaseWhenPatternIsApplied() {
+      Pattern pattern = ApiHelper.createCaseInsensitiveFullMatchPatterns(List.of("APOE")).get(0);
+
+      assertThat(pattern.matcher("apoe").matches()).isTrue();
+      assertThat(pattern.matcher("APOE4").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should quote regex metacharacters when a term contains them")
+    void shouldQuoteRegexMetacharactersWhenTermContainsThem() {
+      Pattern pattern = ApiHelper.createCaseInsensitiveFullMatchPatterns(
+        List.of("Abca7*V1599M")
+      ).get(0);
+
+      assertThat(pattern.matcher("Abca7*V1599M").matches()).isTrue();
+      assertThat(pattern.matcher("Abca77V1599M").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should produce the same patterns for both overloads when terms are equivalent")
+    void shouldProduceSamePatternsForBothOverloadsWhenTermsAreEquivalent() {
+      List<String> fromString = ApiHelper.createCaseInsensitiveFullMatchPatterns(" APOE , TREM2 ")
+        .stream()
+        .map(Pattern::pattern)
+        .toList();
+      List<String> fromList = ApiHelper.createCaseInsensitiveFullMatchPatterns(
+        List.of("APOE", "TREM2")
+      )
+        .stream()
+        .map(Pattern::pattern)
+        .toList();
+
+      assertThat(fromString).isEqualTo(fromList);
+    }
+
+    @Test
+    @DisplayName("should return empty list when the string contains only commas")
+    void shouldReturnEmptyListWhenStringContainsOnlyCommas() {
+      assertThat(ApiHelper.createCaseInsensitiveFullMatchPatterns(",,")).isEmpty();
     }
   }
 }

--- a/libs/explorers/testing/src/lib/e2e/comparison-tool-search.ts
+++ b/libs/explorers/testing/src/lib/e2e/comparison-tool-search.ts
@@ -9,7 +9,7 @@ import {
   searchViaFilterbox,
 } from './comparison-tool';
 
-export async function testPartialCaseInsensitiveSearch(
+export async function expectSearchResults(
   page: Page,
   searchTerm: string,
   expectedMatchNames: string[],


### PR DESCRIPTION
## Description

Searching the Model-AD differential expression comparison tool for a full Ensembl gene ID returned nothing whenever the matching rows also had a `gene_symbol`, because the filterbox only fell back to `ensembl_gene_id` for rows where `gene_symbol` was blank. Users who paste an Ensembl ID (the identifier shown in the table for genes with no symbol, and the one they carry over from other tools) had no way to find those rows. This routes each search term to the field it actually identifies: a term matching `^ENSMUSG\d{11}$` searches `ensembl_gene_id` only, while every other term keeps the existing `gene_symbol`-with-`ensembl_gene_id`-fallback behavior. Routing happens per term, so a comma-separated list can mix gene symbols and Ensembl IDs.

## Related Issue

- [MG-1048](https://sagebionetworks.jira.com/browse/MG-1048)

## Changelog

- Route full Ensembl mouse gene ID search terms to `ensembl_gene_id` in the Model-AD transcriptomics filterbox search, case-insensitively
- Route each term of a comma-separated search independently, so gene symbols and Ensembl IDs can be mixed in one query
- Preserve the existing fallback behavior for every other term, including partial Ensembl IDs
- Add `ApiHelper.splitSearchTerms` and a `List<String>` overload of `createCaseInsensitiveFullMatchPatterns` so callers can inspect terms before building patterns
- Rename the shared e2e helper `testPartialCaseInsensitiveSearch` to `expectSearchResults` and update its call sites across the Agora and Model-AD specs, since the new tests use it for full-match searches and the old name no longer described what it asserts
- Add unit tests for the new search routing and helper methods, plus 6 e2e tests covering the ticket's cases

## Testing

Navigate to the Model-AD differential expression comparison tool at `/comparison/expression?categories=RNA%2520-%2520DIFFERENTIAL%2520EXPRESSION,Tissue%2520-%2520Hemibrain`, then:

- Search `ENSMUSG00000038619` and confirm the `Ensa` rows are returned (this returned no rows before)
- Search `ensmusg00000038619` and confirm the same rows are returned, verifying case-insensitivity
- Search `ENSMUSG00000038619,plec` and confirm both the `Ensa` and `Plec` rows are returned
- Search `ENSMUSG00000037982` (a gene with no symbol) and confirm its rows are returned
- Search `ens` and confirm the partial-match fallback still holds: rows with a gene symbol match on the symbol (`Ensa`) and rows without one match on the Ensembl ID (`ENSMUSG00000037982`)
- Search a plain gene symbol such as `plec` and confirm nothing about the pre-existing partial, case-insensitive search changed

### Preview

Expectations for each search are described in the testing section.

search | dev | this pr 
:---: | :---: | :---: 
`ENSMUSG00000038619` | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/e658a652-3870-477e-a424-033055baf01b" /> | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/1180951e-15f3-45ff-8744-64f4c4e57605" />
`ensmusg00000038619` | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/aee7fef2-3ad1-4948-91b2-f1aa3be559d4" /> | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/87146fea-b29e-4871-bafb-87759861ef46" />
`ENSMUSG00000038619,plec` | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/8da32930-455f-4295-bae5-6c090eab9068" /> | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/d21bc062-7283-4b1b-becc-efe25a17638d" />
`ENSMUSG00000037982` | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/7104e450-c2e4-4afe-8872-125a2e4b35d0" /> | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/2969595a-95a8-4617-aa64-b1124e54ff4a" />
`ens` | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/28648c07-92d8-4fb2-bd52-81b91bc28f9c" /> | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/3a114254-e00d-44d0-b81e-650b9892b5d0" />
`plec` | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/f4e3c6ed-0473-42e0-9107-363b2e0b0d9c" /> | <img width="1665" height="1205" alt="image" src="https://github.com/user-attachments/assets/ce0215b6-be92-4536-8206-55c704a774d9" />

[MG-1048]: https://sagebionetworks.jira.com/browse/MG-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ