### PR TITLE
feat(model-ad): update meta tags (MG-221)

### DIFF
--- a/apps/model-ad/app/src/app/app.routes.ts
+++ b/apps/model-ad/app/src/app/app.routes.ts
@@ -5,6 +5,9 @@ import { resolveModelOrganism } from '@sagebionetworks/model-ad/util';
 import { capitalizeFirstLetter } from '@sagebionetworks/shared/util';
 import { modelOrganismGuard } from './model-organism.guard';
 
+const DEFAULT_META_DESCRIPTION =
+  "Discover next-generation models of Alzheimer's Disease developed by the MODEL-AD consortium and MARMO-AD.";
+
 const modelDetailsData = {
   title: (route: ActivatedRouteSnapshot) => {
     const organism = resolveModelOrganism(route.queryParams['modelOrganism']);
@@ -22,8 +25,7 @@ export const routes: Route[] = [
     loadChildren: () => import('@sagebionetworks/model-ad/home').then((routes) => routes.routes),
     data: {
       title: 'Model AD Explorer',
-      description:
-        "Discover next-generation mouse models of Alzheimer's Disease from the MODEL-AD Consortium.",
+      description: DEFAULT_META_DESCRIPTION,
     },
   },
   {
@@ -65,7 +67,7 @@ export const routes: Route[] = [
     data: {
       title: "Marmoset Model Overview | Overview of marmoset models of Alzheimer's Disease",
       description:
-        "Explore emerging marmoset models of Alzheimer's Disease developed by the Marmo-AD consortium.",
+        "Explore emerging marmoset models of Alzheimer's Disease developed by the MARMO-AD consortium.",
     },
   },
   {
@@ -152,8 +154,7 @@ export const routes: Route[] = [
       import('@sagebionetworks/explorers/shared').then((routes) => routes.notFoundRoute),
     data: {
       title: 'Model AD Explorer | Page Not Found',
-      description:
-        "Discover next-generation mouse models of Alzheimer's Disease from the MODEL-AD Consortium.",
+      description: DEFAULT_META_DESCRIPTION,
       supportEmail: SUPPORT_EMAIL,
     },
   },

--- a/apps/model-ad/app/src/index.html
+++ b/apps/model-ad/app/src/index.html
@@ -5,7 +5,7 @@
     <title>Model AD Explorer</title>
     <meta
       name="description"
-      content="Explore gene expression, pathology, and biomarker data for next generation mouse models of Alzheimer's disease developed by the MODEL-AD consortium."
+      content="Discover next-generation models of Alzheimer's Disease developed by the MODEL-AD consortium and MARMO-AD."
     />
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -24,7 +24,7 @@
     <meta property="og:title" content="Model AD Explorer" />
     <meta
       property="og:description"
-      content="Explore gene expression, pathology, and biomarker data for next generation mouse models of Alzheimer's disease developed by the MODEL-AD consortium."
+      content="Discover next-generation models of Alzheimer's Disease developed by the MODEL-AD consortium and MARMO-AD."
     />
     <meta
       property="og:image"
@@ -38,7 +38,7 @@
     <meta name="twitter:title" content="Model AD Explorer" />
     <meta
       name="twitter:description"
-      content="Explore gene expression, pathology, and biomarker data for next generation mouse models of Alzheimer's disease developed by the MODEL-AD consortium."
+      content="Discover next-generation models of Alzheimer's Disease developed by the MODEL-AD consortium and MARMO-AD."
     />
     <meta
       name="twitter:image"


### PR DESCRIPTION
## Description

The Model AD Explorer now hosts marmoset models alongside mouse models, but its meta descriptions still described the site as covering mouse models from the MODEL-AD Consortium only. This updates the site-wide and route-level descriptions to reflect both consortia (MODEL-AD and MARMO-AD), so search results and social link previews accurately represent what the explorer offers. It also corrects the MARMO-AD consortium name casing on the marmoset model overview route.

## Related Issue

- [MG-221](https://sagebionetworks.jira.com/browse/MG-221) — Update page-specific meta tags
  - Parent epic: [MG-926](https://sagebionetworks.jira.com/browse/MG-926) — Extend Home page to support marmosets

## Changelog

- Update the meta description for the home and not-found routes to cover both MODEL-AD and MARMO-AD models
- Extract the shared description into a `DEFAULT_META_DESCRIPTION` constant so both routes stay in sync
- Update the static `description`, `og:description`, and `twitter:description` tags in `index.html` to match
- Fix the consortium name casing on the marmoset model overview route (`Marmo-AD` → `MARMO-AD`)

## Testing

- Serve the Model AD app, navigate to the home page, and confirm the rendered `<meta name="description">` reads "Discover next-generation models of Alzheimer's Disease developed by the MODEL-AD consortium and MARMO-AD."
- Navigate to a nonexistent route (e.g. `/does-not-exist`) and confirm the not-found page carries the same description and the title "Model AD Explorer | Page Not Found".
- Navigate to the marmoset model overview page and confirm the description reads "Explore emerging marmoset models of Alzheimer's Disease developed by the MARMO-AD consortium."



[MG-221]: https://sagebionetworks.jira.com/browse/MG-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-926]: https://sagebionetworks.jira.com/browse/MG-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ