### PR TITLE
feat(model-ad): make model details toc entries behave like links (MG-1073, MG-1075, MG-1076)

### DIFF
--- a/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
+++ b/apps/model-ad/app/e2e/differential-expression-comparison-tool.spec.ts
@@ -399,7 +399,7 @@ test.describe('differential expression', () => {
 
   test('link for model with special characters opens model details page', async ({ page }) => {
     const specialModel = '5xFAD (IU/Jax/Pitt)';
-    const specialModelEncoded = '5xFAD%20%28IU%2FJax%2FPitt%29';
+    const specialModelEncoded = '5xFAD%20%2528IU%252FJax%252FPitt%2529';
 
     await navigateToComparison(page, CT_PAGE, true);
 

--- a/apps/model-ad/app/e2e/helpers/model-details.ts
+++ b/apps/model-ad/app/e2e/helpers/model-details.ts
@@ -17,7 +17,11 @@ export function getTocList(page: Page) {
 }
 
 export function getTocLinks(page: Page) {
-  return getTocContainer(page).getByTestId('toc-item-link');
+  return getTocContainer(page).getByRole('link');
+}
+
+export function getTocLink(page: Page, name: string) {
+  return getTocContainer(page).getByRole('link', { name, exact: true });
 }
 
 // The highlight is applied after hydration and first paint, which can lag on a cold CI worker.

--- a/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
+++ b/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
@@ -79,7 +79,7 @@ test.describe('marmoset model details - boxplots selector', () => {
     await expect(
       newTab.getByRole('heading', { level: 3, name: ageSection, exact: true }),
     ).toBeInViewport();
-    await expectPageNotAtTop(page);
+    await expectPageNotAtTop(newTab);
   });
 
   test('loading a page with an age fragment highlights the age group heading', async ({ page }) => {

--- a/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
+++ b/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { expectPageNotAtTop } from '@sagebionetworks/explorers/testing/e2e';
 import { baseURL } from '../playwright.config';
 import {
   expectHighlightClears,
@@ -10,6 +11,7 @@ import {
 test.describe('marmoset model details - boxplots selector', () => {
   const model = 'Presenilin 1';
   const biomarkersPath = '/models/Presenilin%201/biomarkers?modelOrganism=marmoset';
+  const noTabPath = '/models/Presenilin%201?modelOrganism=marmoset';
   const measurementDefault = 'Soluble Aβ40';
   const measurementOther = 'Insoluble Aβ42';
   const ageSection = '0-1 year';
@@ -25,6 +27,27 @@ test.describe('marmoset model details - boxplots selector', () => {
     await expect(
       page.getByRole('heading', { level: 3, name: ageSection, exact: true }),
     ).toBeInViewport();
+    await expectPageNotAtTop(page);
+  });
+
+  test('age group section is shown when a url with no tab segment includes an age fragment', async ({
+    page,
+  }) => {
+    await page.goto(`${noTabPath}#${ageFragment}`);
+    await expect(
+      page.getByRole('heading', { level: 3, name: ageSection, exact: true }),
+    ).toBeInViewport();
+    await expectPageNotAtTop(page);
+    await page.waitForURL(`${noTabPath}#${ageFragment}`);
+  });
+
+  test('filters are set from query parameters when the url has no tab segment', async ({
+    page,
+  }) => {
+    const sexFilter = 'Female';
+    await page.goto(`${noTabPath}&sex=${sexFilter}`);
+    await expect(page.getByRole('combobox', { name: sexFilter })).toBeVisible();
+    await page.waitForURL(`${noTabPath}&sex=${sexFilter}`);
   });
 
   test('clicking on an age group adds fragment to url', async ({ page }) => {

--- a/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
+++ b/apps/model-ad/app/e2e/marmoset-model-details.spec.ts
@@ -5,7 +5,7 @@ import {
   expectHighlightClears,
   expectTocLinksScrollToSections,
   getTocExpandButton,
-  getTocLinks,
+  getTocLink,
 } from './helpers/model-details';
 
 test.describe('marmoset model details - boxplots selector', () => {
@@ -55,10 +55,31 @@ test.describe('marmoset model details - boxplots selector', () => {
     await expect(page.getByRole('heading', { level: 1, name: model })).toBeVisible();
 
     await getTocExpandButton(page).click();
-    await getTocLinks(page).filter({ hasText: ageSection }).click();
+    await getTocLink(page, ageSection).click();
 
     await expect(page.getByRole('heading', { level: 3, name: ageSection })).toBeInViewport();
     await page.waitForURL(`${biomarkersPath}#${ageFragment}`);
+  });
+
+  test('TOC link on a url with no tab segment opens the age group in a new tab', async ({
+    page,
+    context,
+  }) => {
+    await page.goto(noTabPath);
+    await getTocExpandButton(page).click();
+
+    const tocLink = getTocLink(page, ageSection);
+    await expect(tocLink).toHaveAttribute('href', `${noTabPath}#${ageFragment}`);
+
+    const newTabPromise = context.waitForEvent('page');
+    await tocLink.click({ modifiers: ['ControlOrMeta'] });
+    const newTab = await newTabPromise;
+
+    await expect(newTab).toHaveURL(`${noTabPath}#${ageFragment}`);
+    await expect(
+      newTab.getByRole('heading', { level: 3, name: ageSection, exact: true }),
+    ).toBeInViewport();
+    await expectPageNotAtTop(page);
   });
 
   test('loading a page with an age fragment highlights the age group heading', async ({ page }) => {

--- a/apps/model-ad/app/e2e/mouse-model-details.spec.ts
+++ b/apps/model-ad/app/e2e/mouse-model-details.spec.ts
@@ -410,7 +410,7 @@ test.describe('mouse model details - boxplots selector - table of contents', () 
     await expect(
       newTab.getByRole('heading', { level: 2, name: section, exact: true }),
     ).toBeInViewport();
-    await expectPageNotAtTop(page);
+    await expectPageNotAtTop(newTab);
   });
 
   test('clicking a TOC link moves focus to its section heading', async ({ page }) => {

--- a/apps/model-ad/app/e2e/mouse-model-details.spec.ts
+++ b/apps/model-ad/app/e2e/mouse-model-details.spec.ts
@@ -13,6 +13,7 @@ import {
   expectTocLinksScrollToSections,
   getTocCollapseButton,
   getTocExpandButton,
+  getTocLink,
   getTocLinks,
   getTocList,
 } from './helpers/model-details';
@@ -296,8 +297,7 @@ test.describe('mouse model details - boxplots selector - table of contents', () 
     await expect(page.getByRole('heading', { level: 1, name: testModel })).toBeVisible();
 
     await getTocExpandButton(page).click();
-    const nflButton = getTocLinks(page).filter({ hasText: section });
-    await nflButton.click();
+    await getTocLink(page, section).click();
 
     await expect(page.getByRole('heading', { level: 2, name: section })).toBeInViewport();
     await page.waitForURL(`${biomarkersPath}#${fragment}`);
@@ -311,8 +311,7 @@ test.describe('mouse model details - boxplots selector - table of contents', () 
     await expect(page.getByRole('heading', { level: 1, name: testModel })).toBeVisible();
 
     await getTocExpandButton(page).click();
-    const nflButton = getTocLinks(page).filter({ hasText: section });
-    await nflButton.click();
+    await getTocLink(page, section).click();
 
     await expect(page.getByRole('heading', { level: 2, name: section })).toBeInViewport();
     await page.waitForURL(`${biomarkersPath}#${fragment}`);
@@ -381,13 +380,48 @@ test.describe('mouse model details - boxplots selector - table of contents', () 
     await page.goto(biomarkersPath);
     await getTocExpandButton(page).click();
 
-    const tocLink = getTocLinks(page).filter({ hasText: section });
+    const tocLink = getTocLink(page, section);
     await tocLink.click();
 
     await expectHighlightClears(
       tocLink,
       page.getByRole('heading', { level: 2, name: section, exact: true }),
     );
+  });
+
+  test('TOC link href points at the current panel URL and opens it in a new tab', async ({
+    page,
+    context,
+  }) => {
+    const section = 'NfL';
+    const fragment = 'nfl';
+
+    await page.goto(biomarkersPath);
+    await getTocExpandButton(page).click();
+
+    const tocLink = getTocLink(page, section);
+    await expect(tocLink).toHaveAttribute('href', `${biomarkersPath}#${fragment}`);
+
+    const newTabPromise = context.waitForEvent('page');
+    await tocLink.click({ modifiers: ['ControlOrMeta'] });
+    const newTab = await newTabPromise;
+
+    await expect(newTab).toHaveURL(`${biomarkersPath}#${fragment}`);
+    await expect(
+      newTab.getByRole('heading', { level: 2, name: section, exact: true }),
+    ).toBeInViewport();
+    await expectPageNotAtTop(page);
+  });
+
+  test('clicking a TOC link moves focus to its section heading', async ({ page }) => {
+    const section = 'NfL';
+
+    await page.goto(biomarkersPath);
+    await getTocExpandButton(page).click();
+
+    await getTocLink(page, section).click();
+
+    await expect(page.getByRole('heading', { level: 2, name: section, exact: true })).toBeFocused();
   });
 
   test('TOC stays expanded after clicking a link', async ({ page }) => {
@@ -555,7 +589,7 @@ test.describe('mouse model details - boxplots selector - share links - updates',
 
     await getTocExpandButton(page).click();
 
-    await page.getByRole('button', { name: 'Soluble Aβ42', exact: true }).click();
+    await getTocLink(page, 'Soluble Aβ42').click();
     await page.waitForURL(`${pathWithParams}#soluble-abeta42`);
   });
 

--- a/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/marmoset-model-details-boxplots-selector/marmoset-model-details-boxplots-selector.component.spec.ts
@@ -1,4 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
+import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { LoggerService, SvgIconService } from '@sagebionetworks/explorers/services';
 import {
@@ -31,7 +32,18 @@ async function setup() {
   return { fixture, component: fixture.componentInstance };
 }
 
+function getBaseComponent(
+  fixture: ComponentFixture<MarmosetModelDetailsBoxplotsSelectorComponent>,
+) {
+  return fixture.debugElement.query(By.directive(ModelDetailsBoxplotsSelectorComponent))
+    .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+}
+
 describe('MarmosetModelDetailsBoxplotsSelectorComponent', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should render title', async () => {
     await setup();
     expect(screen.getByRole('heading', { level: 2, name: 'Plasma Biomarkers' })).toBeVisible();
@@ -96,10 +108,19 @@ describe('MarmosetModelDetailsBoxplotsSelectorComponent', () => {
     );
   });
 
+  it('should move focus to the age group heading when scrolling to its anchor', async () => {
+    const { fixture, component } = await setup();
+    const base = getBaseComponent(fixture);
+    jest.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
+
+    base.scrollToSection(component.generateAnchorId(ageGroup));
+
+    expect(screen.getByRole('heading', { level: 3, name: ageGroup })).toHaveFocus();
+  });
+
   it('should highlight the age group heading of the highlighted anchor until the hold elapses', async () => {
     const { fixture, component } = await setup();
-    const base = fixture.debugElement.query(By.directive(ModelDetailsBoxplotsSelectorComponent))
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
 
     const heading = screen.getByRole('heading', { level: 3, name: ageGroup });
     const anchorId = component.generateAnchorId(ageGroup);

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.html
@@ -72,13 +72,13 @@
       <ul class="table-of-contents" id="toc-list">
         @for (item of tocItems(); track item) {
           <li>
-            <button
-              (click)="scrollToSection(generateAnchorId(item))"
+            <a
+              [href]="tocLinkHref(item)"
+              (click)="onTocLinkClick($event, generateAnchorId(item))"
               [class.highlighted]="isHighlightedFn(generateAnchorId(item))"
-              data-testid="toc-item-link"
             >
               {{ item | decodeGreekEntity }}
-            </button>
+            </a>
           </li>
         }
       </ul>

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.scss
@@ -105,19 +105,13 @@
     li {
       padding-bottom: 10px;
 
-      button {
-        background: none;
-        border: none;
-        padding: 0;
+      a {
         color: var(--color-text);
         font-weight: 700;
         font-size: 18px;
         line-height: 20px;
-        cursor: pointer;
         text-decoration: underline;
 
-        // focus-visible rather than focus: a mouse click leaves the button focused, which
-        // would hold the emphasis color past the end of the highlight
         &:hover,
         &:focus-visible {
           color: var(--color-action-primary);

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.spec.ts
@@ -1,5 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { Component } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
 import { SvgIconService } from '@sagebionetworks/explorers/services';
 import {
   MockWikiComponent,
@@ -9,7 +10,7 @@ import {
 import { ModelData, Sex } from '@sagebionetworks/model-ad/api-client';
 import { mouseModelMock } from '@sagebionetworks/model-ad/testing';
 import { BoxplotsGridComponent } from '@sagebionetworks/model-ad/ui';
-import { render, screen, waitFor } from '@testing-library/angular';
+import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import {
   ANCHOR_HIGHLIGHT_HOLD_MS,
@@ -69,7 +70,35 @@ async function setupHost(overrides: Partial<TestHostComponent> = {}) {
   return { fixture, host: fixture.componentInstance, user };
 }
 
+function getBaseComponent(fixture: ComponentFixture<TestHostComponent>) {
+  return fixture.debugElement.children[0]
+    .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+}
+
+async function setupWithExpandedToc(overrides: Partial<TestHostComponent> = {}) {
+  const { fixture, user } = await setupHost(overrides);
+  const base = getBaseComponent(fixture);
+  base.isTocCollapsed.set(false);
+  fixture.detectChanges();
+
+  const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
+
+  return { fixture, base, user, scrollToSpy };
+}
+
+function getTocLink(name: string) {
+  return screen.getByRole('link', { name });
+}
+
+function getSectionHeading(name: string) {
+  return screen.getByRole('heading', { level: 2, name });
+}
+
 describe('ModelDetailsBoxplotsSelectorComponent', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should render title', async () => {
     await setupHost();
     expect(screen.getByRole('heading', { level: 2, name: mockTitle })).toBeVisible();
@@ -107,9 +136,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
 
   it('should convert label to anchor id', async () => {
     const { fixture } = await setupHost();
-    // Access the base component instance through the host's child
-    const base = fixture.debugElement.children[0]
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
     expect(base.generateAnchorId('Amyloid Beta')).toBe('amyloid-beta');
     expect(base.generateAnchorId('Insoluble A&beta;42')).toBe('insoluble-abeta42');
     expect(base.generateAnchorId('Tau-pS396')).toBe('tau-ps396');
@@ -120,8 +147,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
 
   it('should decode HTML entities correctly', async () => {
     const { fixture } = await setupHost();
-    const base = fixture.debugElement.children[0]
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
     expect(base.decodeHtmlEntities('A&beta;42')).toBe('Abeta42');
     expect(base.decodeHtmlEntities('&alpha;-&gamma; test')).toBe('alpha-gamma test');
     expect(base.decodeHtmlEntities('no entities here')).toBe('no entities here');
@@ -130,8 +156,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
 
   it('should generate boxplots filename correctly', async () => {
     const { fixture } = await setupHost();
-    const base = fixture.debugElement.children[0]
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
     expect(
       base.generateBoxplotsFilename(
         'Insoluble A&beta;40',
@@ -160,8 +185,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
 
   it('should not duplicate evidenceType in filename when it matches filterValue', async () => {
     const { fixture } = await setupHost();
-    const base = fixture.debugElement.children[0]
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
     expect(
       base.generateBoxplotsFilename(
         'Soluble A&beta;40',
@@ -193,8 +217,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
       componentProperties: { modelDataList: mockModelDataList },
       providers: [provideHttpClient(), { provide: SvgIconService, useClass: SvgIconServiceStub }],
     });
-    const base = fixture.debugElement.children[0]
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
 
     await waitFor(() => expect(base.selectedFilterOption()).toBe('Brain'));
 
@@ -259,8 +282,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
       },
       providers: [provideHttpClient(), { provide: SvgIconService, useClass: SvgIconServiceStub }],
     });
-    const base = fixture.debugElement.children[0]
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
 
     await waitFor(() => expect(base.selectedFilterOption()).toBe('Soluble A40'));
 
@@ -280,8 +302,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
 
   it('should generate boxplots zip filename correctly', async () => {
     const { fixture } = await setupHost();
-    const base = fixture.debugElement.children[0]
-      .componentInstance as ModelDetailsBoxplotsSelectorComponent;
+    const base = getBaseComponent(fixture);
     expect(
       base.generateBoxplotsZipFilename(
         'Cerebral Cortex',
@@ -360,38 +381,52 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     });
   });
 
-  describe('anchor highlight', () => {
-    async function setupWithExpandedToc() {
-      const { fixture } = await setupHost();
-      const base = fixture.debugElement.children[0]
-        .componentInstance as ModelDetailsBoxplotsSelectorComponent;
-      base.isTocCollapsed.set(false);
-      fixture.detectChanges();
+  describe('TOC link navigation', () => {
+    it('should render TOC items as links to the current page plus their section anchor', async () => {
+      const { base } = await setupWithExpandedToc();
+      const evidenceType = base.evidenceTypes()[0];
 
-      jest.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
+      expect(getTocLink(evidenceType)).toHaveAttribute(
+        'href',
+        `${window.location.pathname}#${base.generateAnchorId(evidenceType)}`,
+      );
+    });
+
+    it('should move focus to the section heading when a TOC link is clicked', async () => {
+      const { base, user } = await setupWithExpandedToc();
+      const evidenceType = base.evidenceTypes()[0];
+
+      await user.click(getTocLink(evidenceType));
+
+      expect(getSectionHeading(evidenceType)).toHaveFocus();
+    });
+
+    it('should leave a modified click to the browser so the link can open in a new tab', async () => {
+      const { base, scrollToSpy } = await setupWithExpandedToc();
+      const evidenceType = base.evidenceTypes()[0];
+      scrollToSpy.mockClear();
+
+      fireEvent.click(getTocLink(evidenceType), { metaKey: true });
+
+      expect(scrollToSpy).not.toHaveBeenCalled();
+      expect(getSectionHeading(evidenceType)).not.toHaveFocus();
+    });
+  });
+
+  describe('anchor highlight', () => {
+    async function setupWithFakeTimers() {
+      const setup = await setupWithExpandedToc();
       // PrimeNG rendering needs real timers, so switch to fake timers only after render()
       jest.useFakeTimers();
-
-      return { fixture, base };
-    }
-
-    function getTocLink(name: string) {
-      return screen
-        .getAllByTestId('toc-item-link')
-        .find((link) => link.textContent?.trim() === name) as HTMLElement;
-    }
-
-    function getSectionHeading(name: string) {
-      return screen.getByRole('heading', { level: 2, name });
+      return setup;
     }
 
     afterEach(() => {
       jest.useRealTimers();
-      jest.restoreAllMocks();
     });
 
     it('should highlight the TOC link and section heading of the scrolled-to anchor', async () => {
-      const { fixture, base } = await setupWithExpandedToc();
+      const { fixture, base } = await setupWithFakeTimers();
       const evidenceType = base.evidenceTypes()[0];
 
       base.scrollToSection(base.generateAnchorId(evidenceType));
@@ -403,7 +438,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     });
 
     it('should clear the highlight after the hold duration', async () => {
-      const { fixture, base } = await setupWithExpandedToc();
+      const { fixture, base } = await setupWithFakeTimers();
       const evidenceType = base.evidenceTypes()[0];
 
       base.scrollToSection(base.generateAnchorId(evidenceType));
@@ -418,7 +453,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
     });
 
     it('should move the highlight to the newly scrolled-to anchor', async () => {
-      const { fixture, base } = await setupWithExpandedToc();
+      const { fixture, base } = await setupWithFakeTimers();
       const [firstEvidenceType, secondEvidenceType] = base.evidenceTypes();
 
       base.scrollToSection(base.generateAnchorId(firstEvidenceType));
@@ -433,7 +468,7 @@ describe('ModelDetailsBoxplotsSelectorComponent', () => {
 
     it('should restart the hold on the newly scrolled-to anchor rather than inheriting the previous deadline', async () => {
       const partialHoldMs = ANCHOR_HIGHLIGHT_HOLD_MS / 2;
-      const { fixture, base } = await setupWithExpandedToc();
+      const { fixture, base } = await setupWithFakeTimers();
       const [firstEvidenceType, secondEvidenceType] = base.evidenceTypes();
 
       base.scrollToSection(base.generateAnchorId(firstEvidenceType));

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -314,7 +314,7 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
 
   getUpdatedUrlFragment(fragment: string | undefined): string {
     const fragmentPart = fragment ? `#${fragment}` : '';
-    return `${window.location.pathname}${window.location.search}${fragmentPart}`;
+    return `${this.location.path()}${fragmentPart}`;
   }
 
   updateUrlFragment(fragment: string | undefined): void {
@@ -387,13 +387,14 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
     // A bare `#fragment` href resolves against `<base href="/">` and lands on the home page, and
     // routerLink can't supply the current URL because the panel segment is set with replaceState
     return this.location.prepareExternalUrl(
-      `${this.location.path()}#${this.generateAnchorId(item)}`,
+      this.getUpdatedUrlFragment(this.generateAnchorId(item)),
     );
   }
 
   onTocLinkClick(event: MouseEvent, anchorId: string): void {
-    // Let the browser handle modified clicks so the link can still be opened in a new tab
-    if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+    // Let the browser handle modified clicks so the link can still be opened in a new tab,
+    // window, or download
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 
     event.preventDefault();
     this.scrollToSection(anchorId);

--- a/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-boxplots-selector/model-details-boxplots-selector.component.ts
@@ -31,6 +31,8 @@ import { generateAnchorId } from '../../utils';
 
 export const ANCHOR_HIGHLIGHT_HOLD_MS = 3000;
 
+const SECTION_HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
+
 export interface FilterConfig {
   label: string;
   queryParamKey: string;
@@ -367,12 +369,34 @@ export class ModelDetailsBoxplotsSelectorComponent implements OnInit, OnDestroy 
 
         if (updateUrl) this.updateUrlFragment(anchorId);
 
+        // Focus the section's title heading rather than the section wrapper, which has no
+        // accessible name to announce. preventScroll keeps focus from cancelling the smooth
+        // scroll started above
+        const focusTarget = element.querySelector<HTMLElement>(SECTION_HEADING_SELECTOR) ?? element;
+        focusTarget.tabIndex = -1;
+        focusTarget.focus({ preventScroll: true });
         this.highlightAnchor(anchorId);
 
         return true;
       }
     }
     return false;
+  }
+
+  tocLinkHref(item: string): string {
+    // A bare `#fragment` href resolves against `<base href="/">` and lands on the home page, and
+    // routerLink can't supply the current URL because the panel segment is set with replaceState
+    return this.location.prepareExternalUrl(
+      `${this.location.path()}#${this.generateAnchorId(item)}`,
+    );
+  }
+
+  onTocLinkClick(event: MouseEvent, anchorId: string): void {
+    // Let the browser handle modified clicks so the link can still be opened in a new tab
+    if (event.metaKey || event.ctrlKey || event.shiftKey) return;
+
+    event.preventDefault();
+    this.scrollToSection(anchorId);
   }
 
   highlightAnchor(anchorId: string): void {

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -158,8 +158,9 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   /**
    * Specifies the active panel when either no panel is specified in the path or when the specified
    * panel is disabled or doesn't exist.
-   * If no panel is specified, then use the default panel and retain all query parameters and hash
-   * fragments.
+   * If no panel is specified, then use the default panel and leave the URL untouched, retaining all
+   * query parameters and hash fragments. modelOrganism does not need appending here because
+   * modelOrganismGuard has already redirected the URL to carry it.
    * If a disabled or invalid panel is specified, then drop the query parameters and hash fragment
    * (other than the required modelOrganism query parameter).
    */
@@ -170,7 +171,7 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
     this.activePanel = fallback.activePanel;
     this.activeParent = fallback.activeParent;
 
-    if (params.get('tab') ?? params.get('subtab')) {
+    if (params.has('tab')) {
       this.location.replaceState(this.appendModelOrganism(this.getUrlBasePath()));
       this.maybeScrollToPanelNavElementOnInitialLoad = false;
     }

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -32,6 +32,8 @@ import {
   getPanelsWithDisabledState as getMousePanelsWithDisabledState,
 } from './components/mouse-model-details-content/mouse-model-details-panels';
 
+const MODEL_ORGANISM_QUERY_KEY = 'modelOrganism';
+
 @Component({
   selector: 'model-ad-model-details',
   imports: [
@@ -86,7 +88,7 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
       .pipe(
         map(([params, queryParams]): [ParamMap, ModelOrganism] => [
           params,
-          resolveModelOrganism(queryParams.get('modelOrganism')),
+          resolveModelOrganism(queryParams.get(MODEL_ORGANISM_QUERY_KEY)),
         ]),
         distinctUntilChanged(
           ([prevParams, prevModelOrganism], [params, modelOrganism]) =>
@@ -118,7 +120,7 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
             this.model = model;
             this.panels = this.buildPanels(model);
             this.setActivePanelAndParentFromUrl(params);
-            this.changePanelAndUrlIfInitialActivePanelIsInvalid();
+            this.applyFallbackPanelIfNeeded(params);
             this.scrollToPanelNavElementOnInitialLoad =
               this.maybeScrollToPanelNavElementOnInitialLoad;
             this.isLoading = false;
@@ -153,11 +155,22 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
     }
   }
 
-  private changePanelAndUrlIfInitialActivePanelIsInvalid() {
+  /**
+   * Specifies the active panel when either no panel is specified in the path or when the specified
+   * panel is disabled or doesn't exist.
+   * If no panel is specified, then use the default panel and retain all query parameters and hash
+   * fragments.
+   * If a disabled or invalid panel is specified, then drop the query parameters and hash fragment
+   * (other than the required modelOrganism query parameter).
+   */
+  private applyFallbackPanelIfNeeded(params: ParamMap) {
     const fallback = this.helperService.getFallbackPanelIfInvalid(this.panels, this.activePanel);
-    if (fallback) {
-      this.activePanel = fallback.activePanel;
-      this.activeParent = fallback.activeParent;
+    if (!fallback) return;
+
+    this.activePanel = fallback.activePanel;
+    this.activeParent = fallback.activeParent;
+
+    if (params.get('tab') ?? params.get('subtab')) {
       this.location.replaceState(this.appendModelOrganism(this.getUrlBasePath()));
       this.maybeScrollToPanelNavElementOnInitialLoad = false;
     }
@@ -178,7 +191,7 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
 
   private appendModelOrganism(url: string) {
     const separator = url.includes('?') ? '&' : '?';
-    return `${url}${separator}modelOrganism=${this.modelOrganism}`;
+    return `${url}${separator}${MODEL_ORGANISM_QUERY_KEY}=${this.modelOrganism}`;
   }
 
   onPanelChange(event: Panel) {


### PR DESCRIPTION
## Description

Clicking a table of content entry on the model details pages scrolled the page to a section but since entries weren't built from real links, none of the behavior users expect of in-page navigation was available: no URL to open in a new tab or copy, no destination preview on hover, and no focus change for keyboard and screen reader users, who stayed behind in the TOC while the page scrolled away from them. This PR turns each entry into a genuine anchor pointing at the current page plus the section fragment, and moves focus to the target section heading on activation.

Real links are only correct if the current URL is, so this branch also fixes URL fidelity on model details URLs with no tab segment. Previously a URL such as `/models/Presenilin%201?modelOrganism=marmoset` dropped its query parameters and hash fragment while falling back to the default panel, which would have made every table of contents link on that page point at a stripped-down URL.

## Related Issue

- [MG-1073](https://sagebionetworks.jira.com/browse/MG-1073)
- [MG-1075](https://sagebionetworks.jira.com/browse/MG-1075)
- [MG-1076](https://sagebionetworks.jira.com/browse/MG-1076)

## Changelog

- Render table of contents entries as anchors whose `href` is the current page URL plus the section fragment, so they can be hovered, copied, and opened in a new tab
- Move focus to the target section heading whenever the page scrolls to a section -- on click and on load with a section fragment in the URL -- without cancelling the smooth scroll
- Leave modified clicks (cmd, ctrl, shift, alt) to the browser so the link can be opened in a new tab or window, or downloaded
- Preserve query parameters and hash fragments when a model details URL has no tab segment and falls back to the default panel
- Add e2e coverage for link `href` values, new-tab opening, and focus movement across the mouse and marmoset pages

## Testing

- On a mouse model, open `/models/Abca7*V1599M/biomarkers?modelOrganism=mouse`, expand the table of contents, and hover an entry -- the browser status bar should show the full current URL plus the section fragment, not the home page
- Cmd/ctrl-click an entry and confirm the new tab loads the same page scrolled to that section, with the original tab left where it was
- Click an entry normally and confirm the page scrolls smoothly (not a hard jump), the URL fragment updates, and the section heading and table of contents entry both highlight and then clear after a few seconds
- Immediately after that click, press Tab and confirm focus continues from inside the target section rather than back in the table of contents; with a screen reader on, confirm the section title is announced
- Paste a section URL such as `/models/Abca7*V1599M/biomarkers?modelOrganism=mouse#nfl` into a fresh tab, then press Tab -- focus should continue from inside that section rather than from the top of the page
- Set the Tissue and Sex filters away from their defaults, then copy an entry's link and open it in a new tab -- the filters and the section should both be restored
- Repeat the hover and new-tab checks on a marmoset model at `/models/Presenilin%201?modelOrganism=marmoset` (no tab segment) and confirm the age group links keep `?modelOrganism=marmoset` and land on the right age group

### Preview

TOC link can be opened in new tab, which scrolls to appropriate section: 

https://github.com/user-attachments/assets/20f98d57-c0e4-416a-96f2-c3426962929c

TOC link can be previewed and scrolls to appropriate section on click: 

https://github.com/user-attachments/assets/c86f1269-f2f7-43bf-958c-c818012fb156

TOC link focus moves to appropriate section after scroll: 

https://github.com/user-attachments/assets/d471d876-769f-4992-b8b7-1ee9a74c9aa7

Model details page without a tab segment respects the hash fragment: 

https://github.com/user-attachments/assets/ac504cb3-08d5-45cf-aaa3-765594995a63

Model details page without a tab segment respects the filter query parameter: 

https://github.com/user-attachments/assets/358eac9f-8dbb-4437-afd0-2814f9e2492c

[MG-1073]: https://sagebionetworks.jira.com/browse/MG-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ