### PR TITLE
feat(model-ad): fix filter panel scrolling when checkboxes are selected (MG-996)

### DIFF
--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-filter-panel/comparison-tool-filter-panel.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-filter-panel/comparison-tool-filter-panel.component.html
@@ -9,7 +9,7 @@
         />
         <div class="filter-panel-main-menu">
           <ul>
-            @for (filter of filters(); track filter; let i = $index) {
+            @for (filter of filters(); track $index; let i = $index) {
               <li
                 class="filter-panel-main-menu-item-{{ filter.name }}"
                 [class.active]="activePane() === i"
@@ -26,7 +26,7 @@
     </div>
 
     <div class="filter-panel-panes">
-      @for (filter of filters(); track filter; let i = $index) {
+      @for (filter of filters(); track $index; let i = $index) {
         <div
           class="filter-panel-pane filter-panel-pane-{{ filter.name }}"
           [class.open]="activePane() === i"
@@ -38,7 +38,7 @@
               (closeClick)="close()"
             />
             <ul>
-              @for (option of filter.options; track option; let j = $index) {
+              @for (option of filter.options; track $index; let j = $index) {
                 @let filterOptionId = filter.name + '-' + option.label;
                 <li>
                   <div class="checkbox">

--- a/libs/explorers/comparison-tool/src/lib/comparison-tool-filter-panel/comparison-tool-filter-panel.component.html
+++ b/libs/explorers/comparison-tool/src/lib/comparison-tool-filter-panel/comparison-tool-filter-panel.component.html
@@ -9,7 +9,7 @@
         />
         <div class="filter-panel-main-menu">
           <ul>
-            @for (filter of filters(); track $index; let i = $index) {
+            @for (filter of filters(); track filter.name; let i = $index) {
               <li
                 class="filter-panel-main-menu-item-{{ filter.name }}"
                 [class.active]="activePane() === i"
@@ -26,7 +26,7 @@
     </div>
 
     <div class="filter-panel-panes">
-      @for (filter of filters(); track $index; let i = $index) {
+      @for (filter of filters(); track filter.name; let i = $index) {
         <div
           class="filter-panel-pane filter-panel-pane-{{ filter.name }}"
           [class.open]="activePane() === i"
@@ -38,7 +38,7 @@
               (closeClick)="close()"
             />
             <ul>
-              @for (option of filter.options; track $index; let j = $index) {
+              @for (option of filter.options; track option.label) {
                 @let filterOptionId = filter.name + '-' + option.label;
                 <li>
                   <div class="checkbox">


### PR DESCRIPTION
## Description

Selecting an option in a comparison tool filter panel reset the pane's vertical scroll back to the top, which made working through long option lists (for example the model list) tedious — every checkbox click sent the reviewer back to the start of the list. `ComparisonToolFilterService.setFilters` deliberately `structuredClone`s the filters to publish a new reference, so the `@for` blocks that tracked filters and options by object identity treated every filter change as a full replacement and destroyed/recreated the list DOM along with its scroll offset. Tracking by index instead lets Angular reuse the existing DOM nodes, so the scroll position survives the update.

## Related Issue

- [MG-996](https://sagebionetworks.jira.com/browse/MG-996) — CT Filter panels: Don't reset vertical scroll on user interaction

## Changelog

- Track the filter panel's main menu items, panes, and filter options by index so option toggles reuse the existing DOM instead of recreating it
- Preserve each filter pane's vertical scroll position when a filter option is selected or cleared

## Testing

- Open a comparison tool with a long filter list (e.g. Model-AD → Comparison Tool → Model filter pane, or the Agora nominated targets filter panel) and scroll partway down the option list.
- Select a checkbox and confirm the list stays put instead of jumping back to the top; the table results should still update.
- Uncheck the same option and confirm the scroll position is again preserved.
- Switch between filter panes (e.g. Model → Sex) and confirm the correct pane opens, the correct options are listed, and previously selected checkboxes remain checked.
- Use the panel's reset/clear action and confirm all checkboxes clear and the table returns to the unfiltered result set.
- Confirm the active main-menu item highlight still follows the pane you open.

### Preview

Before:

https://github.com/user-attachments/assets/61d39704-fcdd-4f18-9291-ad85c8c96bce

After (no vertical scroll reset):

https://github.com/user-attachments/assets/2d1f9e1c-b7dd-40f1-b4cc-ac761b261d27

Additional video showing unselecting items and using the clear all button:

https://github.com/user-attachments/assets/17914489-7862-49a1-91c4-bffe081b41f8


[MG-996]: https://sagebionetworks.jira.com/browse/MG-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-945]: https://sagebionetworks.jira.com/browse/MG-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ