### PR TITLE
fix(explorers): update heatmap legend to include no circle information, correct heatmap circle hover and zero values (MG-1067, MG-1069, MG-1070)

### DIFF
--- a/libs/explorers/assets/images/legend-color-chart.svg
+++ b/libs/explorers/assets/images/legend-color-chart.svg
@@ -3,7 +3,7 @@
 <rect x="55.5557" width="55.5556" height="38.0952" fill="#F16681"/>
 <rect x="111.111" width="55.5556" height="38.0952" fill="#F78BA0"/>
 <rect x="166.667" width="55.5556" height="38.0952" fill="#FBB8C5"/>
-<rect x="222.222" width="55.5556" height="38.0952" fill="#B5CBEF"/>
+<rect x="222.222" width="55.5556" height="38.0952" fill="#DFE2E6"/>
 <rect x="277.778" width="55.5556" height="38.0952" fill="#84A5DB"/>
 <rect x="333.333" width="55.5556" height="38.0952" fill="#5E84C3"/>
 <rect x="388.889" width="55.5556" height="38.0952" fill="#3E68AA"/>

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.html
@@ -4,6 +4,4 @@
   [pTooltip]="getCircleTooltip()(data())"
   tooltipPosition="bottom"
   tooltipStyleClass="tooltip"
->
-  <span></span>
-</div>
+></div>

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.scss
@@ -18,6 +18,10 @@
     --heatmap-circle-ring-color: #d72247;
   }
 
+  &.zero {
+    --heatmap-circle-ring-color: var(--color-gray-600);
+  }
+
   &:hover {
     box-shadow:
       inset 0 0 0 2px var(--heatmap-circle-ring-color),

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.scss
@@ -6,41 +6,21 @@
   height: 40px;
   margin: 0 auto;
   border-radius: 50%;
-  border: 1px solid transparent;
   transition: vars.$transition-duration;
 
-  > span {
-    display: block;
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    border: 2px solid transparent;
-    opacity: 0;
-    visibility: hidden;
-    background-color: transparent;
-    transition: vars.$transition-duration;
-  }
+  --heatmap-circle-ring-color: transparent;
 
   &.plus {
-    &,
-    > span {
-      border-color: #245299;
-    }
+    --heatmap-circle-ring-color: #245299;
   }
 
   &.minus {
-    &,
-    > span {
-      border-color: #d72247;
-    }
+    --heatmap-circle-ring-color: #d72247;
   }
 
   &:hover {
-    box-shadow: 2px 2px 4px 0 rgb(0 0 0 / 25%);
-
-    > span {
-      opacity: 1;
-      visibility: visible;
-    }
+    box-shadow:
+      inset 0 0 0 2px var(--heatmap-circle-ring-color),
+      2px 2px 4px 0 rgb(0 0 0 / 25%);
   }
 }

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.spec.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.spec.ts
@@ -51,6 +51,16 @@ describe('HeatmapCircleComponent', () => {
     expect(element.style.backgroundColor).toBe('rgb(241, 102, 129)');
   });
 
+  it('should render a zero class for a value of zero', async () => {
+    const { element } = await setup({ log2_fc: 0, adj_p_val: 0.01 });
+
+    expect(element.className).toContain('heatmap-circle');
+    expect(element.className).toContain('zero');
+    expect(element.className).not.toContain('plus');
+    expect(element.className).not.toContain('minus');
+    expect(element.style.backgroundColor).toBe('var(--color-gray-400)');
+  });
+
   it('should hide the circle when significance threshold is active and exceeded', async () => {
     const { element, fixture, service } = await setup({ log2_fc: 0.2, adj_p_val: 0.2 });
 

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.ts
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-table/heatmap-circle/heatmap-circle.component.ts
@@ -4,6 +4,9 @@ import { ComparisonToolFilterService, HelperService } from '@sagebionetworks/exp
 import { TooltipModule } from 'primeng/tooltip';
 import { knownColorMetricToDisplayName } from '../../comparison-tool.variables';
 
+// Used as the circle's CSS class, so manually keep in sync with the stylesheet's selectors
+type CircleValueSign = 'none' | 'zero' | 'plus' | 'minus';
+
 @Component({
   selector: 'explorers-heatmap-circle',
   imports: [TooltipModule],
@@ -108,11 +111,20 @@ export class HeatmapCircleComponent<T extends HeatmapCircleData = HeatmapCircleD
     }
   }
 
+  private getCircleValueSign(colorValue: number | null | undefined): CircleValueSign {
+    if (colorValue === null || colorValue === undefined) return 'none';
+    if (colorValue === 0) return 'zero';
+    return colorValue > 0 ? 'plus' : 'minus';
+  }
+
   getCircleColor(colorValue: number | undefined | null) {
     if (colorValue === undefined || colorValue === null) return '#F0F0F0';
 
+    const sign = this.getCircleValueSign(colorValue);
+    if (sign === 'zero') return 'var(--color-gray-400)';
+
     const rounded = this.helperService.getSignificantFigures(colorValue, 3);
-    if (rounded > 0) {
+    if (sign === 'plus') {
       if (rounded < 0.1) {
         return '#B5CBEF';
       } else if (rounded < 0.2) {
@@ -175,9 +187,7 @@ export class HeatmapCircleComponent<T extends HeatmapCircleData = HeatmapCircleD
 
   getCircleClass(colorValue: number | null | undefined) {
     const baseClass = 'heatmap-circle';
-    if (colorValue === null || colorValue === undefined) {
-      return baseClass;
-    }
-    return `${baseClass} ${colorValue >= 0 ? 'plus' : 'minus'}`;
+    const sign = this.getCircleValueSign(colorValue);
+    return sign === 'none' ? baseClass : `${baseClass} ${sign}`;
   }
 }

--- a/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.html
+++ b/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.html
@@ -17,3 +17,9 @@
   <div>{{ sizeChartLowerLabel() }}</div>
   <div>{{ sizeChartUpperLabel() }}</div>
 </div>
+
+<h2>NO CIRCLE</h2>
+<p>
+  If no circle is displayed, the corresponding result is not available due to missing or
+  insufficient data.
+</p>

--- a/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.html
+++ b/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.html
@@ -20,6 +20,7 @@
 
 <h2>NO CIRCLE</h2>
 <p>
-  If no circle is displayed, the corresponding result is not available due to missing or
-  insufficient data.
+  If no circle is displayed by default, the corresponding result is not available due to missing or
+  insufficient data. Circles can also be temporarily masked from view based on adjusted p-value by
+  enabling the "Hide insignificant" toggle.
 </p>

--- a/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.scss
+++ b/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.scss
@@ -14,15 +14,9 @@ img {
   margin: 10px 0;
 }
 
-#color-chart-labels {
-  margin: 0 0 40px;
-  display: flex;
-  justify-content: space-between;
-  font-size: 12px;
-}
-
+#color-chart-labels,
 #size-chart-labels {
-  margin: 0 0 10px;
+  margin: 0 0 40px;
   display: flex;
   justify-content: space-between;
   font-size: 12px;

--- a/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.stories.ts
+++ b/libs/explorers/comparison-tool/src/lib/help-links/legend-panel/legend/legend.component.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { LegendComponent } from './legend.component';
+
+const meta: Meta<LegendComponent> = {
+  component: LegendComponent,
+  title: 'Comparison Tool/Legend',
+};
+export default meta;
+type Story = StoryObj<LegendComponent>;
+
+export const Legend: Story = {
+  args: {
+    colorChartLowerLabel: 'Downregulated',
+    colorChartUpperLabel: 'Upregulated',
+    colorChartText:
+      'Circle color indicates the log2 fold change value. Red shades indicate reduced expression levels in AD patients compared to controls, while blue shades indicate increased expression levels in AD patients relative to controls.',
+    sizeChartLowerLabel: 'Significant',
+    sizeChartUpperLabel: 'Insignificant',
+    sizeChartText:
+      'Circle diameter indicates P-value. Larger circles indicate higher statistical significance, while smaller circles indicate lower statistical significance.',
+  },
+};


### PR DESCRIPTION
## Description

Usability testing and a design pass recently revealed three issues with the comparison tool heatmap circle: the legend didn't explain what it means when a cell has no circle at all, the heatmap circle outline outline painted at all times rather than only on hover, and a value of exactly zero rendered a blue outline on a pink fill. This PR fixes each of these issues.

## Related Issue

- [MG-1067](https://sagebionetworks.jira.com/browse/MG-1067)
- [MG-1069](https://sagebionetworks.jira.com/browse/MG-1069)
- [MG-1070](https://sagebionetworks.jira.com/browse/MG-1070)

## Changelog

- Show the circle outline only on hover, drawn as an inset `box-shadow` rather than a child `<span>`
- Render a value of exactly zero as neutral gray with a gray outline, instead of letting it fall through to the lightest shade of the negative color scale
- Extract a single sign classifier so the CSS class and the fill color can no longer disagree about a value's sign
- Recolor the legend color chart's midpoint swatch to the same neutral gray, so the legend matches what a zero-value circle now looks like
- Add a NO CIRCLE section to the legend panel explaining that an absent circle means missing or insufficient data
- Add a Storybook story for the comparison tool legend

## Testing

- Open a comparison tool with heatmap columns (for example Model-AD differential expression) and confirm that no circle shows an outline until it is hovered
- Hover a circle and confirm the outline is drawn inside the circle's footprint -- the circle should not appear to grow, and there should be no gap between the fill and the outline
- Confirm circles still scale with significance, and that the smallest ones are still large enough to hover reliably
- Find a cell whose value is exactly 0 and confirm the circle is neutral gray with a gray hover outline, and that its tooltip reports the value as 0
- Open the legend panel and confirm the NO CIRCLE text reads correctly and the color chart's middle swatch matches a zero-value circle
- Export the table as a PNG and confirm the circle fills, including the zero gray, are present in the exported image

### Preview

Heatmap zero value is gray with gray outline on hover: 

<img width="173" height="116" alt="image" src="https://github.com/user-attachments/assets/3677b469-083d-433b-9d59-fdd95555e9ed" />

Heatmap outline only shown on hover: 

https://github.com/user-attachments/assets/3f15d76e-2c13-47cc-aefc-eed8a15cf3f0

Heatmap legend updated to show gray for zero value and include "No Circle" info: 

<img width="633" height="777" alt="image" src="https://github.com/user-attachments/assets/f4a80d9c-7eb7-4251-98e0-2f057a27bb9c" />





[MG-1067]: https://sagebionetworks.jira.com/browse/MG-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-1069]: https://sagebionetworks.jira.com/browse/MG-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-1070]: https://sagebionetworks.jira.com/browse/MG-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ