### PR TITLE
feat(model-ad): add load1 matched control url; update ensembl version (MG-1044, MG-1078)

### DIFF
--- a/libs/model-ad/model-details/src/lib/components/model-details-modified-genes/model-details-modified-genes.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-modified-genes/model-details-modified-genes.component.spec.ts
@@ -64,7 +64,7 @@ describe('ModelDetailsModifiedGenesComponent', () => {
       await setup();
       const gene = mouseModelMock.genetic_info[0];
       const ensemblLink = screen.getByRole('link', { name: gene.ensembl_gene_id });
-      expect(ensemblLink.getAttribute('href')).toContain('sep2025');
+      expect(ensemblLink.getAttribute('href')).toContain('jun2026');
     });
   });
 

--- a/libs/model-ad/model-details/src/lib/components/model-details-modified-genes/model-details-modified-genes.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/model-details-modified-genes/model-details-modified-genes.component.ts
@@ -22,6 +22,6 @@ export class ModelDetailsModifiedGenesComponent {
   getGeneUrl(gene: string) {
     const prefix = Object.keys(ENSEMBL_GENE_ID_PREFIX_TO_SPECIES).find((p) => gene.startsWith(p));
     const species = prefix ? ENSEMBL_GENE_ID_PREFIX_TO_SPECIES[prefix] : 'Homo_sapiens';
-    return `https://sep2025.archive.ensembl.org/${species}/Gene/Summary?db=core;g=${gene}`;
+    return `https://jun2026.archive.ensembl.org/${species}/Gene/Summary?db=core;g=${gene}`;
   }
 }

--- a/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.ts
+++ b/libs/model-ad/model-details/src/lib/components/mouse-model-details-hero/mouse-model-details-hero.component.ts
@@ -18,6 +18,7 @@ export class MouseModelDetailsHeroComponent {
     B6129: `${this.JAX_STRAIN_URL}/101045`,
     '5xFAD': `${this.JAX_STRAIN_URL}/008730`,
     'C57BL/6J': `${this.JAX_STRAIN_URL}/000664`,
+    LOAD1: `${this.JAX_STRAIN_URL}/028709`,
   };
 
   model = input.required<MouseModel>();


### PR DESCRIPTION
## Description

Update model details page heroes to add LOAD1 matched control URL to hardcoded list and update ensembl version.

## Related Issue

- [MG-1044](https://sagebionetworks.jira.com/browse/MG-1044)
- [MG-1078](https://sagebionetworks.jira.com/browse/MG-1078)

## Changelog

- Add LOAD1 matched control URL
- Update ensembl version

## Testing

- Navigate to LOAD2 model details page (`/models/LOAD2?modelOrganism=mouse`) and confirm LOAD1 links to appropriate JAX page
- Navigate to mouse model details page (`/models/LOAD2?modelOrganism=mouse`) and confirm ENSMUSG links point at jun2026 ensembl version
- Navigate to marmoset model details page (`/models/Presenilin%201?modelOrganism=marmoset`) and confirm ENSCJAG links point at jun2026 ensembl version

## Preview

`model-ad-build-images && model-ad-docker-start`

LOAD1 JAX link: 

https://github.com/user-attachments/assets/5575e491-c9cb-4cde-b9f8-f7fb65c3671e

Mouse ensembl link: 

https://github.com/user-attachments/assets/6f8a4b75-0cf2-47c5-81e6-d8670fd983d5

Marmoset ensembl link: 

https://github.com/user-attachments/assets/8ded3160-c80d-4a21-81d1-ae4f128e86fa

[MG-1044]: https://sagebionetworks.jira.com/browse/MG-1044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-1078]: https://sagebionetworks.jira.com/browse/MG-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ