### PR TITLE
fix(model-ad): read model details route state from one snapshot (MG-1099)

### DIFF
--- a/libs/explorers/util/src/index.ts
+++ b/libs/explorers/util/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/modal-link/modal-link.component';
 export * from './lib/pipes';
 export * from './lib/popover-link/popover-link.component';
 export * from './lib/prefetch-config';
+export * from './lib/route-state/route-state';
 export * from './lib/svg-icon/svg-icon.component';
 export * from './lib/tooltip-button/tooltip-button.component';
 export * from './lib/widest-line-width/widest-line-width.directive';

--- a/libs/explorers/util/src/lib/route-state/route-state.spec.ts
+++ b/libs/explorers/util/src/lib/route-state/route-state.spec.ts
@@ -1,0 +1,61 @@
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute, RouterOutlet } from '@angular/router';
+import { render } from '@testing-library/angular';
+import { routeSnapshotChanges } from './route-state';
+
+interface RouteStateEmission {
+  name: string | null;
+  query: string | null;
+}
+
+const emissions: RouteStateEmission[] = [];
+
+@Component({
+  selector: 'explorers-route-state-probe',
+  template: '',
+})
+class RouteStateProbeComponent {
+  constructor() {
+    routeSnapshotChanges(inject(ActivatedRoute)).subscribe((snapshot) => {
+      emissions.push({
+        name: snapshot.paramMap.get('name'),
+        query: snapshot.queryParamMap.get('q'),
+      });
+    });
+  }
+}
+
+async function setup() {
+  emissions.length = 0;
+
+  return render('<router-outlet></router-outlet>', {
+    imports: [RouterOutlet],
+    routes: [{ path: 'items/:name', component: RouteStateProbeComponent }],
+    initialRoute: '/items/A?q=1',
+  });
+}
+
+describe('routeSnapshotChanges', () => {
+  it('should emit once per navigation, with params and query params of the same navigation', async () => {
+    const { navigate } = await setup();
+    expect(emissions).toEqual([{ name: 'A', query: '1' }]);
+
+    await navigate('/items/B?q=2');
+
+    expect(emissions).toEqual([
+      { name: 'A', query: '1' },
+      { name: 'B', query: '2' },
+    ]);
+  });
+
+  it('should emit when only the query params change', async () => {
+    const { navigate } = await setup();
+
+    await navigate('/items/A?q=2');
+
+    expect(emissions).toEqual([
+      { name: 'A', query: '1' },
+      { name: 'A', query: '2' },
+    ]);
+  });
+});

--- a/libs/explorers/util/src/lib/route-state/route-state.ts
+++ b/libs/explorers/util/src/lib/route-state/route-state.ts
@@ -1,0 +1,16 @@
+import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
+import { distinctUntilChanged, map, merge, Observable } from 'rxjs';
+
+/**
+ * Params and query params come in on two separate streams, and the router pushes one right after
+ * the other, so combining them can give you the new query param with the old path param. The
+ * snapshot is already updated before either push, so read from that and use the streams only as
+ * a trigger. Both pushes hand back the same snapshot object, so distinctUntilChanged drops the
+ * second one and we get a single emission per navigation.
+ */
+export function routeSnapshotChanges(route: ActivatedRoute): Observable<ActivatedRouteSnapshot> {
+  return merge(route.paramMap, route.queryParamMap).pipe(
+    map(() => route.snapshot),
+    distinctUntilChanged(),
+  );
+}

--- a/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
@@ -1,14 +1,22 @@
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, Router, RouterOutlet } from '@angular/router';
 import { PlatformService } from '@sagebionetworks/explorers/services';
 import { provideLoadingIconColors } from '@sagebionetworks/explorers/testing';
 import { LoadingIconComponent } from '@sagebionetworks/explorers/util';
 import { Model, ModelOrganism, ModelService } from '@sagebionetworks/model-ad/api-client';
-import { MODEL_AD_LOADING_ICON_COLORS } from '@sagebionetworks/model-ad/config';
+import { MODEL_AD_LOADING_ICON_COLORS, ROUTE_PATHS } from '@sagebionetworks/model-ad/config';
 import { marmosetModelMock, mouseModelMock } from '@sagebionetworks/model-ad/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { ModelDetailsComponent } from './model-details.component';
+
+@Component({
+  selector: 'model-ad-not-found-stub',
+  template: 'Not found',
+})
+class NotFoundStubComponent {}
 
 async function setup(
   model: Model = mouseModelMock,
@@ -19,10 +27,12 @@ async function setup(
 ) {
   const user = userEvent.setup();
 
-  const queryParams = modelOrganism === null ? {} : { modelOrganism };
+  const paramMap = convertToParamMap({ name: model.name, tab: tab, subtab: subtab });
+  const queryParamMap = convertToParamMap(modelOrganism === null ? {} : { modelOrganism });
   const mockActivatedRoute = {
-    paramMap: of(convertToParamMap({ name: model.name, tab: tab, subtab: subtab })),
-    queryParamMap: of(convertToParamMap(queryParams)),
+    paramMap: of(paramMap),
+    queryParamMap: of(queryParamMap),
+    snapshot: { paramMap, queryParamMap },
   };
 
   const mockModelService = {
@@ -119,6 +129,60 @@ describe('ModelDetailsComponent', () => {
       const { component } = await setup(mouseModelMock, 'omics', null, mockPlatformService);
       expect(component.container.querySelector('.loading-icon')).toBeVisible();
       expect(screen.queryByText(/This page isn't available/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('navigation between organisms', () => {
+    const load1Mock = { ...mouseModelMock, name: 'LOAD1' };
+    const load1Route = `/models/${load1Mock.name}?modelOrganism=mouse`;
+
+    async function setupWithRouter() {
+      const getModelByName = jest.fn((modelOrganism: ModelOrganism, name: string) => {
+        const model = [marmosetModelMock, load1Mock].find(
+          (candidate) => candidate.type === modelOrganism && candidate.name === name,
+        );
+        return model
+          ? of(model)
+          : throwError(() => new Error(`${modelOrganism}/${name} not found`));
+      });
+
+      const { navigate } = await render('<router-outlet></router-outlet>', {
+        imports: [RouterOutlet, LoadingIconComponent],
+        routes: [
+          { path: 'models/:name', component: ModelDetailsComponent },
+          { path: ROUTE_PATHS.NOT_FOUND, component: NotFoundStubComponent },
+        ],
+        initialRoute: `/models/${marmosetModelMock.name}?modelOrganism=marmoset`,
+        providers: [
+          { provide: ModelService, useValue: { getModelByName } },
+          { provide: PlatformService, useValue: { isBrowser: true, isServer: false } },
+          provideLoadingIconColors(MODEL_AD_LOADING_ICON_COLORS),
+        ],
+      });
+
+      return { navigate, getModelByName, router: TestBed.inject(Router) };
+    }
+
+    it('should never request the name of one navigation with the organism of another', async () => {
+      const { navigate, getModelByName } = await setupWithRouter();
+
+      await navigate(load1Route);
+
+      expect(
+        getModelByName.mock.calls.map(([modelOrganism, name]) => [modelOrganism, name]),
+      ).toEqual([
+        [ModelOrganism.Marmoset, marmosetModelMock.name],
+        [ModelOrganism.Mouse, load1Mock.name],
+      ]);
+    });
+
+    it('should stay on the requested model page instead of the not found page', async () => {
+      const { navigate, router } = await setupWithRouter();
+
+      await navigate(load1Route);
+
+      expect(router.url).toBe(load1Route);
+      expect(screen.queryByText('Not found')).not.toBeInTheDocument();
     });
   });
 

--- a/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
@@ -198,6 +198,14 @@ describe('ModelDetailsComponent', () => {
       expect(router.url).toBe(load1Route);
       expect(screen.queryByText('Not found')).not.toBeInTheDocument();
     });
+
+    it('should redirect to the not found page when the model does not exist', async () => {
+      const { navigate } = await setupWithRouter();
+
+      await navigate('/models/Unknown?modelOrganism=mouse');
+
+      expect(screen.getByText('Not found')).toBeInTheDocument();
+    });
   });
 
   describe('marmoset model', () => {

--- a/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.spec.ts
@@ -9,8 +9,10 @@ import { MODEL_AD_LOADING_ICON_COLORS, ROUTE_PATHS } from '@sagebionetworks/mode
 import { marmosetModelMock, mouseModelMock } from '@sagebionetworks/model-ad/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
-import { of, throwError } from 'rxjs';
+import { of, switchMap, throwError, timer } from 'rxjs';
 import { ModelDetailsComponent } from './model-details.component';
+
+const NOT_FOUND_DELAY_MS = 10;
 
 @Component({
   selector: 'model-ad-not-found-stub',
@@ -136,14 +138,15 @@ describe('ModelDetailsComponent', () => {
     const load1Mock = { ...mouseModelMock, name: 'LOAD1' };
     const load1Route = `/models/${load1Mock.name}?modelOrganism=mouse`;
 
-    async function setupWithRouter() {
+    async function setupWithRouter(notFoundDelayMs = 0) {
       const getModelByName = jest.fn((modelOrganism: ModelOrganism, name: string) => {
         const model = [marmosetModelMock, load1Mock].find(
           (candidate) => candidate.type === modelOrganism && candidate.name === name,
         );
-        return model
-          ? of(model)
-          : throwError(() => new Error(`${modelOrganism}/${name} not found`));
+        if (model) return of(model);
+
+        const notFound = throwError(() => new Error(`${modelOrganism}/${name} not found`));
+        return notFoundDelayMs ? timer(notFoundDelayMs).pipe(switchMap(() => notFound)) : notFound;
       });
 
       const { navigate } = await render('<router-outlet></router-outlet>', {
@@ -180,6 +183,17 @@ describe('ModelDetailsComponent', () => {
       const { navigate, router } = await setupWithRouter();
 
       await navigate(load1Route);
+
+      expect(router.url).toBe(load1Route);
+      expect(screen.queryByText('Not found')).not.toBeInTheDocument();
+    });
+
+    it('should ignore a failed request that a newer navigation has superseded', async () => {
+      const { navigate, router } = await setupWithRouter(NOT_FOUND_DELAY_MS);
+
+      await navigate('/models/Unknown?modelOrganism=mouse');
+      await navigate(load1Route);
+      await new Promise((resolve) => setTimeout(resolve, NOT_FOUND_DELAY_MS * 2));
 
       expect(router.url).toBe(load1Route);
       expect(screen.queryByText('Not found')).not.toBeInTheDocument();

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -20,7 +20,7 @@ import {
 } from '@sagebionetworks/model-ad/api-client';
 import { ROUTE_PATHS } from '@sagebionetworks/model-ad/config';
 import { resolveModelOrganism } from '@sagebionetworks/model-ad/util';
-import { distinctUntilChanged, map } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, map, Observable, switchMap, tap } from 'rxjs';
 import { MarmosetModelDetailsContentComponent } from './components/marmoset-model-details-content/marmoset-model-details-content.component';
 import {
   getPanels as getMarmosetPanels,
@@ -94,46 +94,46 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
           ([prevParams, prevModelOrganism], [params, modelOrganism]) =>
             prevParams.get('name') === params.get('name') && prevModelOrganism === modelOrganism,
         ),
+        tap(() => this.reset()),
+        switchMap(([params, modelOrganism]) =>
+          // only fetch data during client hydration
+          this.platformService.isBrowser
+            ? this.loadPanelData(params, modelOrganism).pipe(map((model) => ({ model, params })))
+            : EMPTY,
+        ),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(([params, modelOrganism]) => {
-        this.reset();
-
-        // only fetch data during client hydration
-        if (this.platformService.isBrowser) {
-          this.loadPanelData(params, modelOrganism);
-        }
-      });
+      .subscribe(({ model, params }) => this.setModel(model, params));
   }
 
-  private loadPanelData(params: ParamMap, modelOrganism: ModelOrganism) {
+  private loadPanelData(params: ParamMap, modelOrganism: ModelOrganism): Observable<Model> {
     this.modelOrganism = modelOrganism;
     const modelName = params.get('name');
-    if (modelName) {
-      this.modelService
-        .getModelByName(modelOrganism, modelName, 'body', false, {
-          context: new HttpContext().set(SUPPRESS_ERROR_OVERLAY, true),
-        })
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe({
-          next: (model: Model) => {
-            this.model = model;
-            this.panels = this.buildPanels(model);
-            this.setActivePanelAndParentFromUrl(params);
-            this.applyFallbackPanelIfNeeded(params);
-            this.scrollToPanelNavElementOnInitialLoad =
-              this.maybeScrollToPanelNavElementOnInitialLoad;
-            this.isLoading = false;
-          },
-          error: () => {
-            this.isLoading = false;
-            this.logger.log(
-              `ModelDetailsComponent: loadPanelData: Model ${modelName} (modelOrganism: ${modelOrganism}) not found, redirecting`,
-            );
-            this.router.navigateByUrl(ROUTE_PATHS.NOT_FOUND, { skipLocationChange: true });
-          },
-        });
-    }
+    if (!modelName) return EMPTY;
+
+    return this.modelService
+      .getModelByName(modelOrganism, modelName, 'body', false, {
+        context: new HttpContext().set(SUPPRESS_ERROR_OVERLAY, true),
+      })
+      .pipe(
+        catchError(() => {
+          this.isLoading = false;
+          this.logger.log(
+            `ModelDetailsComponent: loadPanelData: Model ${modelName} (modelOrganism: ${modelOrganism}) not found, redirecting`,
+          );
+          this.router.navigateByUrl(ROUTE_PATHS.NOT_FOUND, { skipLocationChange: true });
+          return EMPTY;
+        }),
+      );
+  }
+
+  private setModel(model: Model, params: ParamMap) {
+    this.model = model;
+    this.panels = this.buildPanels(model);
+    this.setActivePanelAndParentFromUrl(params);
+    this.applyFallbackPanelIfNeeded(params);
+    this.scrollToPanelNavElementOnInitialLoad = this.maybeScrollToPanelNavElementOnInitialLoad;
+    this.isLoading = false;
   }
 
   private buildPanels(model: Model): Panel[] {

--- a/libs/model-ad/model-details/src/lib/model-details.component.ts
+++ b/libs/model-ad/model-details/src/lib/model-details.component.ts
@@ -10,7 +10,7 @@ import {
   PlatformService,
   SUPPRESS_ERROR_OVERLAY,
 } from '@sagebionetworks/explorers/services';
-import { LoadingIconComponent } from '@sagebionetworks/explorers/util';
+import { LoadingIconComponent, routeSnapshotChanges } from '@sagebionetworks/explorers/util';
 import {
   MarmosetModel,
   Model,
@@ -20,7 +20,7 @@ import {
 } from '@sagebionetworks/model-ad/api-client';
 import { ROUTE_PATHS } from '@sagebionetworks/model-ad/config';
 import { resolveModelOrganism } from '@sagebionetworks/model-ad/util';
-import { combineLatest, distinctUntilChanged, map } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs';
 import { MarmosetModelDetailsContentComponent } from './components/marmoset-model-details-content/marmoset-model-details-content.component';
 import {
   getPanels as getMarmosetPanels,
@@ -84,11 +84,11 @@ export class ModelDetailsComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-    combineLatest([this.route.paramMap, this.route.queryParamMap])
+    routeSnapshotChanges(this.route)
       .pipe(
-        map(([params, queryParams]): [ParamMap, ModelOrganism] => [
-          params,
-          resolveModelOrganism(queryParams.get(MODEL_ORGANISM_QUERY_KEY)),
+        map((snapshot): [ParamMap, ModelOrganism] => [
+          snapshot.paramMap,
+          resolveModelOrganism(snapshot.queryParamMap.get(MODEL_ORGANISM_QUERY_KEY)),
         ]),
         distinctUntilChanged(
           ([prevParams, prevModelOrganism], [params, modelOrganism]) =>


### PR DESCRIPTION
## Description

Clicking a search result for a model of the opposite organism landed on the 404 page, even though the address bar showed the correct URL. The model details page read the model name and the modelOrganism query parameter as two separate router streams, which Angular advances one after the other within a single navigation — so the page paired the new organism with the previous model name and requested a model that does not exist. This fix reads both values from the router snapshot instead, and makes model requests cancellable so a superseded request can no longer redirect the user away from the page they asked for.

## Related Issue

- [MG-1099](https://sagebionetworks.jira.com/browse/MG-1099)

## Changelog

- Add `routeSnapshotChanges` to `@sagebionetworks/explorers/util`, which emits the router snapshot once
  per navigation so path parameters and query parameters are always read as one consistent unit
- Read model details route state through that helper instead of pairing `paramMap` and `queryParamMap`
  with `combineLatest`, eliminating the mismatched organism/name request
- Cancel in-flight model requests when a newer navigation starts, replacing an uncancelled nested
  `subscribe` with `switchMap`
- Handle a not-found model with `catchError` so the redirect no longer terminates the route
  subscription


## Testing

- On the marmoset **Presenilin 1** details page, type `LOAD1` in the header search and click the
  typeahead match. You should land on the mouse LOAD1 details page, and the network tab should show the correct LOAD1 model detail page (See Preview) with no request for `/api/v1/models/mouse/Presenilin%201`.
- Repeat in the other direction: from a mouse model details page, search a marmoset model and click the
  result.


### Preview

Cross-organism navigation works in both directions now 

#### From a mouse model page → marmoset search result

| Dev (before) | This PR (after) |
| --- | --- |
| <img width="100%" alt="dev-mouse-to-marmoset" src="https://github.com/user-attachments/assets/a23dfc91-390b-4d32-bbde-37743298a967" /> | <img width="100%" alt="pr-mouse-to-marmoset" src="https://github.com/user-attachments/assets/aa9af6b5-df13-45b4-8dbf-cdc3ab12b73a" /> |

#### From a marmoset model page → mouse search result

| Dev (before) | This PR (after) |
| --- | --- |
| <img width="100%" alt="dev-marmoset-to-mouse" src="https://github.com/user-attachments/assets/74c3f6bb-8be0-457d-9496-d034e602fbf4" /> | <img width="100%" alt="pr-marmoset-to-mouse" src="https://github.com/user-attachments/assets/a1d2e5f5-dd88-422c-a068-2f480c00467b" /> |




[MG-1099]: https://sagebionetworks.jira.com/browse/MG-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ