### PR TITLE
feat(model-ad): highlight the targeted TOC link and section heading (MG-995)

### DIFF
--- a/apps/model-ad/app/e2e/helpers/model-details.ts
+++ b/apps/model-ad/app/e2e/helpers/model-details.ts
@@ -20,13 +20,16 @@ export function getTocLinks(page: Page) {
   return getTocContainer(page).getByTestId('toc-item-link');
 }
 
+// The highlight is applied after hydration and first paint, which can lag on a cold CI worker.
+const HIGHLIGHT_APPEAR_TIMEOUT_MS = 10000;
+
 // Must exceed ANCHOR_HIGHLIGHT_HOLD_MS in model-details-boxplots-selector.component.ts.
 const HIGHLIGHT_CLEAR_TIMEOUT_MS = 10000;
 
 // All the highlights are asserted before any is waited out, since they share a single hold timer.
 export async function expectHighlightClears(...locators: Locator[]) {
   for (const locator of locators) {
-    await expect(locator).toHaveClass(/highlighted/);
+    await expect(locator).toHaveClass(/highlighted/, { timeout: HIGHLIGHT_APPEAR_TIMEOUT_MS });
   }
   for (const locator of locators) {
     await expect(locator).not.toHaveClass(/highlighted/, { timeout: HIGHLIGHT_CLEAR_TIMEOUT_MS });

--- a/apps/model-ad/app/e2e/helpers/model-details.ts
+++ b/apps/model-ad/app/e2e/helpers/model-details.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, Locator, Page, test } from '@playwright/test';
 
 export function getTocContainer(page: Page) {
   return page.locator('.table-of-contents-container');
@@ -18,6 +18,19 @@ export function getTocList(page: Page) {
 
 export function getTocLinks(page: Page) {
   return getTocContainer(page).getByTestId('toc-item-link');
+}
+
+// Must exceed ANCHOR_HIGHLIGHT_HOLD_MS in model-details-boxplots-selector.component.ts.
+const HIGHLIGHT_CLEAR_TIMEOUT_MS = 10000;
+
+// All the highlights are asserted before any is waited out, since they share a single hold timer.
+export async function expectHighlightClears(...locators: Locator[]) {
+  for (const locator of locators) {
+    await expect(locator).toHaveClass(/highlighted/);
+  }
+  for (const locator of locators) {
+    await expect(locator).not.toHaveClass(/highlighted/, { timeout: HIGHLIGHT_CLEAR_TIMEOUT_MS });
+  }
 }
 
 // Expands the table of contents, then clicks every link and asserts it scrolls to its section.

--- a/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
+++ b/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { baseURL } from '../playwright.config';
 import {
+  expectHighlightClears,
   expectTocLinksScrollToSections,
   getTocExpandButton,
   getTocLinks,
@@ -35,6 +36,14 @@ test.describe('marmoset model details - boxplots selector', () => {
 
     await expect(page.getByRole('heading', { level: 3, name: ageSection })).toBeInViewport();
     await page.waitForURL(`${biomarkersPath}#${ageFragment}`);
+  });
+
+  test('loading a page with an age fragment highlights the age group heading', async ({ page }) => {
+    await page.goto(`${biomarkersPath}#${ageFragment}`);
+
+    await expectHighlightClears(
+      page.getByRole('heading', { level: 3, name: ageSection, exact: true }),
+    );
   });
 
   test('default measurement filter is set when there is no query parameter', async ({ page }) => {

--- a/apps/model-ad/app/e2e/mouse-model-details.spec.ts
+++ b/apps/model-ad/app/e2e/mouse-model-details.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@sagebionetworks/explorers/testing/e2e';
 import { baseURL } from '../playwright.config';
 import {
+  expectHighlightClears,
   expectTocLinksScrollToSections,
   getTocCollapseButton,
   getTocExpandButton,
@@ -361,6 +362,32 @@ test.describe('mouse model details - boxplots selector - table of contents', () 
       page.getByRole('heading', { level: 2, name: section, exact: true }),
     ).toBeInViewport();
     await expect(page).toHaveURL(`${biomarkersPath}#${fragment}`);
+  });
+
+  test('loading a page with an anchor fragment highlights the section heading', async ({
+    page,
+  }) => {
+    const section = 'NfL';
+    await page.goto(`${biomarkersPath}#nfl`);
+
+    await expectHighlightClears(
+      page.getByRole('heading', { level: 2, name: section, exact: true }),
+    );
+  });
+
+  test('clicking a TOC link highlights the link and its section heading', async ({ page }) => {
+    const section = 'NfL';
+
+    await page.goto(biomarkersPath);
+    await getTocExpandButton(page).click();
+
+    const tocLink = getTocLinks(page).filter({ hasText: section });
+    await tocLink.click();
+
+    await expectHighlightClears(
+      tocLink,
+      page.getByRole('heading', { level: 2, name: section, exact: true }),
+    );
   });
 
   test('TOC stays expanded after clicking a link', async ({ page }) => {

--- a/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.html
@@ -7,6 +7,7 @@
   let-setActiveShareLink="setActiveShareLink"
   let-clearActiveShareLink="clearActiveShareLink"
   let-isShareLinkActive="isShareLinkActive"
+  let-isHighlighted="isHighlighted"
 >
   <div
     class="marmoset-legend"
@@ -24,7 +25,7 @@
         (mouseleave)="clearActiveShareLink()"
       >
         <div class="age-group-title">
-          <h3>{{ ageGroup.age }}</h3>
+          <h3 [class.highlighted]="isHighlighted(anchorId)">{{ ageGroup.age }}</h3>
           @if (isShareLinkActive(anchorId)) {
             <explorers-copy-link-button
               [onClick]="copyLinkFn(anchorId)"

--- a/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.scss
@@ -12,6 +12,10 @@
       @include mixins.boxplots-section-title('h3');
 
       margin-bottom: 16px;
+
+      h3.highlighted {
+        @include mixins.anchor-highlight;
+      }
     }
   }
 }

--- a/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { By } from '@angular/platform-browser';
 import { LoggerService, SvgIconService } from '@sagebionetworks/explorers/services';
 import {
   MockWikiComponent,
@@ -8,7 +9,13 @@ import {
 import { ModelData, Sex } from '@sagebionetworks/model-ad/api-client';
 import { marmosetModelDataMock } from '@sagebionetworks/model-ad/testing';
 import { render, screen } from '@testing-library/angular';
+import {
+  ANCHOR_HIGHLIGHT_HOLD_MS,
+  ModelDetailsBoxplotsSelectorComponent,
+} from '../model-details-boxplots-selector/model-details-boxplots-selector.component';
 import { MarmosetModelDetailsBoxplotsSelectorComponent } from './marmoset-model-details-boxplots-selector.component';
+
+const ageGroup = '0-1 year';
 
 async function setup() {
   const { fixture } = await render(MarmosetModelDetailsBoxplotsSelectorComponent, {
@@ -17,11 +24,11 @@ async function setup() {
       title: 'Plasma Biomarkers',
       modelName: 'Presenilin 1',
       modelDataList: marmosetModelDataMock,
-      wikiParams: validWikiParams,
+      wikiParams: validWikiParams[0],
     },
     providers: [provideHttpClient(), { provide: SvgIconService, useClass: SvgIconServiceStub }],
   });
-  return { component: fixture.componentInstance };
+  return { fixture, component: fixture.componentInstance };
 }
 
 describe('MarmosetModelDetailsBoxplotsSelectorComponent', () => {
@@ -72,7 +79,7 @@ describe('MarmosetModelDetailsBoxplotsSelectorComponent', () => {
         title: 'Plasma Biomarkers',
         modelName: 'Presenilin 1',
         modelDataList: duplicateAgeData,
-        wikiParams: validWikiParams,
+        wikiParams: validWikiParams[0],
       },
       providers: [
         provideHttpClient(),
@@ -87,5 +94,26 @@ describe('MarmosetModelDetailsBoxplotsSelectorComponent', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('expected 1 ModelData per age group but got 2'),
     );
+  });
+
+  it('should highlight the age group heading of the highlighted anchor until the hold elapses', async () => {
+    const { fixture, component } = await setup();
+    const base = fixture.debugElement.query(By.directive(ModelDetailsBoxplotsSelectorComponent))
+      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+
+    const heading = screen.getByRole('heading', { level: 3, name: ageGroup });
+    const anchorId = component.generateAnchorId(ageGroup);
+
+    jest.useFakeTimers();
+
+    base.highlightAnchor(anchorId);
+    fixture.detectChanges();
+    expect(heading).toHaveClass('highlighted');
+
+    jest.advanceTimersByTime(ANCHOR_HIGHLIGHT_HOLD_MS);
+    fixture.detectChanges();
+    expect(heading).not.toHaveClass('highlighted');
+
+    jest.useRealTimers();
   });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -72,7 +72,11 @@
       <ul class="table-of-contents" id="toc-list">
         @for (item of tocItems(); track item) {
           <li>
-            <button (click)="scrollToSection(generateAnchorId(item))" data-testid="toc-item-link">
+            <button
+              (click)="scrollToSection(generateAnchorId(item))"
+              [class.highlighted]="isHighlightedFn(generateAnchorId(item))"
+              data-testid="toc-item-link"
+            >
               {{ item | decodeGreekEntity }}
             </button>
           </li>
@@ -92,7 +96,9 @@
       >
         <div class="boxplots-evidence-type-title-bar">
           <div class="boxplots-evidence-type-title">
-            <h2>{{ evidenceType | decodeGreekEntity }}</h2>
+            <h2 [class.highlighted]="isHighlightedFn(generateAnchorId(evidenceType))">
+              {{ evidenceType | decodeGreekEntity }}
+            </h2>
             @if (showSectionShareLink() && activeShareLink() === evidenceType) {
               <explorers-copy-link-button
                 [onClick]="copyShareLinkCallbackFn(evidenceType)"
@@ -127,6 +133,7 @@
               setActiveShareLink: setActiveShareLinkFn,
               clearActiveShareLink: clearActiveShareLinkFn,
               isShareLinkActive: isShareLinkActiveFn,
+              isHighlighted: isHighlightedFn,
             }"
           />
         </div>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -116,9 +116,15 @@
         cursor: pointer;
         text-decoration: underline;
 
+        // focus-visible rather than focus: a mouse click leaves the button focused, which
+        // would hold the emphasis color past the end of the highlight
         &:hover,
-        &:focus {
+        &:focus-visible {
           color: var(--color-action-primary);
+        }
+
+        &.highlighted {
+          @include mixins.anchor-highlight;
         }
       }
     }
@@ -133,6 +139,10 @@
 
     .boxplots-evidence-type-title {
       @include mixins.boxplots-section-title;
+
+      h2.highlighted {
+        @include mixins.anchor-highlight;
+      }
     }
   }
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -12,6 +12,7 @@ import { BoxplotsGridComponent } from '@sagebionetworks/model-ad/ui';
 import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import {
+  ANCHOR_HIGHLIGHT_HOLD_MS,
   FilterConfig,
   ModelDetailsBoxplotsSelectorComponent,
 } from './model-details-boxplots-selector.component';
@@ -53,7 +54,7 @@ class TestHostComponent {
   description = mockDescription;
   modelName = mouseModelMock.name;
   modelDataList: ModelData[] = mouseModelMock.pathology;
-  wikiParams = validWikiParams;
+  wikiParams = validWikiParams[0];
   filterConfig: FilterConfig = mouseFilterConfig;
   anchorDataField: keyof ModelData = 'evidence_type';
 }
@@ -356,6 +357,99 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
         const tocList = screen.queryByRole('list');
         expect(tocList).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('anchor highlight', () => {
+    async function setupWithExpandedToc() {
+      const { fixture } = await setupHost();
+      const base = fixture.debugElement.children[0]
+        .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+      base.isTocCollapsed.set(false);
+      fixture.detectChanges();
+
+      jest.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
+      // PrimeNG rendering needs real timers, so switch to fake timers only after render()
+      jest.useFakeTimers();
+
+      return { fixture, base };
+    }
+
+    function getTocLink(name: string) {
+      return screen
+        .getAllByTestId('toc-item-link')
+        .find((link) => link.textContent?.trim() === name) as HTMLElement;
+    }
+
+    function getSectionHeading(name: string) {
+      return screen.getByRole('heading', { level: 2, name });
+    }
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it('should highlight the TOC link and section heading of the scrolled-to anchor', async () => {
+      const { fixture, base } = await setupWithExpandedToc();
+      const evidenceType = base.evidenceTypes()[0];
+
+      base.scrollToSection(base.generateAnchorId(evidenceType));
+      fixture.detectChanges();
+
+      expect(base.highlightedAnchorId()).toBe(base.generateAnchorId(evidenceType));
+      expect(getTocLink(evidenceType)).toHaveClass('highlighted');
+      expect(getSectionHeading(evidenceType)).toHaveClass('highlighted');
+    });
+
+    it('should clear the highlight after the hold duration', async () => {
+      const { fixture, base } = await setupWithExpandedToc();
+      const evidenceType = base.evidenceTypes()[0];
+
+      base.scrollToSection(base.generateAnchorId(evidenceType));
+      fixture.detectChanges();
+
+      jest.advanceTimersByTime(ANCHOR_HIGHLIGHT_HOLD_MS);
+      fixture.detectChanges();
+
+      expect(base.highlightedAnchorId()).toBe('');
+      expect(getTocLink(evidenceType)).not.toHaveClass('highlighted');
+      expect(getSectionHeading(evidenceType)).not.toHaveClass('highlighted');
+    });
+
+    it('should move the highlight to the newly scrolled-to anchor', async () => {
+      const { fixture, base } = await setupWithExpandedToc();
+      const [firstEvidenceType, secondEvidenceType] = base.evidenceTypes();
+
+      base.scrollToSection(base.generateAnchorId(firstEvidenceType));
+      fixture.detectChanges();
+
+      base.scrollToSection(base.generateAnchorId(secondEvidenceType));
+      fixture.detectChanges();
+
+      expect(getSectionHeading(firstEvidenceType)).not.toHaveClass('highlighted');
+      expect(getSectionHeading(secondEvidenceType)).toHaveClass('highlighted');
+    });
+
+    it('should restart the hold on the newly scrolled-to anchor rather than inheriting the previous deadline', async () => {
+      const partialHoldMs = ANCHOR_HIGHLIGHT_HOLD_MS / 2;
+      const { fixture, base } = await setupWithExpandedToc();
+      const [firstEvidenceType, secondEvidenceType] = base.evidenceTypes();
+
+      base.scrollToSection(base.generateAnchorId(firstEvidenceType));
+      fixture.detectChanges();
+
+      jest.advanceTimersByTime(partialHoldMs);
+      base.scrollToSection(base.generateAnchorId(secondEvidenceType));
+      fixture.detectChanges();
+
+      jest.advanceTimersByTime(partialHoldMs);
+      fixture.detectChanges();
+      expect(getSectionHeading(secondEvidenceType)).toHaveClass('highlighted');
+
+      jest.advanceTimersByTime(partialHoldMs);
+      fixture.detectChanges();
+      expect(getSectionHeading(secondEvidenceType)).not.toHaveClass('highlighted');
     });
   });
 });

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -29,6 +29,8 @@ import { ButtonModule } from 'primeng/button';
 import { SelectModule } from 'primeng/select';
 import { generateAnchorId } from '../../utils';
 
+export const ANCHOR_HIGHLIGHT_HOLD_MS = 3000;
+
 export interface FilterConfig {
   label: string;
   queryParamKey: string;
@@ -43,6 +45,7 @@ export interface SectionContext<T = ModelData[]> {
   setActiveShareLink: (id: string) => void;
   clearActiveShareLink: () => void;
   isShareLinkActive: (anchorId: string) => boolean;
+  isHighlighted: (anchorId: string) => boolean;
 }
 
 @Component({
@@ -120,6 +123,9 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
   activeShareLink = signal('');
   lastShareLinkCopied = signal('');
 
+  highlightedAnchorId = signal('');
+  private highlightTimeoutId?: ReturnType<typeof setTimeout>;
+
   isTocCollapsed = signal(true);
 
   constructor() {
@@ -168,6 +174,9 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
   ngOnDestroy(): void {
     if (this.platformService.isBrowser) {
       window.removeEventListener('popstate', this.onPopState);
+    }
+    if (this.highlightTimeoutId) {
+      clearTimeout(this.highlightTimeoutId);
     }
   }
 
@@ -358,10 +367,24 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
 
         if (updateUrl) this.updateUrlFragment(anchorId);
 
+        this.highlightAnchor(anchorId);
+
         return true;
       }
     }
     return false;
+  }
+
+  highlightAnchor(anchorId: string): void {
+    if (this.highlightTimeoutId) {
+      clearTimeout(this.highlightTimeoutId);
+    }
+
+    this.highlightedAnchorId.set(anchorId);
+
+    this.highlightTimeoutId = setTimeout(() => {
+      this.highlightedAnchorId.set('');
+    }, ANCHOR_HIGHLIGHT_HOLD_MS);
   }
 
   getShareLinkTooltipText = (label: string): string => {
@@ -390,6 +413,10 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
 
   isShareLinkActiveFn = (anchorId: string): boolean => {
     return this.activeShareLink() === anchorId;
+  };
+
+  isHighlightedFn = (anchorId: string): boolean => {
+    return this.highlightedAnchorId() === anchorId;
   };
 
   decodeHtmlEntities(text: string): string {

--- a/libs/model-ad/model-details/src/lib/components/mouse-model-details-boxplots-selector/mouse-model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/mouse-model-details-boxplots-selector/mouse-model-details-boxplots-selector.component.spec.ts
@@ -18,7 +18,7 @@ async function setup() {
       modelName: mouseModelMock.name,
       modelControls: mouseModelMock.matched_controls,
       modelDataList: mouseModelMock.pathology,
-      wikiParams: validWikiParams,
+      wikiParams: validWikiParams[0],
     },
     providers: [provideHttpClient(), { provide: SvgIconService, useClass: SvgIconServiceStub }],
   });
@@ -90,7 +90,7 @@ describe('MouseModelDetailsBoxplotsSelectorComponent', () => {
         modelName: 'ModelName (Some Qualifier)',
         modelControls: ['Control1', 'Control2'],
         modelDataList: mockModelDataList,
-        wikiParams: validWikiParams,
+        wikiParams: validWikiParams[0],
       },
       providers: [provideHttpClient(), { provide: SvgIconService, useClass: SvgIconServiceStub }],
     });

--- a/libs/model-ad/styles/src/lib/_mixins.scss
+++ b/libs/model-ad/styles/src/lib/_mixins.scss
@@ -65,3 +65,10 @@
     margin-bottom: 0;
   }
 }
+
+@mixin anchor-highlight {
+  color: var(--color-action-primary);
+  font-weight: 900;
+  text-decoration-line: underline;
+  text-decoration-thickness: 10.5%;
+}


### PR DESCRIPTION
## Description

Clicking a table of contents link or landing on a model details page with a hash fragment scrolls to the right section, but nothing confirms which section was targeted. On pages with many similarly shaped boxplot headings, a reader who arrives mid-page has to re-read the heading to work out where they landed. This adds a transient emphasis to the targeted TOC link and section heading that holds for three seconds and then drops, so the destination is unmistakable without leaving permanent styling on the page.

## Related Issue

- [MG-995](https://sagebionetworks.jira.com/browse/MG-995)

## Changelog

- Highlight the targeted TOC link and section heading for three seconds on TOC clicks, hash fragments on load, and popstate navigation, covering both mouse section headings and marmoset age-group headings
- Restart the hold when a new anchor is targeted, and clear the pending timer when the component is destroyed
- Switch the TOC link's emphasis trigger from `:focus` to `:focus-visible` so a mouse click no longer leaves the link colored after the highlight drops

## Testing

- Open a mouse model details page such as `/models/3xTg-AD/biomarkers`, expand the table of contents, click a link, and confirm both the link and its section heading emphasize for about three seconds and then return to their normal styling
- Load an anchored URL directly, e.g. `/models/3xTg-AD/biomarkers#nfl`, and confirm the section heading highlights on arrival with no TOC interaction
- Repeat on a marmoset page, e.g. `/models/Presenilin%201/biomarkers?modelOrganism=marmoset#0-1-year`, and confirm the age-group heading highlights
- Click several TOC links in quick succession and confirm only the most recently clicked section is highlighted, and that it holds for a full three seconds measured from the last click rather than expiring early
- Tab to a TOC link and press Enter, then confirm the keyboard focus indicator still reads as a sensible focus affordance once the highlight has dropped

### Preview

### Mouse model details page

On load: 

https://github.com/user-attachments/assets/0040ca9f-be06-4223-b478-38572364c44b

On clicking TOC link:

https://github.com/user-attachments/assets/bb54952b-78f0-43e3-bd12-3166974e00dd

### Marmoset model details page

On load: 

https://github.com/user-attachments/assets/4a8c93b8-5642-43b9-a3dd-e4ee6591c238

On clicking TOC link: 

https://github.com/user-attachments/assets/188a9bb8-ef73-439d-8541-ca4f0d52b1b3



[MG-995]: https://sagebionetworks.jira.com/browse/MG-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ